### PR TITLE
Hide ODF dashboard for ODF Managed Services

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -9,7 +9,8 @@
       "href": "/odf"
     },
     "flags": {
-      "required": ["OCS"]
+      "required": ["OCS"],
+      "disallowed": ["ODF_MANAGED"]
     }
   },
   {
@@ -17,6 +18,10 @@
     "properties": {
       "path": ["/odf"],
       "component": { "$codeRef": "dashboard.default" }
+    },
+    "flags": {
+      "required": ["OCS"],
+      "disallowed": ["ODF_MANAGED"]
     }
   }
 ]


### PR DESCRIPTION
This patch is in continuation of https://github.com/openshift/console/pull/9742

- Disabled `Block and File` and `Object` dashboards for ODF Managed Services. (done in #9742)

- `Storage --> Overview` navigation item will be hidden. (done in #9742)

- `Storage --> OpenShift Data Foundation` navigation item will also be hidden. (added flags in this patch)

