### PR TITLE
Show '-' when metrics are not available

### DIFF
--- a/src/components/common/capacity-card/capacity-card.tsx
+++ b/src/components/common/capacity-card/capacity-card.tsx
@@ -142,6 +142,8 @@ const CapacityCardRow: React.FC<CapacityCardRowProps> = ({
       return ProgressVariant.warning;
     }
   })();
+
+  const dataUnavailable = _.isNaN(progress);
   return (
     <>
       <GridItem key={`${data.name}~name`} span={2}>
@@ -159,10 +161,12 @@ const CapacityCardRow: React.FC<CapacityCardRowProps> = ({
         )}
       </GridItem>
       <GridItem key={`${data.name}~progress`} span={7}>
-        <Tooltip content={<>{progress.toFixed(2)} %</>}>
+        <Tooltip
+          content={!dataUnavailable ? <>{progress.toFixed(2)} %</> : '-'}
+        >
           <Progress
-            value={progress}
-            label={`${progress.toFixed(2)} %`}
+            value={dataUnavailable ? null : progress}
+            label={!dataUnavailable ? `${progress.toFixed(2)} %` : ''}
             size="md"
             measureLocation={
               !isPercentage
@@ -174,7 +178,7 @@ const CapacityCardRow: React.FC<CapacityCardRowProps> = ({
         </Tooltip>
       </GridItem>
       <GridItem span={3} key={`${data.name}~value`}>
-        {value}
+        {dataUnavailable ? '-' : value}
       </GridItem>
     </>
   );

--- a/src/components/common/line-graph/line-graph.tsx
+++ b/src/components/common/line-graph/line-graph.tsx
@@ -35,9 +35,13 @@ const LineGraph: React.FC<LineGraphProps> = ({ data }) => {
     yString: datum.y.string,
   }));
 
-  const unit = lineData[0].y.unit;
-  const latestValue = lineData[lineData.length - 1].y.string;
-  return (
+  const dataUnavailable = _.isEmpty(data);
+
+  const unit = !dataUnavailable ? lineData[0].y.unit : '';
+  const latestValue = !dataUnavailable
+    ? lineData[lineData.length - 1].y.string
+    : '';
+  return !dataUnavailable ? (
     <div className="odf-lineGraph">
       <div
         className="pf-u-display-none-on-md pf-u-display-inline-block-on-lg pf-u-w-95-lg"
@@ -83,6 +87,8 @@ const LineGraph: React.FC<LineGraphProps> = ({ data }) => {
         <div>Current</div>
       </div>
     </div>
+  ) : (
+    <>-</>
   );
 };
 

--- a/src/components/odf-dashboard/dashboard.tsx
+++ b/src/components/odf-dashboard/dashboard.tsx
@@ -12,15 +12,11 @@ import { StatusCard } from './status-card/status-card';
 import SystemCapacityCard from './system-capacity-card/capacity-card';
 import '../../style.scss';
 
-type UpperSectionProps = {
-  currentLocation: string;
-};
-
 type ODFDashboardProps = {
   match: RouteComponentProps['match'];
 };
 
-const UpperSection: React.FC<UpperSectionProps> = (props) => (
+const UpperSection: React.FC = () => (
   <Grid hasGutter>
     <GridItem md={8} sm={12}>
       <StatusCard />
@@ -35,17 +31,16 @@ const UpperSection: React.FC<UpperSectionProps> = (props) => (
       <ObjectCapacityCard />
     </GridItem>
     <GridItem md={12} sm={12}>
-      <PerformanceCard {...props} />
+      <PerformanceCard />
     </GridItem>
   </Grid>
 );
 
-export const ODFDashboard: React.FC<ODFDashboardProps> = (props) => {
-  const currentLocation = props.match.path;
+export const ODFDashboard: React.FC<ODFDashboardProps> = () => {
   return (
     <>
       <div className="co-dashboard-body">
-        <UpperSection currentLocation={currentLocation} />
+        <UpperSection />
       </div>
     </>
   );

--- a/src/components/odf-dashboard/performance-card/performance-card.tsx
+++ b/src/components/odf-dashboard/performance-card/performance-card.tsx
@@ -72,7 +72,7 @@ const nameSort = (a: RowProps, b: RowProps, c: SortByDirection) => {
   return negation ? -sortVal : sortVal;
 };
 
-const PerformanceCard: React.FC<PerformanceCardProps> = (props) => {
+const PerformanceCard: React.FC = () => {
   const headerColumns: Column[] = [
     {
       columnName: 'Name',
@@ -141,10 +141,6 @@ const PerformanceCard: React.FC<PerformanceCardProps> = (props) => {
       )}
     </DashboardCard>
   );
-};
-
-type PerformanceCardProps = {
-  currentLocation: string;
 };
 
 export default PerformanceCard;


### PR DESCRIPTION
![Screenshot from 2021-08-24 14-44-49](https://user-images.githubusercontent.com/54092533/130590741-7728ced6-9257-42a2-b8e8-6a39dcad0ef4.png)
