### PR TITLE
Add required flags for extensions

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -9,6 +9,7 @@
       "href": "/odf"
     },
     "flags": {
+      "required": ["ODF_MODEL"],
       "disallowed": ["ODF_MANAGED"]
     }
   },
@@ -19,6 +20,7 @@
       "component": { "$codeRef": "dashboard.default" }
     },
     "flags": {
+      "required": ["ODF_MODEL"],
       "disallowed": ["ODF_MANAGED"]
     }
   }


### PR DESCRIPTION
Without the presence of at least one flag these extensions are not getting loaded.