### PR TITLE
Show proper error message in Performance Card when no storage systems are present

### DIFF
--- a/src/components/odf-dashboard/performance-card/performance-card.scss
+++ b/src/components/odf-dashboard/performance-card/performance-card.scss
@@ -22,7 +22,7 @@
   &--error {
     align-items: center;
     display: flex;
-    min-height: 30px;
+    min-height: 150px;
     place-content: center;
   }
 

--- a/src/components/odf-dashboard/performance-card/performance-card.tsx
+++ b/src/components/odf-dashboard/performance-card/performance-card.tsx
@@ -149,11 +149,12 @@ const PerformanceCard: React.FC = () => {
         />
       )}
       {loading && <PerformanceCardLoading />}
-      {error && !loading && (
-        <div className="odf-performanceCardError">
-          <DataUnavailableError />{' '}
-        </div>
-      )}
+      {(error && !loading) ||
+        (_.isEmpty(rawRows) && (
+          <div className="performanceCard--error">
+            <DataUnavailableError />{' '}
+          </div>
+        ))}
     </DashboardCard>
   );
 };


### PR DESCRIPTION
After:
![Screenshot from 2021-08-30 20-36-55](https://user-images.githubusercontent.com/54092533/131361140-96bbaf63-d9ec-4c7d-9ec5-55e62d9b21c2.png)
