### PR TITLE
Bug 2013561: Fix IOPS graph padding

### DIFF
--- a/src/components/common/line-graph/line-graph.tsx
+++ b/src/components/common/line-graph/line-graph.tsx
@@ -61,8 +61,8 @@ const LineGraph: React.FC<LineGraphProps> = ({ data }) => {
           height={150}
           padding={{
             bottom: 20,
-            left: 75,
-            right: 10, // Adjusted to accommodate legend
+            left: 95,
+            right: 15, // Adjusted to accommodate legend
             top: 20,
           }}
           width={width}


### PR DESCRIPTION
Padding has been added to the graphs.

**Before:**
![Screenshot from 2021-10-14 15-53-46](https://user-images.githubusercontent.com/39404641/137299895-5cfd7e05-0f5d-470c-8afe-8774005db7b2.png)

**After:**
![Screenshot from 2021-10-14 15-52-37](https://user-images.githubusercontent.com/39404641/137299917-0e08b7cd-6b91-4d15-90c7-a418b8f7cf56.png)
