### PR TITLE
Use KBps for Throughput chart

### DIFF
--- a/src/components/odf-dashboard/performance-card/utils.ts
+++ b/src/components/odf-dashboard/performance-card/utils.ts
@@ -1,6 +1,6 @@
 import { PrometheusResponse } from "@openshift-console/dynamic-plugin-sdk";
 import * as _ from "lodash";
-import { humanizeBinaryBytes, humanizeIOPS, humanizeLatency } from "../../../humanize";
+import { humanizeIOPS, humanizeLatency, humanizeDecimalBytesPerSec } from "../../../humanize";
 import { StorageSystemKind } from "../../../types";
 import { LineGraphProps } from "../../common/line-graph/line-graph";
 
@@ -51,7 +51,7 @@ export const generateDataFrames = (
                 data: getDatForSystem(id, curr, humanizeIOPS),
             },
             throughputData: {
-                data: getDatForSystem(td, curr, humanizeBinaryBytes),
+                data: getDatForSystem(td, curr, humanizeDecimalBytesPerSec),
             },
             latencyData: {
                 data: getDatForSystem(ld, curr, humanizeLatency),


### PR DESCRIPTION
Use KBps for Throughput chart in the Performance card inside the ODF
Dashboard.
***
#### Earlier
![image](https://user-images.githubusercontent.com/33557095/141300843-eb8539c6-4d2a-4c36-9c7f-e7d517b62ba6.png)
***
#### Now
![image](https://user-images.githubusercontent.com/33557095/141300731-82648030-2f03-4967-8edf-4d7fed0236e1.png)
***
This change was made in order to use the same unit ("KBps") as defined in the SS List page (see below) in the ODF Dashboard for Throughput.
***
![image](https://user-images.githubusercontent.com/33557095/141301127-e6dd8a9a-8eb9-4703-a875-74b5827eceac.png)

