### PR TITLE
use PF components for the cards on the dashboard

### DIFF
--- a/packages/odf/components/odf-dashboard/activity-card/activity-card.tsx
+++ b/packages/odf/components/odf-dashboard/activity-card/activity-card.tsx
@@ -2,14 +2,11 @@ import * as React from 'react';
 import { FirehoseResource } from '@openshift-console/dynamic-plugin-sdk';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import {
-  DashboardCard,
-  DashboardCardBody,
-  DashboardCardHeader,
-  DashboardCardTitle,
   RecentEventsBody,
 } from '@openshift-console/dynamic-plugin-sdk-internal';
 import { EventKind } from '@openshift-console/dynamic-plugin-sdk-internal/lib/api/internal-types';
 import { useTranslation } from 'react-i18next';
+import { Card, CardBody, CardHeader, CardTitle } from '@patternfly/react-core';
 import './activity-card.scss';
 
 const eventsResource: FirehoseResource = {
@@ -24,11 +21,11 @@ const ActivityCard: React.FC = () => {
     useK8sWatchResource<EventKind[]>(eventsResource);
 
   return (
-    <DashboardCard>
-      <DashboardCardHeader>
-        <DashboardCardTitle>{t('Activity')}</DashboardCardTitle>
-      </DashboardCardHeader>
-      <DashboardCardBody className="odf-activityCard">
+    <Card>
+      <CardHeader>
+        <CardTitle>{t('Activity')}</CardTitle>
+      </CardHeader>
+      <CardBody className="odf-activityCard">
         <RecentEventsBody
           events={{
             data,
@@ -36,8 +33,8 @@ const ActivityCard: React.FC = () => {
             loadError,
           }}
         />
-      </DashboardCardBody>
-    </DashboardCard>
+      </CardBody>
+    </Card>
   );
 };
 

--- a/packages/odf/components/odf-dashboard/object-storage-card/capacity-card.tsx
+++ b/packages/odf/components/odf-dashboard/object-storage-card/capacity-card.tsx
@@ -3,13 +3,10 @@ import CapacityCard from '@odf/shared/dashboards/capacity-card/capacity-card';
 import { humanizeBinaryBytes } from '@odf/shared/utils/humanize';
 import { PrometheusResponse } from '@openshift-console/dynamic-plugin-sdk';
 import {
-  DashboardCard,
-  DashboardCardBody,
-  DashboardCardHeader,
-  DashboardCardTitle,
   usePrometheusPoll,
 } from '@openshift-console/dynamic-plugin-sdk-internal';
 import { useTranslation } from 'react-i18next';
+import { Card, CardBody, CardHeader, CardTitle } from '@patternfly/react-core';
 import { ODFStorageSystem } from '../../../models';
 import { CAPACITY_QUERIES, StorageDashboard } from '../queries';
 
@@ -29,21 +26,21 @@ const ObjectCapacityCard: React.FC = () => {
   const dataFrames = !loaded && !error ? parseMetricData(data) : [];
 
   return (
-    <DashboardCard className="odf-capacityCard--height">
-      <DashboardCardHeader>
-        <DashboardCardTitle>
+    <Card className="odf-capacityCard--height">
+      <CardHeader>
+        <CardTitle>
           {t('External Object Provider Used Capacity')}
-        </DashboardCardTitle>
-      </DashboardCardHeader>
-      <DashboardCardBody>
+        </CardTitle>
+      </CardHeader>
+      <CardBody>
         <CapacityCard
           data={dataFrames}
           relative
           isPercentage={false}
           resourceModel={ODFStorageSystem}
         />
-      </DashboardCardBody>
-    </DashboardCard>
+      </CardBody>
+    </Card>
   );
 };
 

--- a/packages/odf/components/odf-dashboard/performance-card/performance-card.tsx
+++ b/packages/odf/components/odf-dashboard/performance-card/performance-card.tsx
@@ -14,15 +14,13 @@ import {
 import { WatchK8sResource } from '@openshift-console/dynamic-plugin-sdk';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import {
-  DashboardCard,
-  DashboardCardHeader,
-  DashboardCardTitle,
   UtilizationDurationDropdown,
   usePrometheusPoll,
   useUtilizationDuration,
 } from '@openshift-console/dynamic-plugin-sdk-internal';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
+import { Card, CardHeader, CardTitle } from '@patternfly/react-core';
 import { SortByDirection } from '@patternfly/react-table';
 import { ODFStorageSystem } from '../../../models';
 import { StorageSystemKind } from '../../../types';
@@ -145,11 +143,11 @@ const PerformanceCard: React.FC = () => {
     !!systemLoadError || !!throughputError || !!latencyError || !!iopsError;
 
   return (
-    <DashboardCard>
-      <DashboardCardHeader>
-        <DashboardCardTitle>{t('Performance')}</DashboardCardTitle>
+    <Card>
+      <CardHeader>
+        <CardTitle>{t('Performance')}</CardTitle>
         <UtilizationDurationDropdown />
-      </DashboardCardHeader>
+      </CardHeader>
       {!error && !loading && (
         <Table
           columns={headerColumns}
@@ -164,7 +162,7 @@ const PerformanceCard: React.FC = () => {
           <DataUnavailableError />{' '}
         </div>
       )}
-    </DashboardCard>
+    </Card>
   );
 };
 

--- a/packages/odf/components/odf-dashboard/status-card/status-card.tsx
+++ b/packages/odf/components/odf-dashboard/status-card/status-card.tsx
@@ -5,17 +5,13 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import {
-  DashboardCard,
-  DashboardCardBody,
-  DashboardCardHeader,
-  DashboardCardTitle,
   HealthBody,
   HealthItem,
   usePrometheusPoll,
 } from '@openshift-console/dynamic-plugin-sdk-internal';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
-import { Gallery, GalleryItem, pluralize } from '@patternfly/react-core';
+import { Gallery, GalleryItem, pluralize, Card, CardBody, CardHeader, CardTitle } from '@patternfly/react-core';
 import { ODF_OPERATOR } from '../../../constants';
 import { ClusterServiceVersionKind } from '../../../types';
 import { getVendorDashboardLinkFromMetrics } from '../../utils';
@@ -88,11 +84,11 @@ export const StatusCard: React.FC = () => {
   );
 
   return (
-    <DashboardCard className="odfDashboard-card--height">
-      <DashboardCardHeader>
-        <DashboardCardTitle>{t('Status')}</DashboardCardTitle>
-      </DashboardCardHeader>
-      <DashboardCardBody>
+    <Card className="odfDashboard-card--height">
+      <CardHeader>
+        <CardTitle>{t('Status')}</CardTitle>
+      </CardHeader>
+      <CardBody>
         <HealthBody>
           <Gallery className="co-overview-status__health" hasGutter>
             <GalleryItem>
@@ -123,7 +119,7 @@ export const StatusCard: React.FC = () => {
             )}
           </Gallery>
         </HealthBody>
-      </DashboardCardBody>
-    </DashboardCard>
+      </CardBody>
+    </Card>
   );
 };

--- a/packages/odf/components/odf-dashboard/system-capacity-card/capacity-card.tsx
+++ b/packages/odf/components/odf-dashboard/system-capacity-card/capacity-card.tsx
@@ -14,14 +14,11 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import {
-  DashboardCard,
-  DashboardCardBody,
-  DashboardCardHeader,
-  DashboardCardTitle,
   usePrometheusPoll,
 } from '@openshift-console/dynamic-plugin-sdk-internal';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
+import { Card, CardBody, CardHeader, CardTitle } from '@patternfly/react-core';
 import { ODFStorageSystem } from '../../../models';
 import { StorageSystemKind } from '../../../types';
 import { CAPACITY_QUERIES, StorageDashboard } from '../queries';
@@ -81,11 +78,11 @@ const SystemCapacityCard: React.FC = () => {
   const isLoading =
     loadingUsedCapacity && loadingTotalCapacity && !systemsLoaded;
   return (
-    <DashboardCard className="odf-capacityCard--height">
-      <DashboardCardHeader>
-        <DashboardCardTitle>{t('System Capacity')}</DashboardCardTitle>
-      </DashboardCardHeader>
-      <DashboardCardBody>
+    <Card className="odf-capacityCard--height">
+      <CardHeader>
+        <CardTitle>{t('System Capacity')}</CardTitle>
+      </CardHeader>
+      <CardBody>
         {!error ? (
           <CapacityCard
             data={data}
@@ -96,8 +93,8 @@ const SystemCapacityCard: React.FC = () => {
         ) : (
           <>{t('No data available')}</>
         )}
-      </DashboardCardBody>
-    </DashboardCard>
+      </CardBody>
+    </Card>
   );
 };
 


### PR DESCRIPTION
Based on https://github.com/openshift/console/pull/10410 we need to remove the usage of console dashboard components and use PF components instead.

**Before:**
![Screenshot from 2021-12-14 17-07-42](https://user-images.githubusercontent.com/39404641/145992648-f1acfd92-62ab-416d-81bb-b4a3301d4854.png)

**After:**
![Screenshot from 2021-12-14 17-07-01](https://user-images.githubusercontent.com/39404641/145992686-0e73d868-2654-44bd-809d-f64c614b7a48.png)
