### PR TITLE
Improve styling of Health Status PopupItem

### DIFF
--- a/packages/odf/components/odf-dashboard/status-card/status-card.tsx
+++ b/packages/odf/components/odf-dashboard/status-card/status-card.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { useGetOCSHealth } from '@odf/ocs/hooks';
+import HealthItem from '@odf/shared/dashboards/status-card/HealthItem';
 import { ClusterServiceVersionKind } from '@odf/shared/types/console-types';
 import {
   getGVK,
@@ -12,7 +13,6 @@ import {
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import {
   HealthBody,
-  HealthItem,
   usePrometheusPoll,
 } from '@openshift-console/dynamic-plugin-sdk-internal';
 import * as _ from 'lodash';
@@ -159,6 +159,7 @@ export const StatusCard: React.FC = () => {
                 <HealthItem
                   title={pluralize(unHealthySystems.length, 'Storage System')}
                   state={HealthState.ERROR}
+                  maxWidth='35rem'
                 >
                   <StorageSystemPopup systemHealthMap={unHealthySystems} />
                 </HealthItem>

--- a/packages/shared/dashboards/status-card/HealthItem.tsx
+++ b/packages/shared/dashboards/status-card/HealthItem.tsx
@@ -1,0 +1,107 @@
+import * as React from 'react';
+import SecondaryStatus from '@odf/shared/status/SecondaryStatus';
+import { HealthState } from '@openshift-console/dynamic-plugin-sdk';
+import classNames from 'classnames';
+import { useTranslation } from 'react-i18next';
+import { Button, Popover, PopoverPosition } from '@patternfly/react-core';
+import { healthStateMapping, healthStateMessage } from './states';
+
+export type HealthItemProps = {
+  className?: string;
+  title: string;
+  details?: string;
+  state?: HealthState;
+  popupTitle?: string;
+  noIcon?: boolean;
+  icon?: React.ReactNode;
+  maxWidth?: string;
+};
+
+const HealthItemIcon: React.FC<HealthItemIconProps> = ({ state, dataTest }) => (
+  <div data-test={dataTest} className="co-dashboard-icon">
+    {
+      (healthStateMapping[state] || healthStateMapping[HealthState.UNKNOWN])
+        .icon
+    }
+  </div>
+);
+
+// eslint-disable-next-line react/display-name
+const HealthItem: React.FC<HealthItemProps> = React.memo(
+  ({
+    className,
+    state,
+    title,
+    details,
+    popupTitle,
+    noIcon = false,
+    icon,
+    children,
+    maxWidth,
+  }) => {
+    const { t } = useTranslation();
+
+    const detailMessage = details || healthStateMessage(state, t);
+
+    return (
+      <div
+        className={classNames('co-status-card__health-item', className)}
+        data-item-id={`${title}-health-item`}
+      >
+        {state === HealthState.LOADING ? (
+          <div className="skeleton-health">
+            <span className="pf-u-screen-reader">
+              {t('public~Loading {{title}} status', { title })}
+            </span>
+          </div>
+        ) : (
+          !noIcon &&
+          (icon || (
+            <HealthItemIcon
+              state={state}
+              dataTest={`${title}-health-item-icon`}
+            />
+          ))
+        )}
+        <div>
+          <span className="co-status-card__health-item-text">
+            {React.Children.toArray(children).length &&
+            state !== HealthState.LOADING ? (
+              <Popover
+                position={PopoverPosition.top}
+                headerContent={popupTitle}
+                bodyContent={children}
+                enableFlip
+                maxWidth={maxWidth || '21rem'}
+              >
+                <Button
+                  variant="link"
+                  isInline
+                  className="co-status-card__popup"
+                >
+                  {title}
+                </Button>
+              </Popover>
+            ) : (
+              title
+            )}
+          </span>
+          {state !== HealthState.LOADING && detailMessage && (
+            <SecondaryStatus
+              status={detailMessage}
+              className="co-status-card__health-item-text"
+              dataStatusID={`${title}-secondary-status`}
+            />
+          )}
+        </div>
+      </div>
+    );
+  }
+);
+
+export default HealthItem;
+
+type HealthItemIconProps = {
+  state?: HealthState;
+  dataTest?: string;
+};

--- a/packages/shared/dashboards/status-card/states.tsx
+++ b/packages/shared/dashboards/status-card/states.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react';
+import {
+  GrayUnknownIcon,
+  BlueSyncIcon,
+  BlueArrowCircleUpIcon,
+  GreenCheckCircleIcon,
+  RedExclamationCircleIcon,
+  YellowExclamationTriangleIcon,
+} from '@odf/shared/status/icons';
+import { HealthState } from '@openshift-console/dynamic-plugin-sdk';
+import { TFunction } from 'i18next';
+import { InProgressIcon } from '@patternfly/react-icons';
+
+export const healthStateMessage = (
+  state: keyof typeof HealthState,
+  t: TFunction
+): string => {
+  switch (state) {
+    case HealthState.OK:
+      return '';
+    case HealthState.UNKNOWN:
+      return t('console-shared~Unknown');
+    case HealthState.PROGRESS:
+      return t('console-shared~Pending');
+    case HealthState.UPDATING:
+      return t('console-shared~Updating');
+    case HealthState.WARNING:
+      return t('console-shared~Degraded');
+    case HealthState.ERROR:
+      return t('console-shared~Degraded');
+    case HealthState.LOADING:
+      return t('console-shared~Loading');
+    case HealthState.UPGRADABLE:
+      return t('console-shared~Upgrade available');
+    case HealthState.NOT_AVAILABLE:
+      return t('console-shared~Not available');
+    default:
+      return t('console-shared~Unknown');
+  }
+};
+
+export const healthStateMapping: {
+  [key in HealthState]: HealthStateMappingValues;
+} = {
+  [HealthState.OK]: {
+    priority: 0,
+    health: HealthState.OK,
+    icon: <GreenCheckCircleIcon title="Healthy" />,
+  },
+  [HealthState.UNKNOWN]: {
+    priority: 1,
+    health: HealthState.UNKNOWN,
+    icon: <GrayUnknownIcon title="Unknown" />,
+  },
+  [HealthState.PROGRESS]: {
+    priority: 2,
+    health: HealthState.PROGRESS,
+    icon: <InProgressIcon title="In progress" />,
+  },
+  [HealthState.UPDATING]: {
+    priority: 3,
+    health: HealthState.UPDATING,
+    icon: <BlueSyncIcon title="Updating" />,
+  },
+  [HealthState.UPGRADABLE]: {
+    priority: 4,
+    health: HealthState.UPGRADABLE,
+    icon: <BlueArrowCircleUpIcon title="Upgrade available" />,
+  },
+  [HealthState.WARNING]: {
+    priority: 5,
+    health: HealthState.WARNING,
+    icon: <YellowExclamationTriangleIcon title="Warning" />,
+  },
+  [HealthState.ERROR]: {
+    priority: 6,
+    health: HealthState.ERROR,
+    icon: <RedExclamationCircleIcon title="Error" />,
+  },
+  [HealthState.LOADING]: {
+    priority: 7,
+    health: HealthState.LOADING,
+    icon: <div className="skeleton-health" />,
+  },
+  [HealthState.NOT_AVAILABLE]: {
+    priority: 8,
+    health: HealthState.NOT_AVAILABLE,
+    icon: <GrayUnknownIcon title="Not available" />,
+  },
+};
+
+export type HealthStateMappingValues = {
+  icon: React.ReactNode;
+  priority: number;
+  health: HealthState;
+};

--- a/packages/shared/popup/status-popup.scss
+++ b/packages/shared/popup/status-popup.scss
@@ -2,16 +2,16 @@
   align-items: center;
   display: flex;
   flex-direction: column;
-  flex-grow: 1;
-  justify-content: center;
-  margin-left: var(--pf-global--spacer--sm);
-  place-items: center;
+  flex-grow: 0.3;
+  justify-items: center;
   white-space: nowrap;
 }
 
 .odf-status-popup__row {
   display: flex;
+  flex-grow: 1;
   justify-content: space-between;
+  min-width: 17rem;
   padding-bottom: var(--pf-global--spacer--xs);
 }
 

--- a/packages/shared/status/SecondaryStatus.tsx
+++ b/packages/shared/status/SecondaryStatus.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import * as _ from 'lodash';
+
+type SecondaryStatusProps = {
+  status?: string | string[];
+  className?: string;
+  dataStatusID?: string;
+};
+
+const SecondaryStatus: React.FC<SecondaryStatusProps> = ({ status, className, dataStatusID }) => {
+  const statusLabel = _.compact(_.concat([], status)).join(', ');
+  const cssClassName = className || '';
+  if (statusLabel) {
+    return (
+      <div data-status-id={dataStatusID}>
+        <small className={`${cssClassName} text-muted`}>{statusLabel}</small>
+      </div>
+    );
+  }
+  return null;
+};
+
+export default SecondaryStatus;

--- a/packages/shared/status/icons.tsx
+++ b/packages/shared/status/icons.tsx
@@ -1,0 +1,130 @@
+import * as React from 'react';
+import { global_danger_color_100 as dangerColor } from '@patternfly/react-tokens/dist/js/global_danger_color_100';
+import { global_default_color_200 as blueDefaultColor } from '@patternfly/react-tokens/dist/js/global_default_color_200';
+import { global_disabled_color_100 as disabledColor } from '@patternfly/react-tokens/dist/js/global_disabled_color_100';
+import { global_palette_blue_300 as blueInfoColor } from '@patternfly/react-tokens/dist/js/global_palette_blue_300';
+import { global_palette_green_500 as okColor } from '@patternfly/react-tokens/dist/js/global_palette_green_500';
+import { global_warning_color_100 as warningColor } from '@patternfly/react-tokens/dist/js/global_warning_color_100';
+import {
+  CheckCircleIcon,
+  InfoCircleIcon,
+  ExclamationCircleIcon,
+  ExclamationTriangleIcon,
+  ArrowCircleUpIcon,
+  UnknownIcon,
+  SyncAltIcon,
+  ResourcesAlmostFullIcon,
+  ResourcesFullIcon,
+} from '@patternfly/react-icons';
+
+export type ColoredIconProps = {
+  className?: string;
+  title?: string;
+  size?: 'sm' | 'md' | 'lg' | 'xl';
+};
+
+export const GreenCheckCircleIcon: React.FC<ColoredIconProps> = ({
+  className,
+  title,
+  size,
+}) => (
+  <CheckCircleIcon
+    data-test="success-icon"
+    size={size}
+    color={okColor.value}
+    className={className}
+    title={title}
+  />
+);
+
+export const RedExclamationCircleIcon: React.FC<ColoredIconProps> = ({
+  className,
+  title,
+  size,
+}) => (
+  <ExclamationCircleIcon
+    size={size}
+    color={dangerColor.value}
+    className={className}
+    title={title}
+  />
+);
+
+export const YellowExclamationTriangleIcon: React.FC<ColoredIconProps> = ({
+  className,
+  title,
+  size,
+}) => (
+  <ExclamationTriangleIcon
+    size={size}
+    color={warningColor.value}
+    className={className}
+    title={title}
+  />
+);
+
+export const BlueInfoCircleIcon: React.FC<ColoredIconProps> = ({
+  className,
+  title,
+}) => (
+  <InfoCircleIcon
+    color={blueInfoColor.value}
+    className={className}
+    title={title}
+  />
+);
+
+export const GrayUnknownIcon: React.FC<ColoredIconProps> = ({
+  className,
+  title,
+}) => (
+  <UnknownIcon
+    color={disabledColor.value}
+    className={className}
+    title={title}
+  />
+);
+
+export const BlueSyncIcon: React.FC<ColoredIconProps> = ({
+  className,
+  title,
+}) => (
+  <SyncAltIcon
+    color={blueInfoColor.value}
+    className={className}
+    title={title}
+  />
+);
+
+export const RedResourcesFullIcon: React.FC<ColoredIconProps> = ({
+  className,
+  title,
+}) => (
+  <ResourcesFullIcon
+    color={dangerColor.value}
+    className={className}
+    title={title}
+  />
+);
+
+export const YellowResourcesAlmostFullIcon: React.FC<ColoredIconProps> = ({
+  className,
+  title,
+}) => (
+  <ResourcesAlmostFullIcon
+    color={warningColor.value}
+    className={className}
+    title={title}
+  />
+);
+
+export const BlueArrowCircleUpIcon: React.FC<ColoredIconProps> = ({
+  className,
+  title,
+}) => (
+  <ArrowCircleUpIcon
+    color={blueDefaultColor.value}
+    className={className}
+    title={title}
+  />
+);


### PR DESCRIPTION
Add space between two columns in Health Popup in ODF dashbord

Screenshot: 
![Screenshot from 2022-02-10 22-04-58](https://user-images.githubusercontent.com/54092533/153450697-9aece50d-76f2-461d-a54f-e21bba585e8e.png)
