### PR TITLE
Improves style of Object Service card under ODF dashboard

### DIFF
--- a/packages/shared/dashboards/capacity-card/capacity-card.tsx
+++ b/packages/shared/dashboards/capacity-card/capacity-card.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import PlainResourceName from '@odf/shared/resource-link/plain-resource-link';
 import { K8sKind } from '@openshift-console/dynamic-plugin-sdk/lib/api/common-types';
 import classNames from 'classnames';
 import * as _ from 'lodash';
@@ -168,7 +169,7 @@ const CapacityCardRow: React.FC<CapacityCardRowProps> = ({
             />
           </Tooltip>
         ) : (
-          data.name
+          <PlainResourceName resourceName={data.name} />
         )}
       </GridItem>
       <GridItem key={`${data.name}~progress`} span={7}>

--- a/packages/shared/resource-link/plain-resource-link.scss
+++ b/packages/shared/resource-link/plain-resource-link.scss
@@ -1,0 +1,6 @@
+.plainResource--overflow {
+  cursor: default;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/packages/shared/resource-link/plain-resource-link.tsx
+++ b/packages/shared/resource-link/plain-resource-link.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { Tooltip } from '@patternfly/react-core';
+import './plain-resource-link.scss';
+
+type PlainResourceNameProps = {
+  resourceName: string;
+};
+
+const PlainResourceName: React.FC<PlainResourceNameProps> = ({
+  resourceName,
+}) => (
+  <Tooltip content={resourceName}>
+    <div className="plainResource--overflow">{resourceName}</div>
+  </Tooltip>
+);
+
+export default PlainResourceName;


### PR DESCRIPTION
Hide overflowing resource name.
Add tool-tip that displays the overflow text. 

Screenshots:
![Screenshot from 2022-03-01 10-49-51](https://user-images.githubusercontent.com/54092533/156108368-d6506913-3270-4faf-bb25-3af08c8bfeb7.png)
![Screenshot from 2022-03-01 10-47-16](https://user-images.githubusercontent.com/54092533/156108374-57ce51c0-88ae-4a1e-9dde-7c9e6dfd0e79.png)
