### PR TITLE
fix entry point for /compatibility basePath

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -6,7 +6,7 @@ server {
         root   /opt/app-root/src;
     }
     location /compatibility/ {
-        root   /opt/app-root/src/compatibility;
+        root   /opt/app-root/src;
     }
     error_page   500 502 503 504  /50x.html;
     location = /50x.html {


### PR DESCRIPTION
For OCP 4.11 + ODF 4.10 --> basePath: `/compatibility/`
But console is fetching files from `/app-root/src/compatibility/compatibility/plugin-manifest.json` which is incorrect because there is no `compatibility` directory inside parent `compatibility` directory.
Console should fetch files from `/app-root/src/compatibility/plugin-manifest.json` instead, thus, need to change the entry-point for such requests. 