### PR TITLE
remove usage of setFlag from wizard footer.tsx

### DIFF
--- a/packages/odf/constants/common.ts
+++ b/packages/odf/constants/common.ts
@@ -17,6 +17,7 @@ export const OCS_DEVICE_SET_REPLICA = 3;
 export const OCS_DEVICE_SET_ARBITER_REPLICA = 4;
 export const OCS_DEVICE_SET_FLEXIBLE_REPLICA = 1;
 export const MINIMUM_NODES = 3;
+export const SECOND = 1000;
 
 export enum defaultRequestSize {
     BAREMETAL = '1',


### PR DESCRIPTION
https://issues.redhat.com/browse/RHSTOR-2805

As per the discussion: https://github.com/openshift/console/pull/10872#issuecomment-1017732666

`setFlag` will not be exposed. Hence, removing its usage from the `footer.tsx` file.

Values of flags after creating internal mode SS from the UI (without any re-load):
```
MCG_STANDALONE
OCS
OCS_CONVERGED
OCS_INDEPENDENT
```
![Screenshot from 2022-02-28 19-26-32](https://user-images.githubusercontent.com/39404641/155997382-39e26c81-9db2-4129-8b44-3390431861c7.png)
