### PR TITLE
Set MCO flag at compile time

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -8,6 +8,14 @@
     }
   },
   {
+    "type": "console.flag",
+    "properties": {
+      "handler": {
+        "$codeRef": "features.setMCOFlag"
+      }
+    }
+  },
+  {
     "type": "console.navigation/href",
     "properties": {
       "id": "odfdashboard",

--- a/http-server.sh
+++ b/http-server.sh
@@ -6,4 +6,4 @@ public_path="$1"
 shift
 server_opts="$@"
 
-http-server $public_path -p 9001 -S true -C /var/serving-cert/tls.crt -K /var/serving-cert/tls.key -c-1 --cors $server_opts 
+http-server $public_path -p 9001

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test-cypress": "node_modules/.bin/cypress open --config-file ./cypress/cypress.json --env openshift=true",
     "test-cypress-headless": "node --max-old-space-size=4096 node_modules/.bin/cypress run --config-file ./cypress/cypress.json --env openshift=true --browser ${BRIDGE_E2E_BROWSER_NAME:=chrome} --headless",
     "build": "yarn clean && NODE_ENV=production yarn ts-node ./node_modules/.bin/webpack",
+    "build-mco": "yarn clean && NODE_ENV=production MODE=MCO yarn ts-node ./node_modules/.bin/webpack",
     "build-dev": "yarn clean && yarn ts-node ./node_modules/.bin/webpack",
     "dev": "yarn clean && yarn ts-node ./node_modules/.bin/webpack serve",
     "http-server": "./http-server.sh ./dist",

--- a/packages/odf/features.ts
+++ b/packages/odf/features.ts
@@ -18,6 +18,11 @@ export const CEPH_FLAG = 'CEPH';
 // Based on the existence of StorageCluster
 export const OCS_FLAG = 'OCS';
 
+
+export const MCO_MODE_FLAG = 'MCO';
+
+export const isMCO = process.env.MODE === 'MCO';
+
 export enum FEATURES {
   // Flag names to be prefixed with "OCS_" so as to seperate from console flags
   OCS_MULTUS = 'OCS_MULTUS',
@@ -58,6 +63,8 @@ const setOCSFlagsFalse = (setFlag: SetFeatureFlag) => {
 };
 
 export const setODFFlag = (setFlag: SetFeatureFlag) => setFlag(ODF_MODEL_FLAG, true);
+
+export const setMCOFlag = (setFlag: SetFeatureFlag) => setFlag(MCO_MODE_FLAG, isMCO);
 
 export const setOCSFlags = async (setFlag: SetFeatureFlag) => {
   let ocsIntervalId = null;

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -79,16 +79,20 @@ const config: webpack.Configuration = {
       },
     ],
   },
-  plugins: [new ConsoleRemotePlugin(), new CopyWebpackPlugin({
-    patterns: [
-      { from: path.resolve(__dirname, 'locales'), to: 'locales' }
-    ]
-  })],
+  plugins: [
+    new ConsoleRemotePlugin(),
+    new CopyWebpackPlugin({
+      patterns: [{ from: path.resolve(__dirname, 'locales'), to: 'locales' }],
+    }),
+    new webpack.DefinePlugin({
+      'process.env.MODE': JSON.stringify(process.env.MODE),
+    }),
+  ],
   devtool: 'cheap-module-source-map',
   optimization: {
     chunkIds: 'named',
     minimize: false,
-  }
+  },
 };
 
 export default config;


### PR DESCRIPTION
- Creates a build command for MCO
- Sets MCO flag based on build parameter.
- Updates the http-server to remove dependency on certs.
![MCO_flag_set](https://user-images.githubusercontent.com/54092533/160833223-4518cae5-435c-4223-a5b6-76fc80782519.png)
