### PR TITLE
Add arrow-parens rule for eslintrc

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
   },
   plugins: ['react', '@typescript-eslint', 'import'],
   rules: {
+    'arrow-parens': 2,
     'import/no-unresolved': 'off',
     'import/extensions': 'off',
     'import/prefer-default-export': 'off',


### PR DESCRIPTION
Enforces parentheses around single-arguments in arrow functions by
throwing lint errors (severity: error).

Signed-off-by: Pranshu Srivastava <rexagod@gmail.com>