### PR TITLE
Remove NooBaa Management UI link

### DIFF
--- a/packages/ocs/dashboards/object-service/details-card/details-card.tsx
+++ b/packages/ocs/dashboards/object-service/details-card/details-card.tsx
@@ -20,7 +20,6 @@ import {
 } from '@odf/shared/utils';
 import { resourcePathFromModel } from '@odf/shared/utils';
 import { getMetric } from '@odf/shared/utils';
-import { ExternalLink } from '@odf/shared/utils/link';
 import {
   useK8sWatchResource,
   useFlag,
@@ -113,11 +112,9 @@ export const ObjectServiceDetailsCard: React.FC<{}> = () => {
               !systemLink
             }
           >
-            <ExternalLink
-              href={systemLink}
-              dataTestID="system-name-mcg"
-              text={t('Multicloud Object Gateway')}
-            />
+            <p data-test-id="system-name-mcg">
+              {t('Multicloud Object Gateway')}
+            </p>
             {hasRGW && (
               <p
                 className="ceph-details-card__rgw-system-name--margin"


### PR DESCRIPTION
Fixes Bug 2036629 <https://bugzilla.redhat.com/show_bug.cgi?id=2036629>
As per recent update from NooBaa Engineering, the NooBaa Management UI is not
maintained anymore. Remove the NooBaa Management UI link from the ODF Console.

Signed-off-by: Pranshu Srivastava <rexagod@gmail.com>
