### PR TITLE
add events tab and own ref for mcg pages

### DIFF
--- a/locales/en/plugin__odf-console.json
+++ b/locales/en/plugin__odf-console.json
@@ -750,6 +750,7 @@
   "{{count}} hour_plural": "{{count}} hour",
   "{{count}} minute": "{{count}} minute",
   "{{count}} minute_plural": "{{count}} minute",
+  "Managed by": "Managed by",
   "Edit": "Edit",
   "Annotations": "Annotations",
   "{{count}} annotation": "{{count}} annotation",

--- a/packages/odf/components/resource-pages/BackingStoreDetailsPage.tsx
+++ b/packages/odf/components/resource-pages/BackingStoreDetailsPage.tsx
@@ -7,15 +7,16 @@ import { Kebab } from '@odf/shared/kebab/kebab';
 import { useModalLauncher } from '@odf/shared/modals/modalLauncher';
 import { K8sResourceKind } from '@odf/shared/types';
 import { referenceForModel } from '@odf/shared/utils';
-import {
-  ResourceYAMLEditor,
-  useK8sWatchResource,
-} from '@openshift-console/dynamic-plugin-sdk';
+import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { useTranslation } from 'react-i18next';
 import { RouteComponentProps } from 'react-router';
 import { NooBaaBackingStoreModel } from '../../models';
 import { BackingStoreKind } from '../../types';
-import { CommonDetails } from './CommonDetails';
+import {
+  CommonDetails,
+  YAMLEditorWrapped,
+  EventStreamWrapped,
+} from './CommonDetails';
 import ProviderDetails from './Providers';
 
 type BackingStoreDetilsPageProps = {
@@ -47,14 +48,6 @@ const BSDetails: DetailsType =
       </CommonDetails>
     );
   };
-
-type YAMLEditorWrapped = {
-  obj?: BackingStoreKind;
-};
-
-const YAMLEditorWrapped: React.FC<YAMLEditorWrapped> = ({ obj }) => (
-  <ResourceYAMLEditor initialResource={obj} />
-);
 
 const BackingStoreDetailsPage: React.FC<BackingStoreDetilsPageProps> = ({
   match,
@@ -125,6 +118,11 @@ const BackingStoreDetailsPage: React.FC<BackingStoreDetilsPageProps> = ({
             href: 'yaml',
             name: 'YAML',
             component: YAMLEditorWrapped,
+          },
+          {
+            href: 'events',
+            name: 'Events',
+            component: EventStreamWrapped,
           },
         ]}
       />

--- a/packages/odf/components/resource-pages/BucketClassDetailsPage.tsx
+++ b/packages/odf/components/resource-pages/BucketClassDetailsPage.tsx
@@ -6,16 +6,18 @@ import { useDeepCompareMemoize } from '@odf/shared/hooks/deep-compare-memoize';
 import { Kebab } from '@odf/shared/kebab/kebab';
 import { useModalLauncher } from '@odf/shared/modals/modalLauncher';
 import { referenceForModel } from '@odf/shared/utils';
-import {
-  ResourceYAMLEditor,
-  useK8sWatchResource,
-} from '@openshift-console/dynamic-plugin-sdk';
+import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import * as _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { RouteComponentProps } from 'react-router';
 import { NooBaaBucketClassModel } from '../../models';
 import { BucketClassKind } from '../../types';
-import { CommonDetails, DetailsItem } from './CommonDetails';
+import {
+  CommonDetails,
+  DetailsItem,
+  YAMLEditorWrapped,
+  EventStreamWrapped,
+} from './CommonDetails';
 
 type BucketClassDetailsPageProps = {
   match: RouteComponentProps<{ resourceName: string; plural: string }>['match'];
@@ -86,14 +88,6 @@ const BCDetails: DetailsType =
     );
   };
 
-type YAMLEditorWrapped = {
-  obj?: BucketClassKind;
-};
-
-const YAMLEditorWrapped: React.FC<YAMLEditorWrapped> = ({ obj }) => (
-  <ResourceYAMLEditor initialResource={obj} />
-);
-
 const BucketClassDetailsPage: React.FC<BucketClassDetailsPageProps> = ({
   match,
 }) => {
@@ -163,6 +157,11 @@ const BucketClassDetailsPage: React.FC<BucketClassDetailsPageProps> = ({
             href: 'yaml',
             name: 'YAML',
             component: YAMLEditorWrapped,
+          },
+          {
+            href: 'events',
+            name: 'Events',
+            component: EventStreamWrapped,
           },
         ]}
       />

--- a/packages/odf/components/resource-pages/CommonDetails.tsx
+++ b/packages/odf/components/resource-pages/CommonDetails.tsx
@@ -2,9 +2,12 @@ import * as React from 'react';
 import { ResourceSummary } from '@odf/shared/details-page/DetailsPage';
 import { SectionHeading } from '@odf/shared/heading/page-heading';
 import { LaunchModal } from '@odf/shared/modals/modalLauncher';
+import { K8sResourceKind } from '@odf/shared/types';
 import { Conditions } from '@odf/shared/utils/Conditions';
 import {
   K8sModel,
+  ResourceYAMLEditor,
+  ResourceEventStream,
   K8sResourceCommon,
 } from '@openshift-console/dynamic-plugin-sdk';
 import classNames from 'classnames';
@@ -85,3 +88,15 @@ export const CommonDetails: React.FC<CommonDetailsSectionProps> = ({
     </>
   );
 };
+
+type WrappedProps = {
+  obj?: K8sResourceKind;
+};
+
+export const YAMLEditorWrapped: React.FC<WrappedProps> = ({ obj }) => (
+  <ResourceYAMLEditor initialResource={obj} />
+);
+
+export const EventStreamWrapped: React.FC<WrappedProps> = ({ obj }) => (
+  <ResourceEventStream resource={obj} />
+);

--- a/packages/odf/components/resource-pages/NamespaceStoreDetailsPage.tsx
+++ b/packages/odf/components/resource-pages/NamespaceStoreDetailsPage.tsx
@@ -6,15 +6,16 @@ import { useDeepCompareMemoize } from '@odf/shared/hooks/deep-compare-memoize';
 import { Kebab } from '@odf/shared/kebab/kebab';
 import { useModalLauncher } from '@odf/shared/modals/modalLauncher';
 import { referenceForModel } from '@odf/shared/utils';
-import {
-  ResourceYAMLEditor,
-  useK8sWatchResource,
-} from '@openshift-console/dynamic-plugin-sdk';
+import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { useTranslation } from 'react-i18next';
 import { RouteComponentProps } from 'react-router';
 import { NooBaaNamespaceStoreModel } from '../../models';
 import { NamespaceStoreKind } from '../../types';
-import { CommonDetails } from './CommonDetails';
+import {
+  CommonDetails,
+  YAMLEditorWrapped,
+  EventStreamWrapped,
+} from './CommonDetails';
 import ProviderDetails from './Providers';
 
 type BackingStoreDetilsPageProps = {
@@ -46,14 +47,6 @@ const NSDetails: DetailsType =
       </CommonDetails>
     );
   };
-
-type YAMLEditorWrapped = {
-  obj?: NamespaceStoreKind;
-};
-
-const YAMLEditorWrapped: React.FC<YAMLEditorWrapped> = ({ obj }) => (
-  <ResourceYAMLEditor initialResource={obj} />
-);
 
 const NamespaceStoreDetailsPage: React.FC<BackingStoreDetilsPageProps> = ({
   match,
@@ -126,6 +119,11 @@ const NamespaceStoreDetailsPage: React.FC<BackingStoreDetilsPageProps> = ({
             href: 'yaml',
             name: 'YAML',
             component: YAMLEditorWrapped,
+          },
+          {
+            href: 'events',
+            name: 'Events',
+            component: EventStreamWrapped,
           },
         ]}
       />

--- a/packages/shared/details-page/DetailsPage.tsx
+++ b/packages/shared/details-page/DetailsPage.tsx
@@ -52,12 +52,27 @@ type DetailsPageTitleProps = {
 export const DetailsPageTitle: React.FC<DetailsPageTitleProps> = ({
   resource,
   resourceModel,
-}) => (
-  <span>
-    <ResourceIcon resourceModel={resourceModel} />
-    {getName(resource)}
-  </span>
-);
+}) => {
+  const { t } = useCustomTranslation();
+
+  const showOwnerRef = resource?.metadata?.ownerReferences;
+  return (
+    <div className="odf-details-title">
+      <div>
+        <ResourceIcon resourceModel={resourceModel} />
+      </div>
+      <div className="odf-title-owner-reference">
+        {getName(resource)}
+        {showOwnerRef && (
+          <h4 className="odf-details-title odf-managed-owner--gap">
+            {t('Managed by')}
+            <OwnerReferences resource={resource} />
+          </h4>
+        )}
+      </div>
+    </div>
+  );
+};
 
 const DetailsPage: React.FC<DetailsPageProps> = ({
   pages,

--- a/packages/shared/details-page/details.scss
+++ b/packages/shared/details-page/details.scss
@@ -1,3 +1,17 @@
 .odf-resource-details {
   margin-top: var(--pf-global--spacer--md);
 }
+
+.odf-details-title {
+  display: flex;
+  flex-direction: row;
+}
+
+.odf-managed-owner--gap {
+  gap: 0.25rem;
+}
+
+.odf-title-owner-reference {
+  display: flex;
+  flex-direction: column;
+}

--- a/packages/shared/heading/page-heading.scss
+++ b/packages/shared/heading/page-heading.scss
@@ -6,3 +6,8 @@
 .odf-title {
   padding-bottom: 1.5rem;
 }
+
+.odf-title-status {
+  display: flex;
+  flex-direction: row;
+}

--- a/packages/shared/heading/page-heading.tsx
+++ b/packages/shared/heading/page-heading.tsx
@@ -101,7 +101,7 @@ const PageHeading: React.FC<PageHeadingProps> = (props) => {
           <div className="co-m-pane__name co-resource-item">
             <span
               data-test-id="resource-title"
-              className="co-resource-item__resource-name"
+              className="co-resource-item__resource-name odf-title-status"
             >
               {resourceTitle}
               {resourceStatus && (


### PR DESCRIPTION
For BackingStore/BucketClass/NamespaceStore:
-- Added Events tab.
-- Added owner reference (Managed by) under the title of the page.

![Screenshot from 2022-05-18 23-16-19](https://user-images.githubusercontent.com/39404641/169110942-8419a5ef-e9c1-4504-a6d2-be82efdf197d.png)
