### PR TITLE
Fix Tabs in OCS Dashboard

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -340,6 +340,16 @@
   {
     "type": "console.page/route",
     "properties": {
+      "exact": true,
+      "path": "/odf/system/ocs.openshift.io~v1~StorageCluster/:systemName/ceph.rook.io~v1~CephBlockPool/create/~new",
+      "component": {
+        "$codeRef": "createBlockPools.default"
+      }
+    }
+  },
+  {
+    "type": "console.page/route",
+    "properties": {
       "path": "/odf/system/ocs.openshift.io~v1~StorageCluster/:systemName/ceph.rook.io~v1~CephBlockPool/:poolName",
       "exact": false,
       "component": {
@@ -347,20 +357,6 @@
       }
     },
     "flags": {
-      "disallowed": ["MCO"]
-    }
-  },
-  {
-    "type": "console.page/route",
-    "properties": {
-      "exact": true,
-      "path": "/odf/system/ocs.openshift.io~v1~StorageCluster/:systemName/ceph.rook.io~v1~CephBlockPool/create/~new",
-      "component": {
-        "$codeRef": "createBlockPools.default"
-      }
-    },
-    "flags": {
-      "required": ["OCS"],
       "disallowed": ["MCO"]
     }
   },

--- a/packages/ocs/block-pool/CreateBlockPool.tsx
+++ b/packages/ocs/block-pool/CreateBlockPool.tsx
@@ -51,6 +51,7 @@ export const getPoolKindObj = (state: BlockPoolState): StoragePoolKind => ({
 
 export const cephClusterResource = {
   kind: referenceForModel(CephClusterModel),
+  namespace: CEPH_NS,
   isList: true,
 };
 

--- a/packages/ocs/dashboards/ocs-system-dashboard.tsx
+++ b/packages/ocs/dashboards/ocs-system-dashboard.tsx
@@ -177,7 +177,7 @@ const OCSSystemDashboard: React.FC<RouteComponentProps> = () => {
   }, [showInternalDashboard, isIndependent, isObjectServiceAvailable, t]);
 
   return pages.length > 0 ? (
-    <Tabs id="odf-dashboard-tab" tabs={pages} />
+    <Tabs id="odf-dashboard-tab" tabs={pages} basePath="overview" />
   ) : (
     <LoadingBox />
   );

--- a/packages/odf/features.ts
+++ b/packages/odf/features.ts
@@ -27,6 +27,7 @@ import {
   NOOBAA_PROVISIONER,
   ODF_MANAGED_LABEL,
   OCS_SUPPORT_ANNOTATION,
+  OCS_DISABLED_ANNOTATION,
 } from './constants';
 import { NooBaaSystemModel } from './models';
 
@@ -83,6 +84,16 @@ export const OCS_FEATURE_FLAGS = {
   [FEATURES.ODF_MCG_STANDALONE]: 'mcg-standalone',
   [FEATURES.ODF_HPCS_KMS]: 'hpcs-kms',
   [FEATURES.ODF_VAULT_SA_KMS]: 'vault-sa-kms',
+};
+
+export const ODF_BLOCK_FLAG = {
+  [FEATURES.SS_LIST]: 'ss-list',
+  [FEATURES.ADD_CAPACITY]: 'add-capacity',
+  [FEATURES.ODF_WIZARD]: 'install-wizard',
+  [FEATURES.BLOCK_POOL]: 'block-pool',
+  [FEATURES.MCG_RESOURCE]: 'mcg-resource',
+  [FEATURES.ODF_DASHBOARD]: 'odf-dashboard',
+  [FEATURES.COMMON_FLAG]: 'common',
 };
 
 const setOCSFlagsFalse = (setFlag: SetFeatureFlag) => {
@@ -277,6 +288,13 @@ const detectFeatures = (
   const support = JSON.parse(getAnnotations(csv)?.[OCS_SUPPORT_ANNOTATION]);
   _.keys(OCS_FEATURE_FLAGS).forEach((feature) => {
     setFlag(feature, support.includes(OCS_FEATURE_FLAGS[feature]));
+  });
+
+  const disabled = JSON.parse(
+    getAnnotations(csv)?.[OCS_DISABLED_ANNOTATION] || '[]'
+  );
+  _.keys(ODF_BLOCK_FLAG).forEach((feature) => {
+    setFlag(feature, disabled.includes(ODF_BLOCK_FLAG[feature]));
   });
 };
 

--- a/packages/shared/heading/page-heading.scss
+++ b/packages/shared/heading/page-heading.scss
@@ -11,3 +11,9 @@
   display: flex;
   flex-direction: row;
 }
+
+.odf-breadcrumbs {
+  padding: var(--pf-c-page__main-breadcrumb--PaddingTop)
+    var(--pf-c-page__main-breadcrumb--PaddingRight)
+    var(--pf-c-page__main-breadcrumb--PaddingBottom) 0;
+}

--- a/packages/shared/heading/page-heading.tsx
+++ b/packages/shared/heading/page-heading.tsx
@@ -83,7 +83,7 @@ const PageHeading: React.FC<PageHeadingProps> = (props) => {
       style={style}
     >
       {showBreadcrumbs && (
-        <Split style={{ alignItems: 'baseline' }}>
+        <Split style={{ alignItems: 'baseline' }} className="odf-breadcrumbs">
           <SplitItem isFilled>
             <BreadCrumbs breadcrumbs={breadcrumbs} />
           </SplitItem>

--- a/packages/shared/utils/Tabs.tsx
+++ b/packages/shared/utils/Tabs.tsx
@@ -26,9 +26,15 @@ type TabsProps = {
   tabs: TabPage[];
   isSecondary?: boolean;
   id: string;
+  basePath?: string; // The page that is common to these tabs
 };
 
-const Tabs: React.FC<TabsProps> = ({ tabs, isSecondary = false, id }) => {
+const Tabs: React.FC<TabsProps> = ({
+  tabs,
+  isSecondary = false,
+  id,
+  basePath,
+}) => {
   const offset = isSecondary ? 10 : 1;
   const [activeTab, setActiveTab] = React.useState(0 + offset);
 
@@ -75,7 +81,8 @@ const Tabs: React.FC<TabsProps> = ({ tabs, isSecondary = false, id }) => {
         currentLocation.includes(href)
     );
     const trueActiveTab = hrefToTabMap[firstMatchKey];
-    if (!trueActiveTab) {
+    const isActiveBasePath = currentLocation.endsWith(basePath);
+    if (!trueActiveTab && isActiveBasePath) {
       const activeHref = tabToHrefMap[activeTab];
       const sanitizedPath = location.pathname.endsWith('/')
         ? location.pathname.slice(0, -1)

--- a/packages/shared/utils/tabs.scss
+++ b/packages/shared/utils/tabs.scss
@@ -1,3 +1,18 @@
 .odf-tabs {
   overflow: unset;
+  padding-left: 1.5rem;
+  // The following styles are required to override the PF Tab styles and make it consistent with console
+  span {
+    font: 18px 'RedHatText';
+  }
+
+  .pf-c-tabs__link {
+    margin-right: 2rem;
+    padding: var(--pf-c-tabs__link--PaddingTop) 0
+      var(--pf-c-tabs__link--PaddingBottom) 0;
+  }
+
+  .pf-m-current span {
+    color: var(--pf-global--link--Color);
+  }
 }


### PR DESCRIPTION
Issues Fixed: 
 - Fix Breadcrumbs across ODF by adding spacing. 
 - Make Tab component of PF look and feel similar to console HorizontalNav. 
 - Fix Route of BlockPoolCreate (this needs to be defined before BlockPoolListPage)
 - Migrate Feature Disable flag logic to ODF Console
 - Fix route changes in ODF Tabs component to a common basePath

Signed-off-by: Bipul Adhikari <badhikar@redhat.com>

Screenshot: 
![Screenshot from 2022-05-19 16-42-24](https://user-images.githubusercontent.com/54092533/169278702-488e1d77-aca7-4914-9e7c-1306369145e2.png)
