### PR TITLE
Fixing text visibility under Token text-box

### DIFF
--- a/packages/odf/components/kms-config/vault-auth-methods.tsx
+++ b/packages/odf/components/kms-config/vault-auth-methods.tsx
@@ -17,6 +17,7 @@ export const VaultTokenConfigure: React.FC<VaultAuthMethodProps> = ({
   vaultState,
   setAuthValue,
   isValid,
+  isScEncryption,
 }) => {
   const [revealToken, setRevealToken] = React.useState(false);
 
@@ -27,9 +28,12 @@ export const VaultTokenConfigure: React.FC<VaultAuthMethodProps> = ({
       className={className}
       helperTextInvalid={t('plugin__odf-console~This is a required field')}
       validated={isValid(vaultState.authValue?.valid)}
-      helperText={t(
-        'plugin__odf-console~Create a secret with the token for every namespace using encrypted PVCs.'
-      )}
+      helperText={
+        isScEncryption &&
+        t(
+          'plugin__odf-console~Create a secret with the token for every namespace using encrypted PVCs.'
+        )
+      }
       isRequired
     >
       <InputGroup className="ocs-install-kms__form-token">
@@ -91,6 +95,7 @@ export const VaultServiceAccountConfigure: React.FC<VaultAuthMethodProps> = ({
 };
 
 export type VaultAuthMethodProps = {
+  isScEncryption?: boolean;
   className: string;
   vaultState: VaultConfig;
   t: TFunction;

--- a/packages/odf/components/kms-config/vault-config.tsx
+++ b/packages/odf/components/kms-config/vault-config.tsx
@@ -57,6 +57,7 @@ export const VaultConfigure: React.FC<KMSConfigureProps> = ({
   );
 
   const { encryption } = state;
+  const isScEncryption = encryption.storageClass;
 
   const openAdvancedModal = () =>
     launchModal(LAUNCH_MODAL_KEY, {
@@ -167,7 +168,7 @@ export const VaultConfigure: React.FC<KMSConfigureProps> = ({
       <ValutConnectionForm
         {...{
           t,
-          state,
+          isScEncryption,
           vaultState,
           className,
           isWizardFlow,
@@ -189,6 +190,7 @@ const extraMap = {
 
 const ValutConnectionForm: React.FC<ValutConnectionFormProps> = ({
   t,
+  encryption,
   vaultState,
   className,
   isWizardFlow,
@@ -256,6 +258,8 @@ const ValutConnectionForm: React.FC<ValutConnectionFormProps> = ({
 
   const isValid = (value: boolean) =>
     value ? ValidatedOptions.default : ValidatedOptions.error;
+
+  const isScEncryption = encryption['storageClass'];
 
   return (
     <>
@@ -336,6 +340,7 @@ const ValutConnectionForm: React.FC<ValutConnectionFormProps> = ({
             vaultState,
             setAuthValue,
             isValid,
+            isScEncryption,
           }}
         />
       )}
@@ -364,6 +369,7 @@ const ValutConnectionForm: React.FC<ValutConnectionFormProps> = ({
 };
 
 export type ValutConnectionFormProps = {
+  encryption?: boolean;
   vaultState: VaultConfig;
   className: string;
   infraType?: string;


### PR DESCRIPTION
Signed-off-by: Rishabh Bhandari <rishabhbhandari6@gmail.com>

Text visibility under "Token" text box only for `StorageClass` encryption.

![image](https://user-images.githubusercontent.com/41220684/170248248-929d1016-2f61-4b70-be9f-96503a63ff71.png)
![image](https://user-images.githubusercontent.com/41220684/170248314-c0e92a3b-1a1a-4741-9117-b8d6e6a6308e.png)
