### PR TITLE
Add yaml and events tab for ObjectBucketClaim page

### DIFF
--- a/packages/odf/components/mcg/ObjectBucketClaim.tsx
+++ b/packages/odf/components/mcg/ObjectBucketClaim.tsx
@@ -33,6 +33,10 @@ import { sortable } from '@patternfly/react-table';
 import { MCG_FLAG, RGW_FLAG } from '../../features';
 import { NooBaaObjectBucketModel } from '../../models';
 import { getPhase, isBound, obcStatusFilter } from '../../utils';
+import {
+  YAMLEditorWrapped,
+  EventStreamWrapped,
+} from '../resource-pages/CommonDetails';
 import { GetSecret } from './secret';
 
 const tableColumnInfo = [
@@ -424,7 +428,17 @@ export const OBCDetailsPage: React.FC<ObjectBucketClaimDetailsPageProps> = ({
             {
               href: '',
               name: 'Details',
-              component: OBCDetails,
+              component: OBCDetails as any,
+            },
+            {
+              href: 'yaml',
+              name: 'YAML',
+              component: YAMLEditorWrapped,
+            },
+            {
+              href: 'events',
+              name: 'Events',
+              component: EventStreamWrapped,
             },
           ]}
         />


### PR DESCRIPTION
This commit fixes a regression where the YAML and Events tabs are not
migrated to the ObjectBucketClaim page
Before: 

![Screenshot from 2022-05-25 18-38-18](https://user-images.githubusercontent.com/57935785/170270353-7e0fee86-992b-4e5c-a8c2-722f91eaf1fa.png)


After:

![Screenshot from 2022-05-25 18-44-37](https://user-images.githubusercontent.com/57935785/170270568-e6b2f480-7eb4-4fde-b811-a67c20b0d1af.png)


Signed-off-by: Vineet Badrinath <vineetbnath@gmail.com>