### PR TITLE
Fix Forge security issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "mochawesome": "^6.2.2",
     "mochawesome-merge": "^4.2.0",
     "node-sass": "^5.0.0",
+    "node-forge": "^1.3.0",
     "prettier": "2.3.2",
     "read-pkg": "5.x",
     "resolve-url-loader": "2.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7473,10 +7473,10 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-forge@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
-  integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
+node-forge@^1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
+  integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
 
 node-gyp@^7.1.0:
   version "7.1.2"


### PR DESCRIPTION
Resolves: bz#2069591, bz#2069607, bz#2069609

node-forge: Signature verification leniency in checking digestAlgorithm
structure can lead to signature forgery (CVE-2022-24771)
node-forge: Signature verification failing to check tailing garbage bytes
can lead to signature forgery (CVE-2022-24772)
node-forge: Signature verification leniency in checking DigestInfo
structure (CVE-2022-24773)

Signed-off-by: Timothy Asir Jeyasingh <tjeyasin@redhat.com>