### PR TITLE
Add yaml and events page for ObjectBuckets

### DIFF
--- a/packages/odf/components/mcg/ObjectBucket.tsx
+++ b/packages/odf/components/mcg/ObjectBucket.tsx
@@ -30,6 +30,10 @@ import { RouteComponentProps } from 'react-router';
 import { sortable } from '@patternfly/react-table';
 import { NooBaaObjectBucketModel } from '../../models/ocs';
 import { getPhase, obStatusFilter } from '../../utils';
+import {
+  YAMLEditorWrapped,
+  EventStreamWrapped,
+} from '../resource-pages/CommonDetails';
 
 const kind = referenceForModel(NooBaaObjectBucketModel);
 
@@ -324,6 +328,16 @@ export const OBDetailsPage: React.FC<ObjectBucketDetailsPageProps> = ({
               href: '',
               name: 'Details',
               component: Details as any,
+            },
+            {
+              href: 'yaml',
+              name: 'YAML',
+              component: YAMLEditorWrapped,
+            },
+            {
+              href: 'events',
+              name: 'Events',
+              component: EventStreamWrapped,
             },
           ]}
         />


### PR DESCRIPTION
This is part of the same bug as https://github.com/red-hat-storage/odf-console/pull/237

Signed-off-by: Vineet Badrinath <vineetbnath@gmail.com>