### PR TITLE
Fix Dashboard crashes in ODF

### DIFF
--- a/packages/ocs/dashboards/odf-system-dashboard.tsx
+++ b/packages/ocs/dashboards/odf-system-dashboard.tsx
@@ -47,8 +47,8 @@ const ODFSystemDashboard: React.FC<ODFSystemDashboardPageProps> = ({
   React.useEffect(() => {
     const isBlockPoolAdded = pages.find((page) => page.href === blockPoolHref);
     if (isCephAvailable && !isBlockPoolAdded) {
-      setPages([
-        ...pages,
+      setPages((p) => [
+        ...p,
         {
           title: t('BlockPools'),
           href: blockPoolHref,
@@ -56,7 +56,7 @@ const ODFSystemDashboard: React.FC<ODFSystemDashboardPageProps> = ({
         },
       ]);
     }
-  }, [isCephAvailable, pages, t]);
+  }, [isCephAvailable, pages, setPages, t]);
 
   const title = match.params.systemName;
 

--- a/packages/odf/components/odf-dashboard/dashboard.tsx
+++ b/packages/odf/components/odf-dashboard/dashboard.tsx
@@ -104,7 +104,8 @@ const ODFDashboardPage: React.FC<ODFDashboardPageProps> = (props) => {
     if (hasMCG) {
       setPages([...pages, ...newPages]);
     }
-  }, [hasMCG, pages, t]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hasMCG, JSON.stringify(pages), setPages, t]);
 
   const { history } = props;
   const location = useLocation();


### PR DESCRIPTION
 `pages` was being used in conjunction with `setPages` inside the same `useEffect` hook which was causing an infinite loop. 

Signed-off-by: Bipul Adhikari <badhikar@redhat.com>