### PR TITLE
fix: Description under storage class drop down missing in obc creation page

### DIFF
--- a/packages/odf/components/mcg/CreateObjectBucketClaim.tsx
+++ b/packages/odf/components/mcg/CreateObjectBucketClaim.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import ResourceDropdown from '@odf/shared/dropdown/ResourceDropdown';
+import ResourcesDropdown from '@odf/shared/dropdown/ResourceDropdown';
 import { ButtonBar } from '@odf/shared/generic/ButtonBar';
 import { StorageClassModel } from '@odf/shared/models';
 import { getName } from '@odf/shared/selectors';
@@ -125,7 +126,7 @@ export const CreateOBCForm: React.FC<CreateOBCFormProps> = (props) => {
             {t('StorageClass')}
           </label>
           <div className="form-group">
-            <ResourceDropdown<StorageClassResourceKind>
+            <ResourcesDropdown<StorageClassResourceKind>
               resourceModel={StorageClassModel}
               onSelect={(res) => onScChange(res)}
               filterResource={isObjectSC}


### PR DESCRIPTION
Updated the `ResourceDropdown` to the `ResourcesDropdown` which now contains the description along with the StorageClass headings.

![image](https://user-images.githubusercontent.com/41220684/173563821-c48028ad-48b5-4ac5-92dd-99ac38cf72eb.png)


Signed-off-by: Rishabh Bhandari <rishabhbhandari6@gmail.com>