### PR TITLE
added the description for StorageClass dropdown in Add Capacity modal

### DIFF
--- a/packages/odf/components/create-storage-system/create-storage-system-steps/backing-storage-step/backing-storage-step.tsx
+++ b/packages/odf/components/create-storage-system/create-storage-system-steps/backing-storage-step/backing-storage-step.tsx
@@ -10,6 +10,7 @@ import {
   ExternalStorage,
 } from '@odf/core/types';
 import { getSupportedVendors } from '@odf/core/utils';
+import { getStorageClassDescription } from '@odf/core/utils';
 import DevPreviewBadge from '@odf/shared/badges/DevPreviewBadge';
 import { CEPH_STORAGE_NAMESPACE } from '@odf/shared/constants';
 import ResourceDropdown from '@odf/shared/dropdown/ResourceDropdown';
@@ -109,17 +110,6 @@ type ExternalSystemSelectionProps = {
   selectOptions: ExternalStorage[];
 };
 
-const getDescription = (sc: StorageClassResourceKind): string => {
-  const descriptionList = [sc.provisioner, sc.parameters?.type];
-  return descriptionList.reduce(
-    (description, dl) => {
-      if (dl) return description ? `${description} | ${dl}` : dl;
-      return description;
-    },
-    isDefaultClass(sc) ? '(default)' : ''
-  );
-};
-
 const StorageClassSelection: React.FC<StorageClassSelectionProps> = ({
   dispatch,
   selected,
@@ -146,7 +136,7 @@ const StorageClassSelection: React.FC<StorageClassSelectionProps> = ({
         resource={scResource}
         resourceModel={StorageClassModel}
         onSelect={onStorageClassSelect}
-        secondaryTextGenerator={getDescription}
+        secondaryTextGenerator={getStorageClassDescription}
         initialSelection={getInitialSelection}
         data-test="storage-class-dropdown"
       />

--- a/packages/odf/modals/add-capacity/add-capacity-modal.tsx
+++ b/packages/odf/modals/add-capacity/add-capacity-modal.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { getStorageClassDescription } from '@odf/core/utils';
 import ResourceDropdown from '@odf/shared/dropdown/ResourceDropdown';
 import { FieldLevelHelp } from '@odf/shared/generic/FieldLevelHelp';
 import { LoadingInline } from '@odf/shared/generic/Loading';
@@ -83,6 +84,7 @@ const StorageClassDropdown: React.FC<StorageClassDropdownProps> = ({
       resource={scResource}
       resourceModel={StorageClassModel}
       showBadge
+      secondaryTextGenerator={getStorageClassDescription}
       onSelect={onChange}
       initialSelection={initialSelection}
       filterResource={filterSC}

--- a/packages/odf/utils/odf.ts
+++ b/packages/odf/utils/odf.ts
@@ -1,6 +1,8 @@
 import { ODF_OPERATOR } from '@odf/shared/constants';
 import { ClusterServiceVersionKind } from '@odf/shared/types';
 import { K8sResourceKind } from '@odf/shared/types';
+import { StorageClassResourceKind } from '@odf/shared/types';
+import { isDefaultClass } from '@odf/shared/utils';
 import * as _ from 'lodash';
 import { ODF_VENDOR_ANNOTATION } from '../constants';
 
@@ -19,6 +21,19 @@ export const getExternalSubSystemName = (
     0,
     230
   );
+
+export const getStorageClassDescription = (
+  sc: StorageClassResourceKind
+): string => {
+  const descriptionList = [sc.provisioner, sc.parameters?.type];
+  return descriptionList.reduce(
+    (description, dl) => {
+      if (dl) return description ? `${description} | ${dl}` : dl;
+      return description;
+    },
+    isDefaultClass(sc) ? '(default)' : ''
+  );
+};
 
 export const getOperatorVersion = (operator: K8sResourceKind): string =>
   operator?.status?.installedCSV;


### PR DESCRIPTION
Added the `SecondaryTextGenerator` field in the StorageClassDropdown which provides the description for the storage class headings.

![image](https://user-images.githubusercontent.com/41220684/174031327-8c42bb5a-4cfe-4827-8782-78aa22fc4fdc.png)

Signed-off-by: Rishabh Bhandari <rishabhbhandari6@gmail.com>