### PR TITLE
Bug 2098261: Remove BlockPools tab in external mode

### DIFF
--- a/packages/ocs/dashboards/odf-system-dashboard.tsx
+++ b/packages/ocs/dashboards/odf-system-dashboard.tsx
@@ -7,7 +7,7 @@ import { useFlag } from '@openshift-console/dynamic-plugin-sdk';
 import { useTranslation } from 'react-i18next';
 import { RouteComponentProps } from 'react-router';
 import { match as Match } from 'react-router-dom';
-import { CEPH_FLAG } from '../../odf/features';
+import { CEPH_FLAG, OCS_INDEPENDENT_FLAG } from '../../odf/features';
 import { BlockPoolListPage } from '../block-pool/BlockPoolListPage';
 import { CephBlockPoolModel } from '../models';
 import OCSSystemDashboard from './ocs-system-dashboard';
@@ -43,10 +43,11 @@ const ODFSystemDashboard: React.FC<ODFSystemDashboardPageProps> = ({
     },
   ]);
   const isCephAvailable = useFlag(CEPH_FLAG);
+  const isExternal = useFlag(OCS_INDEPENDENT_FLAG);
 
   React.useEffect(() => {
     const isBlockPoolAdded = pages.find((page) => page.href === blockPoolHref);
-    if (isCephAvailable && !isBlockPoolAdded) {
+    if (isCephAvailable && !isBlockPoolAdded && !isExternal) {
       setPages((p) => [
         ...p,
         {
@@ -56,7 +57,10 @@ const ODFSystemDashboard: React.FC<ODFSystemDashboardPageProps> = ({
         },
       ]);
     }
-  }, [isCephAvailable, pages, setPages, t]);
+    if (isBlockPoolAdded && isExternal) {
+      setPages((p) => p.filter((page) => page.href !== blockPoolHref));
+    }
+  }, [isExternal, isCephAvailable, pages, setPages, t]);
 
   const title = match.params.systemName;
 


### PR DESCRIPTION
Remove BlockPools tab when running in external mode.

Signed-off-by: Pranshu Srivastava <rexagod@gmail.com>
***
<details>
<summary>Screenshot</summary>

#### For external mode.
![Screenshot from 2022-06-17 23-40-05](https://user-images.githubusercontent.com/33557095/174355959-df099bd8-da0e-4c0b-9df7-55b9fc42cfd4.png)

#### For internal mode.
![image](https://user-images.githubusercontent.com/33557095/174406401-a6a808fd-9eaf-413a-91e6-e2e12bce5189.png)

</details>