### PR TITLE
show vault namespace option for cluster-wide (SA auth)

### DIFF
--- a/packages/odf/modals/advanced-kms-modal/advanced-vault-modal.tsx
+++ b/packages/odf/modals/advanced-kms-modal/advanced-vault-modal.tsx
@@ -221,26 +221,24 @@ const AdvancedVaultModal = (props: AdvancedKMSModalProps) => {
             name="kms-service-tls"
           />
         </FormGroup>
-        {kms.authMethod === VaultAuthMethods.TOKEN && (
-          <FormGroup
-            fieldId="kms-service-namespace"
-            label={t('Vault Enterprise Namespace')}
-            className="ceph-advanced-kms__form-body"
-            labelIcon={<FieldLevelHelp>{vaultNamespaceTooltip}</FieldLevelHelp>}
-            helperText={t(
-              'The name must be accurate and must match the service namespace'
-            )}
-          >
-            <TextInput
-              value={providerNS}
-              onChange={setProvideNS}
-              type="text"
-              id="kms-service-namespace"
-              name="kms-service-namespace"
-              placeholder="kms-namespace"
-            />
-          </FormGroup>
-        )}
+        <FormGroup
+          fieldId="kms-service-namespace"
+          label={t('Vault Enterprise Namespace')}
+          className="ceph-advanced-kms__form-body"
+          labelIcon={<FieldLevelHelp>{vaultNamespaceTooltip}</FieldLevelHelp>}
+          helperText={t(
+            'The name must be accurate and must match the service namespace'
+          )}
+        >
+          <TextInput
+            value={providerNS}
+            onChange={setProvideNS}
+            type="text"
+            id="kms-service-namespace"
+            name="kms-service-namespace"
+            placeholder="kms-namespace"
+          />
+        </FormGroup>
         <FormGroup
           fieldId="kms-service-ca-cert"
           label={t('CA Certificate')}


### PR DESCRIPTION
When kubernetes authentication method is selected, we disabled the Vault Enterprise Namespace field in PR: https://github.com/openshift/console/pull/10998
Need to enable it again for cluster-wide encryption.

![Screenshot from 2022-08-02 16-47-12](https://user-images.githubusercontent.com/39404641/182364210-37a6c078-e79c-4f8d-bf88-d4ed509a8526.png)
