### PR TITLE
Fix browser crashing issue

### DIFF
--- a/packages/odf/components/odf-dashboard/performance-card/utils.ts
+++ b/packages/odf/components/odf-dashboard/performance-card/utils.ts
@@ -17,6 +17,7 @@ type DataFrame = {
   throughputData: LineGraphProps;
   latencyData: LineGraphProps;
   className?: string;
+  width?: number;
 };
 const getDatForSystem = (
   promData: PrometheusResponse,
@@ -39,7 +40,8 @@ export const generateDataFrames = (
   systems: StorageSystemKind[],
   ld: PrometheusResponse,
   td: PrometheusResponse,
-  id: PrometheusResponse
+  id: PrometheusResponse,
+  width?: number
 ): DataFrame[] => {
   if (_.isEmpty(systems) || !ld || !td || !id) {
     return [] as DataFrame[];
@@ -59,6 +61,7 @@ export const generateDataFrames = (
       latencyData: {
         data: getDatForSystem(ld, curr, humanizeLatency),
       },
+      ...(width && { width }),
     };
     acc.push(frame);
     return acc;

--- a/packages/shared/dashboards/line-graph/line-graph.tsx
+++ b/packages/shared/dashboards/line-graph/line-graph.tsx
@@ -8,7 +8,6 @@ import {
   ChartVoronoiContainer,
 } from '@patternfly/react-charts';
 import { Title } from '@patternfly/react-core';
-import useRefWidth from '../../hooks/ref-width';
 import { HumanizeResult } from '../../types';
 import { useCustomTranslation } from '../../useCustomTranslationHook';
 import './line-graph.scss';
@@ -22,79 +21,82 @@ export type LineGraphProps = {
   data: LineDataType[];
   loading?: boolean;
   error?: string;
+  // width of the parent div container (of the Chart component) is fluctuating with the graph/chart (even if viewport remains same),
+  // causing multiple re-renders if we use useRefWidth on it. So, using useRefWidth on the Card component,
+  // as its width will not change unless we change the viewport dimensions.
+  width?: number;
+  divideBy?: number;
 };
 
-const LineGraph: React.FC<LineGraphProps> = ({ data }) => {
-  const { t } = useCustomTranslation();
-  const [ref, width] = useRefWidth();
-  const lineData = data.map((datum, i) => ({
-    x: String(i + 1),
-    ...datum,
-  }));
-  const mappedLineData = lineData.map((datum) => ({
-    ...datum,
-    y: datum.y.value,
-    yString: datum.y.string,
-  }));
+const LineGraph: React.FC<LineGraphProps> = React.memo(
+  ({ data, width, divideBy }) => {
+    const { t } = useCustomTranslation();
+    const lineData = data.map((datum, i) => ({
+      x: String(i + 1),
+      ...datum,
+    }));
+    const mappedLineData = lineData.map((datum) => ({
+      ...datum,
+      y: datum.y.value,
+      yString: datum.y.string,
+    }));
 
-  const dataUnavailable = _.isEmpty(data);
+    const dataUnavailable = _.isEmpty(data);
 
-  const unit = !dataUnavailable ? lineData[0].y.unit : '';
-  const latestValue = !dataUnavailable
-    ? lineData[lineData.length - 1].y.string
-    : '';
-  return !dataUnavailable ? (
-    <div className="odf-lineGraph">
-      <div
-        className="pf-u-display-none-on-md pf-u-display-inline-block-on-lg pf-u-w-95-lg"
-        ref={ref}
-      >
-        <Chart
-          containerComponent={
-            <ChartVoronoiContainer
-              labels={({ datum }) =>
-                `${datum.yString} at ${datum.timestamp.toLocaleTimeString()}`
-              }
-              constrainToVisibleArea
-            />
-          }
-          height={150}
-          padding={{
-            bottom: 20,
-            left: 95,
-            right: 15, // Adjusted to accommodate legend
-            top: 20,
-          }}
-          width={width}
-        >
-          <ChartAxis
-            dependentAxis
-            showGrid
-            tickCount={2}
-            tickFormat={(tick, _index, _ticks) => {
-              return `${tick} ${unit}`;
-            }}
-            tickValues={
-              mappedLineData.length === 1 ? [mappedLineData[0].y] : undefined
+    const unit = !dataUnavailable ? lineData[0].y.unit : '';
+    const latestValue = !dataUnavailable
+      ? lineData[lineData.length - 1].y.string
+      : '';
+    return !dataUnavailable ? (
+      <div className="odf-lineGraph">
+        <div className="pf-u-display-none-on-md pf-u-display-inline-block-on-lg pf-u-w-95-lg">
+          <Chart
+            containerComponent={
+              <ChartVoronoiContainer
+                labels={({ datum }) =>
+                  `${datum.yString} at ${datum.timestamp.toLocaleTimeString()}`
+                }
+                constrainToVisibleArea
+              />
             }
-          />
-          <ChartGroup>
-            <ChartLine data={mappedLineData} />
-          </ChartGroup>
-        </Chart>
-      </div>
-      <div className="pf-u-w-5-lg pf-u-w-100-md odf-valueBox">
-        <div>
-          <Title headingLevel="h5" size="md">
-            {latestValue}
-          </Title>
+            height={150}
+            padding={{
+              bottom: 20,
+              left: 95,
+              right: 15, // Adjusted to accommodate legend
+              top: 20,
+            }}
+            width={width / divideBy || width}
+          >
+            <ChartAxis
+              dependentAxis
+              showGrid
+              tickCount={2}
+              tickFormat={(tick, _index, _ticks) => {
+                return `${tick} ${unit}`;
+              }}
+              tickValues={
+                mappedLineData.length === 1 ? [mappedLineData[0].y] : undefined
+              }
+            />
+            <ChartGroup>
+              <ChartLine data={mappedLineData} />
+            </ChartGroup>
+          </Chart>
         </div>
-        <div>{t('Current')}</div>
+        <div className="pf-u-w-5-lg pf-u-w-100-md odf-valueBox">
+          <div>
+            <Title headingLevel="h5" size="md">
+              {latestValue}
+            </Title>
+          </div>
+          <div>{t('Current')}</div>
+        </div>
       </div>
-    </div>
-  ) : (
-    <>-</>
-  );
-};
+    ) : (
+      <>-</>
+    );
+  }
+);
 
 export default LineGraph;

--- a/packages/shared/hooks/ref-width.ts
+++ b/packages/shared/hooks/ref-width.ts
@@ -4,10 +4,16 @@ const useRefWidth = () => {
   const ref = React.useRef<HTMLDivElement>(null);
   const [width, setWidth] = React.useState<number>();
 
-  const clientWidth = ref?.current?.clientWidth;
+  const setRef = React.useCallback((e: HTMLDivElement) => {
+    const newWidth = e?.clientWidth;
+    newWidth &&
+      ref.current?.clientWidth !== newWidth &&
+      setWidth(e.clientWidth);
+    ref.current = e;
+  }, []);
 
   React.useEffect(() => {
-    const handleResize = () => setWidth(ref?.current?.clientWidth);
+    const handleResize = () => setWidth(ref.current?.clientWidth);
     window.addEventListener('resize', handleResize);
     window.addEventListener('sidebar_toggle', handleResize);
     return () => {
@@ -16,12 +22,13 @@ const useRefWidth = () => {
     };
   }, []);
 
-  React.useEffect(() => {
-    setWidth(clientWidth);
-  }, [clientWidth]);
+  const clientWidth = ref.current?.clientWidth;
 
-  // eslint-disable-next-line no-undef
-  return [ref, width] as [React.MutableRefObject<HTMLDivElement>, number];
+  React.useEffect(() => {
+    width !== clientWidth && setWidth(clientWidth);
+  }, [clientWidth, width]);
+
+  return [setRef, width] as [React.Ref<HTMLDivElement>, number];
 };
 
 export default useRefWidth;

--- a/packages/shared/table/table.tsx
+++ b/packages/shared/table/table.tsx
@@ -20,86 +20,86 @@ export type RowData = [];
 
 type TableProps = {
   columns: Column[];
-  rowRenderer: (rawData: []) => RowData[];
+  rowRenderer: (rawData: []) => RowData;
   rawData: [];
   ariaLabel: string;
 };
 
-const Table: React.FC<TableProps> = (props) => {
-  const { ariaLabel, columns, rawData, rowRenderer } = props;
-  const [sortIndex, setSortIndex] = React.useState(-1);
-  const [sortDirection, setSortDirection] = React.useState<SortByDirection>(
-    SortByDirection.asc
-  );
-
-  const onSort: OnSort = (
-    event: React.MouseEvent,
-    columnIndex: number,
-    sortByDirection: SortByDirection
-  ) => {
-    setSortIndex(columnIndex);
-    setSortDirection(sortByDirection);
-  };
-
-  const sortedData =
-    sortIndex !== -1
-      ? rawData?.sort((a, b) => {
-          return columns[sortIndex].sortFunction(a, b, sortDirection);
-        })
-      : rawData;
-
-  const rowData = sortedData?.length > 0 ? sortedData.map(rowRenderer) : [];
-
-  const classNames = columns.map((column) => column.className);
-
-  const headerColumns = columns.map((column, columnIndex) => {
-    const isSortable = !!column.sortFunction;
-    const sortParams = isSortable
-      ? {
-          sort: {
-            sortBy: {
-              index: sortIndex,
-              direction: sortDirection,
-            },
-            onSort,
-            columnIndex,
-          },
-        }
-      : {};
-    return (
-      <Th
-        key={columnIndex}
-        className={column.className}
-        {...sortParams}
-        translate={null}
-      >
-        {column.columnName}
-      </Th>
+const Table: React.FC<TableProps> = React.memo(
+  ({ ariaLabel, columns, rawData, rowRenderer }) => {
+    const [sortIndex, setSortIndex] = React.useState(-1);
+    const [sortDirection, setSortDirection] = React.useState<SortByDirection>(
+      SortByDirection.asc
     );
-  });
 
-  return (
-    <TableComposable aria-label={ariaLabel} translate={null}>
-      <Thead translate={null}>
-        <Tr translate={null}>{...headerColumns}</Tr>
-      </Thead>
-      <Tbody translate={null}>
-        {rowData?.map((row, index) => (
-          <Tr key={index} translate={null}>
-            {row.map((item, cellIndex) => (
-              <Td
-                translate={null}
-                key={`${cellIndex}_${index}`}
-                className={classNames[cellIndex]}
-              >
-                {item}
-              </Td>
-            ))}
-          </Tr>
-        ))}
-      </Tbody>
-    </TableComposable>
-  );
-};
+    const onSort: OnSort = (
+      event: React.MouseEvent,
+      columnIndex: number,
+      sortByDirection: SortByDirection
+    ) => {
+      setSortIndex(columnIndex);
+      setSortDirection(sortByDirection);
+    };
+
+    const sortedData =
+      sortIndex !== -1
+        ? rawData?.sort((a, b) => {
+            return columns[sortIndex].sortFunction(a, b, sortDirection);
+          })
+        : rawData;
+    const rowData = sortedData?.length > 0 ? sortedData.map(rowRenderer) : [];
+
+    const classNames = columns.map((column) => column.className);
+
+    const headerColumns = columns.map((column, columnIndex) => {
+      const isSortable = !!column.sortFunction;
+      const sortParams = isSortable
+        ? {
+            sort: {
+              sortBy: {
+                index: sortIndex,
+                direction: sortDirection,
+              },
+              onSort,
+              columnIndex,
+            },
+          }
+        : {};
+      return (
+        <Th
+          key={columnIndex}
+          className={column.className}
+          {...sortParams}
+          translate={null}
+        >
+          {column.columnName}
+        </Th>
+      );
+    });
+
+    return (
+      <TableComposable aria-label={ariaLabel} translate={null}>
+        <Thead translate={null}>
+          <Tr translate={null}>{...headerColumns}</Tr>
+        </Thead>
+        <Tbody translate={null}>
+          {rowData?.map((row, index) => (
+            <Tr key={index} translate={null}>
+              {row.map((item: React.ReactNode, cellIndex: number) => (
+                <Td
+                  translate={null}
+                  key={`${cellIndex}_${index}`}
+                  className={classNames[cellIndex]}
+                >
+                  {item}
+                </Td>
+              ))}
+            </Tr>
+          ))}
+        </Tbody>
+      </TableComposable>
+    );
+  }
+);
 
 export default Table;


### PR DESCRIPTION
- Memoized some of the FC components.
- Updated `useRefWidth` to be same as that of console.
- Fixed browser crashing issue as per https://bugzilla.redhat.com/show_bug.cgi?id=2116891.
width of the parent div container (of the `Chart` component) is fluctuating with the graph/chart (even if viewport remains same), causing multiple re-renders if we use `useRefWidth` on it. So, using `useRefWidth` on the performance `Card` component, as its width will not change unless we change the viewport dimensions.

(Other possible solution could be to fix the min/max width of the parent div to say `x px` or `x rem` but in that case will have to hardcode the numeric width value for different screen sizes, so did not test out this approach)