### PR TITLE
Bug 2109140: fix multiple OB/OBC tabs for non-admin user

### DIFF
--- a/plugins/odf/console-extensions.json
+++ b/plugins/odf/console-extensions.json
@@ -212,9 +212,6 @@
       "component": {
         "$codeRef": "createOBC.CreateOBCPage"
       }
-    },
-    "flags": {
-      "required": ["OCS"]
     }
   },
   {


### PR DESCRIPTION
Follow up on PR: https://github.com/openshift/console/pull/12027
From 4.11 onwards we have migrated our code from older OCP repo to a new ODF repo. We disable/hide older code and enable a new one based on certain flags which UI reads from the ODF operator's CSV.
For non-privileged user (created from htpasswd method), he doesn't has an access to read the CSV, hence flags are never getting set and both older and new UI can be seen (two OB/OBC options, one from old repo another from new).