### PR TITLE
Bug 2124834: Fixes caching issues by adding Expires and Cache-Control headers

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -1,3 +1,10 @@
+map $sent_http_content_type $expires {
+    default                    off;
+    text/html                  epoch;
+    text/css                   max;
+    application/javascript     epoch;
+}
+
 server {
     listen       9001 ssl;
     listen       [::]:9001 ssl;
@@ -14,4 +21,5 @@ server {
         root   /usr/share/nginx/html;
     }
     ssi on;
+    expires $expires;
 }


### PR DESCRIPTION
Firefox caches data and is not checking with the server to see if the chunks are updated. 
Firefox now re-validates cache before using it.
Before:
![Screenshot from 2022-09-21 15-52-40](https://user-images.githubusercontent.com/54092533/191478268-4b336b85-54e7-4704-8464-a4b54b942a7f.png)
After:
![Screenshot from 2022-09-21 15-54-30](https://user-images.githubusercontent.com/54092533/191478379-c390d80b-fffc-4f71-a068-6aff51df02bc.png)


Signed-off-by: Bipul Adhikari <badhikar@redhat.com>