### PR TITLE
Bug 2022356: Range value is not properly displayed for performance card

### DIFF
--- a/packages/shared/dashboards/line-graph/line-graph.tsx
+++ b/packages/shared/dashboards/line-graph/line-graph.tsx
@@ -74,6 +74,9 @@ const LineGraph: React.FC<LineGraphProps> = ({ data }) => {
             tickFormat={(tick, _index, _ticks) => {
               return `${tick} ${unit}`;
             }}
+            tickValues={
+              mappedLineData.length === 1 ? [mappedLineData[0].y] : undefined
+            }
           />
           <ChartGroup>
             <ChartLine data={mappedLineData} />


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2022356

Jira: https://issues.redhat.com/browse/OCSBZM-2774

Desc: Added initial value for the ticks when there is only one value on the y-axis. It is failing to scale appropriately.