### PR TITLE
Supress known warnings in compilation process

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@types/react-router-dom": "5.1.2",
     "@typescript-eslint/eslint-plugin": "^4.28.5",
     "@typescript-eslint/parser": "^4.28.5",
+    "buffer": "^6.0.3",
     "cache-loader": "1.x",
     "chai": "^4.3.6",
     "comment-json": "4.x",

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -21,6 +21,7 @@ const config: webpack.Configuration & DevServerConfiguration = {
     filename: '[name]-bundle.js',
     chunkFilename: '[name]-chunk.js',
   },
+  ignoreWarnings: [(warning) => !!warning?.file?.includes('shared module')],
   watchOptions: {
     ignored: ['node_modules', 'dist'],
   },

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -102,6 +102,9 @@ const config: webpack.Configuration & DevServerConfiguration = {
     new webpack.DefinePlugin({
       'process.env.I8N_NS': JSON.stringify(process.env.I8N_NS),
     }),
+    new webpack.ProvidePlugin({
+      Buffer: ['buffer', 'Buffer'],
+    }),
   ],
   devtool: 'cheap-module-source-map',
   optimization: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2185,6 +2185,11 @@ balanced-match@^2.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-2.0.0.tgz#dc70f920d78db8b858535795867bf48f820633d9"
   integrity sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==
 
+base64-js@^1.3.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
 basic-auth@^1.0.3:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-1.1.0.tgz#45221ee429f7ee1e5035be3f51533f1cdfd29884"
@@ -2358,6 +2363,14 @@ buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+
+buffer@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
 
 bytes@3.0.0:
   version "3.0.0"
@@ -5356,6 +5369,11 @@ icss-utils@^2.1.0:
   integrity sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=
   dependencies:
     postcss "^6.0.1"
+
+ieee754@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 ignore@^4.0.6:
   version "4.0.6"


### PR DESCRIPTION
- Fixes warning related to buffer being not available
- Adds buffer package as a dev dependency
- Configure Provider plugin to polyfill buffer
- Suppress known warnings arising from module federation

![Screenshot from 2022-09-27 14-10-18](https://user-images.githubusercontent.com/54092533/192474153-7978d190-047e-482c-af7b-b0ee255b80f5.png)
