### PR TITLE
Bug 2118683: [release-4.11] Fix PVC tests 

### DIFF
--- a/cypress/tests/expand-pvc.spec.ts
+++ b/cypress/tests/expand-pvc.spec.ts
@@ -17,13 +17,17 @@ describe('Tests Expansion of a PVC', () => {
   });
 
   it('Test expansion of a CephFS PVC', () => {
-    pvc.createPVC('testpvcfs', '5', 'ocs-storagecluster-cephfs');
+    const cephPvcName = 'testpvcfs';
+    pvc.deleteIfExists(cephPvcName, 'default');
+    pvc.createPVC(cephPvcName, '5', 'ocs-storagecluster-cephfs');
     pvc.expandPVC('10');
     cy.byTestID('pvc-requested-capacity').contains('10 GiB');
   });
 
   it('Test expansion of a RBD PVC', () => {
-    pvc.createPVC('testpvcrbd', '5', 'ocs-storagecluster-ceph-rbd', 'Block');
+    const rbdPvcName = 'testpvcrbd';
+    pvc.deleteIfExists(rbdPvcName, 'default');
+    pvc.createPVC(rbdPvcName, '5', 'ocs-storagecluster-ceph-rbd', 'Block');
     pvc.expandPVC('10');
     cy.byTestID('pvc-requested-capacity').contains('10 GiB');
   });

--- a/cypress/views/pvc.ts
+++ b/cypress/views/pvc.ts
@@ -15,7 +15,12 @@ export const pvc = {
       cy.byTestID('Block-radio-input').click();
     }
     cy.byTestID('create-pvc').click();
-    cy.contains('Bound', { timeout: 10000 });
+    cy.contains('Bound', { timeout: 30000 });
+  },
+  deleteIfExists: (pvcName: string, namespace: string) => {
+    cy.exec(`oc delete pvcs ${pvcName} -n ${namespace} --wait`, {
+      failOnNonZeroExit: false,
+    });
   },
   expandPVC: (expansionSize) => {
     cy.byLegacyTestID('actions-menu-button').click();


### PR DESCRIPTION
- Increase the waiting for PVC to get bound
- Delete the PVC if it already exists in case cypress retries the tests

Signed-off-by: Vineet Badrinath <vineetbnath@gmail.com>

Failure on PVC tests previously -
https://user-images.githubusercontent.com/57935785/192537745-9e5530b4-95dc-4686-9175-1a4ef2777c0f.mp4

