### PR TITLE
Bug 2110866: store enterprise namespace to configmap

### DIFF
--- a/packages/odf/components/kms-config/utils.tsx
+++ b/packages/odf/components/kms-config/utils.tsx
@@ -399,6 +399,7 @@ const getClusterVaultResources = (kms: VaultConfig) => {
     case VaultAuthMethods.KUBERNETES:
       vaultConfigData = {
         ...vaultConfigData,
+        VAULT_NAMESPACE: kms.providerNamespace,
         VAULT_AUTH_KUBERNETES_ROLE: kms.authValue.value,
         VAULT_AUTH_MOUNT_PATH: kms.providerAuthPath,
       };


### PR DESCRIPTION
continuation of PR: https://github.com/red-hat-storage/odf-console/pull/354
PR#354 was incomplete as namespace value was not getting stored in the ConfigMap.

![Screenshot from 2022-09-28 17-15-54](https://user-images.githubusercontent.com/39404641/192772352-632fa324-b84a-4cfc-b7ce-4c7c4b941ee1.png)
