### PR TITLE
patch pull-secret in openshift-config namespace [CI]

### DIFF
--- a/openshift-ci/odf-catalog-source.yaml
+++ b/openshift-ci/odf-catalog-source.yaml
@@ -29,8 +29,6 @@ spec:
     base64data: ''
     mediatype: ''
   image: quay.io/rhceph-dev/ocs-registry:latest-stable-4.12.0
-  secrets:
-    - ocs-secret
   priority: 100
   publisher: Red Hat
   sourceType: grpc


### PR DESCRIPTION
On Openshift-CI on trying to install ODF 4.12 on OCP 4.12, all the operators (ODF/OCS/NooBaa) are getting `Succeeded`. But on creating a StorageSystem (creating it from ODF UI), only noobaa-db-pg-0 is getting into `Init:ImagePullBackOff` status:
`message: Back-off pulling image "quay.io/rhceph-dev/rhel8-postgresql-12@sha256:22d9a196645625a312d0e33d409c063603d5eaa8ebc1db4971a4643d25b01b65".`