### PR TITLE
Cleanup: enable no-extraneous-dependencies & no-unused-vars

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,7 +57,10 @@ module.exports = {
     'default-case': 'off',
     'global-require': 'off',
     'implicit-arrow-linebreak': 'off',
-    'import/no-extraneous-dependencies': 'off',
+    'import/no-extraneous-dependencies': [
+      'error',
+      { packageDir: ['.', './packages/odf'] },
+    ],
     'jsx-a11y/anchor-is-valid': 'off',
     'jsx-a11y/click-events-have-key-events': 'off',
     'jsx-a11y/label-has-associated-control': 'off',
@@ -92,7 +95,7 @@ module.exports = {
     'react/no-unused-state': 'off',
     'react/sort-comp': 'off',
     'no-unused-vars': 'off',
-    '@typescript-eslint/no-unused-vars': 'off',
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
     'react/function-component-definition': [
       2,
       {

--- a/cypress/helpers/add-capacity.ts
+++ b/cypress/helpers/add-capacity.ts
@@ -1,4 +1,4 @@
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 
 export const createOSDTreeMap = (nodes) =>
   nodes.reduce((acc, curr) => Object.assign(acc, { [curr.id]: curr }), {});

--- a/cypress/tests/add-capacity.spec.ts
+++ b/cypress/tests/add-capacity.spec.ts
@@ -1,4 +1,4 @@
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import {
   CLUSTER_STATUS,
   STORAGE_SYSTEM_NAME,

--- a/package.json
+++ b/package.json
@@ -51,11 +51,16 @@
     "@patternfly/react-core": "4.175.4",
     "@patternfly/react-icons": "^4.11.0",
     "@patternfly/react-table": "4.104.7",
+    "@patternfly/react-tokens": "^4.12.0",
     "@types/react-dnd-html5-backend": "^3.0.2",
     "classnames": "^2.3.1",
     "eslint-config-airbnb": "18.2.1",
     "fuzzysearch": "^1.0.3",
+    "history": "^4.9.0",
+    "i18next": "^20.2.1",
     "i18next-conv": "^10.1.0",
+    "js-base64": "^2.1.9",
+    "js-yaml": "^3.13.1",
     "lodash-es": "^4.17.21",
     "murmurhash-js": "^1.0.0",
     "react": "^17.0.1",
@@ -69,7 +74,9 @@
     "react-redux": "^7.2.6",
     "react-router": "5.2.0",
     "react-router-dom": "5.2.0",
-    "react-tagsinput": "^3.19.0"
+    "react-tagsinput": "^3.19.0",
+    "redux": "^4.0.0",
+    "victory-core": "^35.4.4"
   },
   "devDependencies": {
     "@cypress/webpack-preprocessor": "^5.9.1",

--- a/packages/mco/components/data-policies/data-policies-list/data-policies-list.tsx
+++ b/packages/mco/components/data-policies/data-policies-list/data-policies-list.tsx
@@ -10,7 +10,7 @@ type DataPoliciesListProps = {
   history: RouteComponentProps['history'];
 };
 
-export const DataPoliciesList: React.FC<DataPoliciesListProps> = (props) => {
+export const DataPoliciesList: React.FC<DataPoliciesListProps> = () => {
   const { t } = useCustomTranslation();
   const title = t('Data policies');
   const pages = [

--- a/packages/mco/components/disaster-recovery/app-dr-status/dr-status-table.tsx
+++ b/packages/mco/components/disaster-recovery/app-dr-status/dr-status-table.tsx
@@ -10,7 +10,7 @@ import {
   StatusIconAndText,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { TFunction } from 'i18next';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import {
   Flex,
   FlexItem,

--- a/packages/mco/components/disaster-recovery/create-dr-policy/create-dr-policy.tsx
+++ b/packages/mco/components/disaster-recovery/create-dr-policy/create-dr-policy.tsx
@@ -13,7 +13,6 @@ import {
   k8sPatch,
   useK8sWatchResource,
 } from '@openshift-console/dynamic-plugin-sdk';
-import * as _ from 'lodash';
 import { RouteComponentProps, match as Match } from 'react-router';
 import {
   Form,

--- a/packages/mco/components/disaster-recovery/create-dr-policy/select-cluster-list.tsx
+++ b/packages/mco/components/disaster-recovery/create-dr-policy/select-cluster-list.tsx
@@ -3,7 +3,6 @@ import { isMinimumSupportedODFVersion } from '@odf/mco/utils';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { referenceForModel } from '@odf/shared/utils';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
-import * as _ from 'lodash';
 import {
   DataList,
   DataListItem,
@@ -233,7 +232,7 @@ export const SelectClusterList: React.FC<SelectClusterListProps> = ({
               placeholder={t('Cluster name')}
               onChange={(val) => setNameSearch(val)}
               value={nameSearch}
-              onClear={(e) => setNameSearch('')}
+              onClear={() => setNameSearch('')}
             />
           </ToolbarItem>
         </ToolbarContent>

--- a/packages/mco/components/disaster-recovery/create-dr-policy/selected-cluster-view.tsx
+++ b/packages/mco/components/disaster-recovery/create-dr-policy/selected-cluster-view.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as _ from 'lodash';
 import {
   Text,
   Badge,
@@ -20,7 +19,7 @@ type SelectedClusterProps = {
 export const SelectedCluster: React.FC<SelectedClusterProps> = ({
   id,
   cluster,
-  dispatch,
+  dispatch, // eslint-disable-line @typescript-eslint/no-unused-vars
 }) => {
   const { name, region, storageSystemName } = cluster;
   return (

--- a/packages/mco/components/disaster-recovery/drpolicy-list-page/drpolicy-list-page.tsx
+++ b/packages/mco/components/disaster-recovery/drpolicy-list-page/drpolicy-list-page.tsx
@@ -21,7 +21,6 @@ import {
   TableColumn,
 } from '@openshift-console/dynamic-plugin-sdk';
 import classNames from 'classnames';
-import * as _ from 'lodash';
 import { Trans } from 'react-i18next';
 import { useHistory } from 'react-router';
 import { sortable, wrappable } from '@patternfly/react-table';

--- a/packages/mco/components/mco-dashboard/dashboard.tsx
+++ b/packages/mco/components/mco-dashboard/dashboard.tsx
@@ -31,7 +31,7 @@ export const MCODashboard: React.FC = () => {
   );
 };
 
-const MCODashboardPage: React.FC<MCODashboardPageProps> = (props) => {
+const MCODashboardPage: React.FC<MCODashboardPageProps> = () => {
   const { t } = useCustomTranslation();
   const title = t('Storage System');
   const pages = [

--- a/packages/mco/components/mco-dashboard/status-card/status-card.tsx
+++ b/packages/mco/components/mco-dashboard/status-card/status-card.tsx
@@ -14,7 +14,6 @@ import {
   PrometheusResponse,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { HealthBody } from '@openshift-console/dynamic-plugin-sdk-internal';
-import * as _ from 'lodash';
 import {
   Flex,
   FlexItem,

--- a/packages/mco/components/mco-dashboard/system-capacity-card/capacity-card.tsx
+++ b/packages/mco/components/mco-dashboard/system-capacity-card/capacity-card.tsx
@@ -19,7 +19,7 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import { TFunction } from 'i18next';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import {
   Progress,
   ProgressMeasureLocation,

--- a/packages/ocs/block-pool/body.tsx
+++ b/packages/ocs/block-pool/body.tsx
@@ -8,7 +8,7 @@ import {
 } from '@odf/shared/types';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { useFlag } from '@openshift-console/dynamic-plugin-sdk';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import {
   Alert,
   Dropdown,

--- a/packages/ocs/dashboards/block-pool/mirroring-card.tsx
+++ b/packages/ocs/dashboards/block-pool/mirroring-card.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { StatusIconAndText } from '@openshift-console/dynamic-plugin-sdk';
 import { TFunction } from 'i18next';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import { Trans } from 'react-i18next';
 import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
 import {

--- a/packages/ocs/dashboards/object-service/capacity-breakdown/capacity-breakdown-card.tsx
+++ b/packages/ocs/dashboards/object-service/capacity-breakdown/capacity-breakdown-card.tsx
@@ -21,7 +21,7 @@ import {
   useFlag,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { K8sModel } from '@openshift-console/dynamic-plugin-sdk/lib/api/common-types';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import {
   Select,
   SelectGroup,

--- a/packages/ocs/dashboards/object-service/data-consumption-card/data-consumption-card-utils.ts
+++ b/packages/ocs/dashboards/object-service/data-consumption-card/data-consumption-card-utils.ts
@@ -7,7 +7,7 @@ import {
   PrometheusResponse,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { TFunction } from 'i18next';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 
 export const DataConsumersValue = {
   [Breakdown.PROVIDERS]: 'PROVIDERS_',

--- a/packages/ocs/dashboards/object-service/data-consumption-card/data-consumption-card.tsx
+++ b/packages/ocs/dashboards/object-service/data-consumption-card/data-consumption-card.tsx
@@ -25,7 +25,7 @@ import {
   PrometheusResponse,
   useFlag,
 } from '@openshift-console/dynamic-plugin-sdk';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import { Card, CardBody, CardHeader, CardTitle } from '@patternfly/react-core';
 import { DataConsumptionDropdown } from './data-consumption-card-dropdown';
 import DataConsumptionGraph from './data-consumption-graph';

--- a/packages/ocs/dashboards/object-service/data-consumption-card/data-consumption-graph.tsx
+++ b/packages/ocs/dashboards/object-service/data-consumption-card/data-consumption-graph.tsx
@@ -9,7 +9,7 @@ import { DATA_CONSUMPTION_QUERIES } from '@odf/ocs/queries';
 import { GraphEmpty } from '@odf/shared/charts';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { PrometheusResponse } from '@openshift-console/dynamic-plugin-sdk';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import {
   Chart,
   ChartAxis,

--- a/packages/ocs/dashboards/object-service/data-consumption-card/performance-graph.tsx
+++ b/packages/ocs/dashboards/object-service/data-consumption-card/performance-graph.tsx
@@ -6,7 +6,7 @@ import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { DataPoint } from '@odf/shared/utils';
 import { humanizeDecimalBytesPerSec, humanizeSeconds } from '@odf/shared/utils';
 import classNames from 'classnames';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import {
   Chart,
   ChartVoronoiContainer,

--- a/packages/ocs/dashboards/object-service/details-card/details-card.tsx
+++ b/packages/ocs/dashboards/object-service/details-card/details-card.tsx
@@ -27,7 +27,6 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import { DetailsBody } from '@openshift-console/dynamic-plugin-sdk-internal';
 import { OverviewDetailItem as DetailItem } from '@openshift-console/plugin-shared';
-import * as _ from 'lodash';
 import { Link } from 'react-router-dom';
 import { Card, CardBody, CardHeader, CardTitle } from '@patternfly/react-core';
 import { getOCSVersion } from '../../../utils';

--- a/packages/ocs/dashboards/object-service/resource-providers-card/resource-providers-card-item.tsx
+++ b/packages/ocs/dashboards/object-service/resource-providers-card/resource-providers-card-item.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { RedExclamationCircleIcon } from '@odf/shared/status/icons';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 
 const ResourceProvidersItemStatus: React.FC<ResourceProvidersRowStatusProps> =
   // eslint-disable-next-line react/display-name

--- a/packages/ocs/dashboards/object-service/resource-providers-card/resource-providers-card.tsx
+++ b/packages/ocs/dashboards/object-service/resource-providers-card/resource-providers-card.tsx
@@ -7,7 +7,7 @@ import {
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { getMetric } from '@odf/shared/utils';
 import { PrometheusResponse } from '@openshift-console/dynamic-plugin-sdk';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import { Card, CardBody, CardHeader, CardTitle } from '@patternfly/react-core';
 import { ResourceProvidersBody } from './resource-providers-card-body';
 import {

--- a/packages/ocs/dashboards/object-service/status-card/status-card.tsx
+++ b/packages/ocs/dashboards/object-service/status-card/status-card.tsx
@@ -22,7 +22,7 @@ import {
   HealthBody,
 } from '@openshift-console/dynamic-plugin-sdk-internal';
 import { SubsystemHealth } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/dashboard-types';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import {
   Gallery,
   GalleryItem,

--- a/packages/ocs/dashboards/persistent-internal/activity-card/activity-card.tsx
+++ b/packages/ocs/dashboards/persistent-internal/activity-card/activity-card.tsx
@@ -24,7 +24,7 @@ import {
   RecentEventsBody,
 } from '@openshift-console/dynamic-plugin-sdk-internal';
 import { EventKind } from '@openshift-console/dynamic-plugin-sdk/lib/api/internal-types';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import { Card, CardHeader, CardTitle } from '@patternfly/react-core';
 import { OCS_OPERATOR, PVC_PROVISIONER_ANNOTATION } from '../../../constants';
 import { StorageClusterModel } from '../../../models';

--- a/packages/ocs/dashboards/persistent-internal/status-card/status-card.tsx
+++ b/packages/ocs/dashboards/persistent-internal/status-card/status-card.tsx
@@ -20,7 +20,7 @@ import {
   HealthItem,
 } from '@openshift-console/dynamic-plugin-sdk-internal';
 import { SubsystemHealth } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/dashboard-types';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import {
   Gallery,
   GalleryItem,

--- a/packages/ocs/dashboards/persistent-internal/utilization-card/prometheus-multi-utilization-item.tsx
+++ b/packages/ocs/dashboards/persistent-internal/utilization-card/prometheus-multi-utilization-item.tsx
@@ -6,7 +6,6 @@ import {
 } from '@odf/shared/hooks/custom-prometheus-poll';
 import { Humanize } from '@openshift-console/dynamic-plugin-sdk';
 import { useUtilizationDuration } from '@openshift-console/dynamic-plugin-sdk-internal';
-import * as _ from 'lodash';
 import { MultilineUtilizationItem } from './multi-utilization-item';
 
 export const PrometheusMultilineUtilizationItem: React.FC<PrometheusMultilineUtilizationItemProps> =

--- a/packages/ocs/queries/object-storage.ts
+++ b/packages/ocs/queries/object-storage.ts
@@ -1,6 +1,6 @@
 import { NooBaaBucketClassModel } from '@odf/core/models';
 import { ProjectModel } from '@odf/shared/models';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import {
   CapacityBreakdown,
   ServiceType,

--- a/packages/ocs/storage-class/sc-form.tsx
+++ b/packages/ocs/storage-class/sc-form.tsx
@@ -53,7 +53,7 @@ import {
   useK8sWatchResource,
   useModal,
 } from '@openshift-console/dynamic-plugin-sdk';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import {
   Alert,
   Dropdown,

--- a/packages/ocs/utils/common.ts
+++ b/packages/ocs/utils/common.ts
@@ -16,7 +16,7 @@ import {
 } from '@odf/shared/types';
 import { DataPoint, humanizePercentage } from '@odf/shared/utils';
 import { EventKind } from '@openshift-console/dynamic-plugin-sdk-internal/lib/api/internal-types';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import { cephStorageLabel, CEPH_NS } from '../constants';
 
 const OCS_OPERATOR = 'ocs-operator';

--- a/packages/ocs/utils/metrics.ts
+++ b/packages/ocs/utils/metrics.ts
@@ -6,7 +6,7 @@ import {
   PrometheusRule,
   Rule,
 } from '@openshift-console/dynamic-plugin-sdk';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import { murmur3 } from 'murmurhash-js';
 
 export const getStackChartStats: GetStackStats = (

--- a/packages/odf/components/bucket-class/time-duration-dropdown.tsx
+++ b/packages/odf/components/bucket-class/time-duration-dropdown.tsx
@@ -9,7 +9,7 @@ import {
 import { TimeUnits } from '../../constants';
 
 export const TimeDurationDropdown: React.FC<TimeDurationDropdownProps> = ({
-  id,
+  id, // eslint-disable-line @typescript-eslint/no-unused-vars
   inputClassName,
   onChange,
   required,

--- a/packages/odf/components/create-storage-system/create-storage-system-steps/create-local-volume-set-step/body.tsx
+++ b/packages/odf/components/create-storage-system/create-storage-system-steps/create-local-volume-set-step/body.tsx
@@ -12,7 +12,7 @@ import { SingleSelectDropdown } from '@odf/shared/dropdown/singleselectdropdown'
 import { NodeKind } from '@odf/shared/types';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { TFunction } from 'i18next';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import { SelectOption } from '@patternfly/react-core';
 import {
   FormGroup,

--- a/packages/odf/components/create-storage-system/create-storage-system-steps/create-local-volume-set-step/selected-capacity.tsx
+++ b/packages/odf/components/create-storage-system/create-storage-system-steps/create-local-volume-set-step/selected-capacity.tsx
@@ -19,7 +19,7 @@ import { NodeKind } from '@odf/shared/types';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { convertToBaseValue, humanizeBinaryBytes } from '@odf/shared/utils';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import { ChartDonut, ChartLabel } from '@patternfly/react-charts';
 import { Button } from '@patternfly/react-core';
 import { WizardState, WizardDispatch } from '../../reducer';

--- a/packages/odf/components/create-storage-system/create-storage-system-steps/review-and-create-step/review-and-create-step.tsx
+++ b/packages/odf/components/create-storage-system/create-storage-system-steps/review-and-create-step/review-and-create-step.tsx
@@ -14,7 +14,7 @@ import { BackingStorageType, DeploymentType } from '@odf/core/types';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { humanizeBinaryBytes } from '@odf/shared/utils';
 import { useFlag } from '@openshift-console/dynamic-plugin-sdk';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import {
   TextContent,
   Text,

--- a/packages/odf/components/create-storage-system/create-storage-system-steps/security-and-network-step/encryption.tsx
+++ b/packages/odf/components/create-storage-system/create-storage-system-steps/security-and-network-step/encryption.tsx
@@ -271,7 +271,7 @@ export const EncryptionForm: React.FC<EncryptionProps> = ({
   kms,
   dispatch,
   infraType,
-  isMCG,
+  isMCG, // eslint-disable-line @typescript-eslint/no-unused-vars
 }) => {
   // enclosed in a "Form" so that child components can use default pf classes
   return (

--- a/packages/odf/components/create-storage-system/external-storage/red-hat-ceph-storage/index.tsx
+++ b/packages/odf/components/create-storage-system/external-storage/red-hat-ceph-storage/index.tsx
@@ -22,7 +22,7 @@ import { ListKind, PodKind } from '@odf/shared/types';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { getAPIVersionForModel } from '@odf/shared/utils';
 import { K8sKind } from '@openshift-console/dynamic-plugin-sdk/lib/api/common-types';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import { Trans } from 'react-i18next';
 import {
   FormGroup,

--- a/packages/odf/components/create-storage-system/header.tsx
+++ b/packages/odf/components/create-storage-system/header.tsx
@@ -4,7 +4,7 @@ import { TextVariants, Text, TextContent } from '@patternfly/react-core';
 import './create-storage-system.scss';
 
 export const CreateStorageSystemHeader: React.FC<CreateStorageSystemHeaderProps> =
-  ({ url }) => {
+  () => {
     const { t } = useCustomTranslation();
     return (
       <div className="odf-create-storage-system__header">

--- a/packages/odf/components/create-storage-system/payloads.ts
+++ b/packages/odf/components/create-storage-system/payloads.ts
@@ -10,7 +10,7 @@ import { K8sResourceKind, Patch, StorageSystemKind } from '@odf/shared/types';
 import { getAPIVersionForModel, k8sPatchByName } from '@odf/shared/utils';
 import { k8sCreate, k8sGet } from '@openshift-console/dynamic-plugin-sdk';
 import { K8sKind } from '@openshift-console/dynamic-plugin-sdk/lib/api/common-types';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import {
   ocsTaint,
   defaultRequestSize,

--- a/packages/odf/components/create-storage-system/reducer.ts
+++ b/packages/odf/components/create-storage-system/reducer.ts
@@ -1,5 +1,5 @@
 import { NodeKind } from '@odf/shared/types';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import {
   KMSEmptyState,
   NO_PROVISIONER,

--- a/packages/odf/components/create-storage-system/select-nodes-table/select-nodes-table.tsx
+++ b/packages/odf/components/create-storage-system/select-nodes-table/select-nodes-table.tsx
@@ -27,7 +27,7 @@ import {
   useListPageFilter,
 } from '@openshift-console/dynamic-plugin-sdk';
 import classNames from 'classnames';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import { Table, TableHeader, TableBody } from '@patternfly/react-table';
 import { IRow, sortable } from '@patternfly/react-table';
 import { WizardNodeState } from '../reducer';

--- a/packages/odf/components/kms-config/hpcs-config.tsx
+++ b/packages/odf/components/kms-config/hpcs-config.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useDeepCompareMemoize } from '@odf/shared/hooks/deep-compare-memoize';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import { FormGroup, TextInput, ValidatedOptions } from '@patternfly/react-core';
 import { validateConnectionName } from '../../constants';
 import { HpcsConfig, HPCSParams, ProviderNames } from '../../types';

--- a/packages/odf/components/kms-config/name-address-port.tsx
+++ b/packages/odf/components/kms-config/name-address-port.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import classNames from 'classnames';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import { FormGroup, TextInput, ValidatedOptions } from '@patternfly/react-core';
 import { validateConnectionName } from '../../constants';
 import { VaultConfig, ThalesConfig } from '../../types';

--- a/packages/odf/components/kms-config/thales-config.tsx
+++ b/packages/odf/components/kms-config/thales-config.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useDeepCompareMemoize } from '@odf/shared/hooks/deep-compare-memoize';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { TFunction } from 'i18next';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import { FormGroup, TextInput, FileUpload } from '@patternfly/react-core';
 import { KMSMaxFileUploadSize } from '../../constants';
 import { ThalesConfig, ProviderNames } from '../../types';

--- a/packages/odf/components/kms-config/utils.tsx
+++ b/packages/odf/components/kms-config/utils.tsx
@@ -4,7 +4,6 @@ import { getName } from '@odf/shared/selectors';
 import { K8sResourceKind, ConfigMapKind, SecretKind } from '@odf/shared/types';
 import { getRandomChars, isValidIP } from '@odf/shared/utils';
 import { k8sCreate, k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
-import * as _ from 'lodash';
 import {
   KMSConfigMapName,
   KMSVaultTokenSecretName,

--- a/packages/odf/components/kms-config/vault-config.tsx
+++ b/packages/odf/components/kms-config/vault-config.tsx
@@ -5,7 +5,7 @@ import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { useFlag } from '@openshift-console/dynamic-plugin-sdk';
 import { global_palette_blue_300 as blueInfoColor } from '@patternfly/react-tokens/dist/js/global_palette_blue_300';
 import { TFunction } from 'i18next';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import {
   FormGroup,
   FormSelect,

--- a/packages/odf/components/mcg-endpoints/gcp-endpoint-type.tsx
+++ b/packages/odf/components/mcg-endpoints/gcp-endpoint-type.tsx
@@ -4,7 +4,7 @@ import { SecretModel } from '@odf/shared/models';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import classNames from 'classnames';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import {
   Button,
   FormGroup,

--- a/packages/odf/components/mcg/CreateObjectBucketClaim.tsx
+++ b/packages/odf/components/mcg/CreateObjectBucketClaim.tsx
@@ -12,7 +12,7 @@ import {
   getAPIVersionForModel,
   k8sCreate,
 } from '@openshift-console/dynamic-plugin-sdk';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import { Helmet } from 'react-helmet';
 import { match, useHistory } from 'react-router';
 import { Link } from 'react-router-dom';

--- a/packages/odf/components/mcg/ObjectBucket.tsx
+++ b/packages/odf/components/mcg/ObjectBucket.tsx
@@ -26,7 +26,7 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import Status from '@openshift-console/dynamic-plugin-sdk/lib/app/components/status/Status';
 import classNames from 'classnames';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import { RouteComponentProps } from 'react-router';
 import { sortable } from '@patternfly/react-table';
 import { NooBaaObjectBucketModel } from '../../models/ocs';

--- a/packages/odf/components/mcg/ObjectBucketClaim.tsx
+++ b/packages/odf/components/mcg/ObjectBucketClaim.tsx
@@ -28,7 +28,7 @@ import {
   VirtualizedTable,
 } from '@openshift-console/dynamic-plugin-sdk';
 import classNames from 'classnames';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import { useTranslation } from 'react-i18next';
 import { RouteComponentProps } from 'react-router';
 import { sortable } from '@patternfly/react-table';

--- a/packages/odf/components/namespace-store/namespace-store-table.tsx
+++ b/packages/odf/components/namespace-store/namespace-store-table.tsx
@@ -17,7 +17,6 @@ import {
   VirtualizedTable,
 } from '@openshift-console/dynamic-plugin-sdk';
 import classNames from 'classnames';
-import * as _ from 'lodash';
 import { Checkbox } from '@patternfly/react-core';
 import { NooBaaNamespaceStoreModel } from '../../models';
 import { NamespaceStoreKind } from '../../types';

--- a/packages/odf/components/odf-dashboard/performance-card/performance-card.tsx
+++ b/packages/odf/components/odf-dashboard/performance-card/performance-card.tsx
@@ -24,7 +24,7 @@ import {
   UtilizationDurationDropdown,
   useUtilizationDuration,
 } from '@openshift-console/dynamic-plugin-sdk-internal';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import {
   Card,
   CardHeader,

--- a/packages/odf/components/odf-dashboard/performance-card/utils.ts
+++ b/packages/odf/components/odf-dashboard/performance-card/utils.ts
@@ -6,7 +6,7 @@ import {
   humanizeDecimalBytesPerSec,
 } from '@odf/shared/utils/humanize';
 import { PrometheusResponse } from '@openshift-console/dynamic-plugin-sdk';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 
 type DataFrame = {
   systemName: string;

--- a/packages/odf/components/odf-dashboard/status-card/status-card.tsx
+++ b/packages/odf/components/odf-dashboard/status-card/status-card.tsx
@@ -20,7 +20,6 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { HealthBody } from '@openshift-console/dynamic-plugin-sdk-internal';
-import * as _ from 'lodash';
 import {
   Gallery,
   GalleryItem,

--- a/packages/odf/components/odf-dashboard/system-capacity-card/capacity-card.tsx
+++ b/packages/odf/components/odf-dashboard/system-capacity-card/capacity-card.tsx
@@ -20,7 +20,7 @@ import {
   WatchK8sResource,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import { Card, CardBody, CardHeader, CardTitle } from '@patternfly/react-core';
 import { StorageDashboard, CAPACITY_QUERIES } from '../queries';
 

--- a/packages/odf/components/resource-pages/BucketClassDetailsPage.tsx
+++ b/packages/odf/components/resource-pages/BucketClassDetailsPage.tsx
@@ -9,7 +9,6 @@ import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { referenceForModel } from '@odf/shared/utils';
 import { EventStreamWrapped, YAMLEditorWrapped } from '@odf/shared/utils/Tabs';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
-import * as _ from 'lodash';
 import { RouteComponentProps } from 'react-router';
 import { NooBaaBucketClassModel } from '../../models';
 import { BucketClassKind } from '../../types';

--- a/packages/odf/components/resource-pages/list-page.tsx
+++ b/packages/odf/components/resource-pages/list-page.tsx
@@ -29,7 +29,6 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import classNames from 'classnames';
 import { TFunction } from 'i18next';
-import * as _ from 'lodash';
 import { sortable } from '@patternfly/react-table';
 import {
   NooBaaBackingStoreModel,

--- a/packages/odf/components/system-list/odf-system-list.tsx
+++ b/packages/odf/components/system-list/odf-system-list.tsx
@@ -42,7 +42,7 @@ import {
   VirtualizedTable,
 } from '@openshift-console/dynamic-plugin-sdk';
 import classNames from 'classnames';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import { sortable, wrappable } from '@patternfly/react-table';
 import { ODF_QUERIES, ODFQueries } from '../../queries';
 import { OperandStatus } from '../utils';

--- a/packages/odf/components/utils/common.ts
+++ b/packages/odf/components/utils/common.ts
@@ -24,7 +24,7 @@ import {
   convertToBaseValue,
 } from '@odf/shared/utils';
 import { Base64 } from 'js-base64';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import {
   MINIMUM_NODES,
   IP_FAMILY,

--- a/packages/odf/components/utils/operand-status.tsx
+++ b/packages/odf/components/utils/operand-status.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Status } from '@odf/shared/status/Status';
 import { SuccessStatus } from '@odf/shared/status/statuses';
 import { K8sResourceCondition, K8sResourceKind } from '@odf/shared/types';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 
 type OperandStatusType = {
   type: string;

--- a/packages/odf/components/utils/osd-size-dropdown.tsx
+++ b/packages/odf/components/utils/osd-size-dropdown.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { SingleSelectDropdown } from '@odf/shared/dropdown/singleselectdropdown';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { TFunction } from 'i18next';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import { SelectOption } from '@patternfly/react-core';
 import { OCS_DEVICE_SET_REPLICA, OSD_CAPACITY_SIZES } from '../../constants';
 

--- a/packages/odf/constants/mcg.ts
+++ b/packages/odf/constants/mcg.ts
@@ -1,4 +1,4 @@
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 
 export enum BC_PROVIDERS {
   AWS = 'AWS S3',

--- a/packages/odf/features.ts
+++ b/packages/odf/features.ts
@@ -23,7 +23,7 @@ import {
   K8sResourceCommon,
   SelfSubjectAccessReviewKind,
 } from '@openshift-console/dynamic-plugin-sdk';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import {
   SECOND,
   OCS_OPERATOR,

--- a/packages/odf/modals/attach-deployment/attach-deployment-obc-modal.tsx
+++ b/packages/odf/modals/attach-deployment/attach-deployment-obc-modal.tsx
@@ -13,7 +13,6 @@ import { DeploymentKind, K8sResourceKind } from '@odf/shared/types';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { resourcePathFromModel } from '@odf/shared/utils';
 import { k8sPatch } from '@openshift-console/dynamic-plugin-sdk';
-import * as _ from 'lodash';
 import { useHistory } from 'react-router';
 import { Alert, Button, Modal, ModalVariant } from '@patternfly/react-core';
 import { getAttachOBCPatch } from '../../utils';

--- a/packages/odf/utils/lso.ts
+++ b/packages/odf/utils/lso.ts
@@ -6,7 +6,7 @@ import {
   k8sCreate,
   MatchExpression,
 } from '@openshift-console/dynamic-plugin-sdk';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import {
   HOSTNAME_LABEL_KEY,
   DISCOVERY_CR_NAME,

--- a/packages/odf/utils/mcg.ts
+++ b/packages/odf/utils/mcg.ts
@@ -7,7 +7,7 @@ import {
 } from '@odf/shared/types';
 import { RowFilter } from '@openshift-console/dynamic-plugin-sdk';
 import { TFunction } from 'i18next';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import {
   AWS_REGIONS,
   BC_PROVIDERS,

--- a/packages/odf/utils/ocs.ts
+++ b/packages/odf/utils/ocs.ts
@@ -15,7 +15,7 @@ import {
   k8sPatch,
   MatchExpression,
 } from '@openshift-console/dynamic-plugin-sdk';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import {
   HOSTNAME_LABEL_KEY,
   LABEL_OPERATOR,

--- a/packages/odf/utils/odf.ts
+++ b/packages/odf/utils/odf.ts
@@ -3,7 +3,7 @@ import { ClusterServiceVersionKind } from '@odf/shared/types';
 import { K8sResourceKind } from '@odf/shared/types';
 import { StorageClassResourceKind } from '@odf/shared/types';
 import { isDefaultClass } from '@odf/shared/utils';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import { ODF_VENDOR_ANNOTATION } from '../constants';
 
 export const getSupportedVendors = (

--- a/packages/odf/utils/storage.ts
+++ b/packages/odf/utils/storage.ts
@@ -1,6 +1,5 @@
 import { K8sResourceKind } from '@odf/shared/types';
 import { convertToBaseValue } from '@odf/shared/utils/humanize';
-import * as _ from 'lodash';
 
 export const calcPVsCapacity = (pvs: K8sResourceKind[]): number =>
   pvs.reduce((sum, pv) => {

--- a/packages/shared/charts/PrometheusGraph.tsx
+++ b/packages/shared/charts/PrometheusGraph.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useActivePerspective } from '@openshift-console/dynamic-plugin-sdk';
 import classNames from 'classnames';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import { Link } from 'react-router-dom';
 
 export const PrometheusGraph: React.FC<PrometheusGraphProps> = React.forwardRef(

--- a/packages/shared/charts/tooltip.tsx
+++ b/packages/shared/charts/tooltip.tsx
@@ -1,6 +1,6 @@
 // Mostly just a copy-paste from patternfly.
 import * as React from 'react';
-import { defaults } from 'lodash';
+import { defaults } from 'lodash-es';
 //@ts-ignore
 import { Helpers } from 'victory-core';
 import {

--- a/packages/shared/charts/utils.ts
+++ b/packages/shared/charts/utils.ts
@@ -3,7 +3,7 @@ import {
   PrometheusResult,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { chart_color_orange_300 as requestedColor } from '@patternfly/react-tokens/dist/js/chart_color_orange_300';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import { DataPoint, getType } from '../utils';
 
 const log = (x: number, y: number) => {

--- a/packages/shared/dashboards/breakdown-card/utils.tsx
+++ b/packages/shared/dashboards/breakdown-card/utils.tsx
@@ -2,7 +2,6 @@ import { DataPoint } from '@odf/shared/utils';
 import { Humanize } from '@openshift-console/dynamic-plugin-sdk';
 import { global_palette_black_400 as globalBlack400 } from '@patternfly/react-tokens/dist/js/global_palette_black_400';
 import { TFunction } from 'i18next';
-import * as _ from 'lodash';
 import { Colors } from './consts';
 
 const getTotal = (stats: StackDataPoint[]) =>

--- a/packages/shared/dashboards/capacity-card/capacity-card.tsx
+++ b/packages/shared/dashboards/capacity-card/capacity-card.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import PlainResourceName from '@odf/shared/resource-link/plain-resource-link';
 import { K8sKind } from '@openshift-console/dynamic-plugin-sdk/lib/api/common-types';
 import classNames from 'classnames';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import {
   Grid,
   GridItem,

--- a/packages/shared/dashboards/line-graph/line-graph.tsx
+++ b/packages/shared/dashboards/line-graph/line-graph.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import {
   Chart,
   ChartAxis,

--- a/packages/shared/details-page/DetailsPage.tsx
+++ b/packages/shared/details-page/DetailsPage.tsx
@@ -9,7 +9,7 @@ import {
   useAccessReview,
 } from '@openshift-console/dynamic-plugin-sdk';
 import classnames from 'classnames';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -289,14 +289,14 @@ export const ResourceSummary: React.FC<ResourceSummaryProps> = ({
   children,
   resource,
   customPathName,
-  showPodSelector = false,
-  showNodeSelector = false,
+  showPodSelector = false, // eslint-disable-line @typescript-eslint/no-unused-vars
+  showNodeSelector = false, // eslint-disable-line @typescript-eslint/no-unused-vars
   showAnnotations = true,
-  showTolerations = false,
+  showTolerations = false, // eslint-disable-line @typescript-eslint/no-unused-vars
   showLabelEditor = true,
   canUpdateResource = true,
-  podSelector = 'spec.selector',
-  nodeSelector = 'spec.template.spec.nodeSelector',
+  podSelector = 'spec.selector', // eslint-disable-line @typescript-eslint/no-unused-vars
+  nodeSelector = 'spec.template.spec.nodeSelector', // eslint-disable-line @typescript-eslint/no-unused-vars
   launchModal,
   resourceModel,
 }) => {

--- a/packages/shared/dropdown/ResourceDropdown.tsx
+++ b/packages/shared/dropdown/ResourceDropdown.tsx
@@ -7,7 +7,7 @@ import {
 import { K8sModel } from '@openshift-console/dynamic-plugin-sdk/lib/api/common-types';
 import classNames from 'classnames';
 import * as fuzzy from 'fuzzysearch';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import {
   Dropdown,
   DropdownItem,

--- a/packages/shared/generic/ButtonBar.tsx
+++ b/packages/shared/generic/ButtonBar.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import classNames from 'classnames';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import { Alert, AlertGroup } from '@patternfly/react-core';
 import { useCustomTranslation } from '../useCustomTranslationHook';
 import { LoadingInline } from './Loading';

--- a/packages/shared/generic/ModalTitle.tsx
+++ b/packages/shared/generic/ModalTitle.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as _ from 'lodash';
 import { ActionGroup, Button } from '@patternfly/react-core';
 import { useCustomTranslation } from '../useCustomTranslationHook';
 import { ButtonBar } from './ButtonBar';

--- a/packages/shared/generic/status-box.tsx
+++ b/packages/shared/generic/status-box.tsx
@@ -5,7 +5,7 @@ import {
   TimeoutError,
 } from '@odf/shared/utils/error/http-error';
 import classNames from 'classnames';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import { Trans } from 'react-i18next';
 import { Alert, Button } from '@patternfly/react-core';
 import { useCustomTranslation } from '../useCustomTranslationHook';

--- a/packages/shared/heading/page-heading.tsx
+++ b/packages/shared/heading/page-heading.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { ResourceStatus } from '@openshift-console/dynamic-plugin-sdk';
 import Status from '@openshift-console/dynamic-plugin-sdk/lib/app/components/status/Status';
 import classNames from 'classnames';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import { Link } from 'react-router-dom';
 import {
   Breadcrumb,

--- a/packages/shared/hooks/deep-compare-memoize.ts
+++ b/packages/shared/hooks/deep-compare-memoize.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 
 export const useDeepCompareMemoize = <T = any>(
   value: T,

--- a/packages/shared/hooks/rbac-hook.ts
+++ b/packages/shared/hooks/rbac-hook.ts
@@ -6,7 +6,7 @@ import {
   AccessReviewResourceAttributes,
   useSafetyFirst,
 } from '@openshift-console/dynamic-plugin-sdk';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import { ProjectModel, SelfSubjectAccessReviewModel } from '../models';
 
 /**

--- a/packages/shared/modals/DeleteModal.tsx
+++ b/packages/shared/modals/DeleteModal.tsx
@@ -6,7 +6,6 @@ import {
   ResourceLink,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { K8sModel } from '@openshift-console/dynamic-plugin-sdk/lib/api/common-types';
-import * as _ from 'lodash';
 import { Trans } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import { Alert, Button, Modal, ModalVariant } from '@patternfly/react-core';

--- a/packages/shared/modals/EditLabelModal.tsx
+++ b/packages/shared/modals/EditLabelModal.tsx
@@ -4,7 +4,7 @@ import {
   K8sResourceCommon,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { K8sModel } from '@openshift-console/dynamic-plugin-sdk/lib/api/common-types';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import {
   Alert,
   Button,

--- a/packages/shared/modals/Selector.tsx
+++ b/packages/shared/modals/Selector.tsx
@@ -5,7 +5,7 @@ import {
   Selector,
 } from '@openshift-console/dynamic-plugin-sdk/lib/api/common-types';
 import classNames from 'classnames';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import * as TagsInput from 'react-tagsinput';
 import * as k8sSelectorRequirement from './selector-requirement';
 import { createEquals, requirementFromString } from './selector-requirement';

--- a/packages/shared/modals/selector-requirement.ts
+++ b/packages/shared/modals/selector-requirement.ts
@@ -1,5 +1,5 @@
 import { MatchExpression } from '@openshift-console/dynamic-plugin-sdk/lib/api/common-types';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 
 export const createEquals = (key: string, value: string): MatchExpression => ({
   key,

--- a/packages/shared/monitoring/utils.ts
+++ b/packages/shared/monitoring/utils.ts
@@ -1,5 +1,5 @@
 import { Alert, PrometheusLabels } from '@openshift-console/dynamic-plugin-sdk';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import { MonitoringResource } from './types';
 
 export const AlertResource: MonitoringResource = {

--- a/packages/shared/selectors/Node.ts
+++ b/packages/shared/selectors/Node.ts
@@ -1,4 +1,4 @@
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import { NodeCondition, NodeKind } from '../types';
 
 export const isNodeReady = (node: NodeKind): boolean => {

--- a/packages/shared/selectors/k8s.ts
+++ b/packages/shared/selectors/k8s.ts
@@ -1,5 +1,5 @@
 import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 
 type GetStringProperty<T = K8sResourceCommon> = (resource: T) => string;
 

--- a/packages/shared/status/SecondaryStatus.tsx
+++ b/packages/shared/status/SecondaryStatus.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 
 type SecondaryStatusProps = {
   status?: string | string[];

--- a/packages/shared/table/table.tsx
+++ b/packages/shared/table/table.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as _ from 'lodash';
 import {
   OnSort,
   SortByDirection,

--- a/packages/shared/utils/Errors.tsx
+++ b/packages/shared/utils/Errors.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as _ from 'lodash';
 import { Helmet } from 'react-helmet';
 import PageHeading from '../heading/page-heading';
 import { useCustomTranslation } from '../useCustomTranslationHook';

--- a/packages/shared/utils/NameValueEditor.tsx
+++ b/packages/shared/utils/NameValueEditor.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import classNames from 'classnames';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import { Button, Tooltip } from '@patternfly/react-core';

--- a/packages/shared/utils/Tabs.tsx
+++ b/packages/shared/utils/Tabs.tsx
@@ -3,7 +3,7 @@ import {
   ResourceYAMLEditor,
   ResourceEventStream,
 } from '@openshift-console/dynamic-plugin-sdk';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import {
   RouteComponentProps,
   useHistory,

--- a/packages/shared/utils/common.ts
+++ b/packages/shared/utils/common.ts
@@ -8,7 +8,7 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk-internal/lib/extensions/console-types';
 import { K8sKind } from '@openshift-console/dynamic-plugin-sdk/lib/api/common-types';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import { GetAPIVersionForModel } from '../types';
 
 const defaultClassAnnotation = 'storageclass.kubernetes.io/is-default-class';

--- a/packages/shared/utils/metrics.ts
+++ b/packages/shared/utils/metrics.ts
@@ -3,7 +3,7 @@ import {
   PrometheusResponse,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { Alert, PrometheusLabels } from '@openshift-console/dynamic-plugin-sdk';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 
 export const getGaugeValue = (response: PrometheusResponse) =>
   response?.data?.result?.[0]?.value?.[1];

--- a/packages/shared/utils/swagger.ts
+++ b/packages/shared/utils/swagger.ts
@@ -1,6 +1,6 @@
 import { consoleFetchJSON } from '@openshift-console/dynamic-plugin-sdk';
 import { K8sKind } from '@openshift-console/dynamic-plugin-sdk/lib/api/common-types';
-import * as _ from 'lodash';
+import * as _ from 'lodash-es';
 import { referenceForModel } from './common';
 
 export const STORAGE_PREFIX = 'bridge';


### PR DESCRIPTION
Fix lint issues detected by the following enabled rules:
* **no-extraneous-dependencies**: add explicit dependencies for imports that  previously were relying on dependencies of dependencies (so if a future version of a dependency drops the imported one, our code would break).
  * `import * as _ from 'lodash-es';` is now the only allowed `lodash`import as our current dependency is `lodash-es`.
* **@typescript-eslint/no-unused-vars**:
  *  Removed unnecessary `lodash` imports.
  * Removed unused vars.

Signed-off-by: Alfonso Martínez <almartin@redhat.com>