### PR TITLE
Remove outdated alert on PV expansion on encrypted PVs

### DIFF
--- a/locales/en/plugin__odf-console.json
+++ b/locales/en/plugin__odf-console.json
@@ -332,7 +332,6 @@
   "KMS service {{value}} already exist": "KMS service {{value}} already exist",
   "Choose existing KMS connection": "Choose existing KMS connection",
   "Create new KMS connection": "Create new KMS connection",
-  "PV expansion operation is not supported for encrypted PVs.": "PV expansion operation is not supported for encrypted PVs.",
   "Enable Thick Provisioning": "Enable Thick Provisioning",
   "By enabling thick-provisioning, volumes will allocate the requested capacity upon volume creation. Volume creation will be slower when thick-provisioning is enabled.": "By enabling thick-provisioning, volumes will allocate the requested capacity upon volume creation. Volume creation will be slower when thick-provisioning is enabled.",
   "Pool {{name}} creation in progress": "Pool {{name}} creation in progress",

--- a/packages/ocs/storage-class/sc-form.tsx
+++ b/packages/ocs/storage-class/sc-form.tsx
@@ -683,14 +683,6 @@ export const StorageClassEncryptionKMSID: React.FC<ProvisionerProps> = ({
             </Card>
           )}
         </div>
-        <Alert
-          className="co-alert"
-          variant="warning"
-          title={t(
-            'PV expansion operation is not supported for encrypted PVs.'
-          )}
-          isInline
-        />
       </FormGroup>
     </Form>
   );


### PR DESCRIPTION
This alert became obsolete since https://github.com/ceph/ceph-csi/pull/2258

Signed-off-by: Alfonso Martínez <almartin@redhat.com>