### PR TITLE
CI: drop Node.js EOL releases

### DIFF
--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14, 15, 16, 17, 18]
+        node-version: [14, 16, 18]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:15 AS builder
+FROM docker.io/library/node:14.17.3 AS builder
 WORKDIR /app
 COPY . /app
 RUN yarn install
 RUN yarn build
 
 
-FROM node:15 as serverpackage
+FROM docker.io/library/node:14.17.3 as serverpackage
 RUN yarn global add http-server
 RUN export PATH="$(yarn global bin):$PATH"
 

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM node:15 AS builder
+FROM docker.io/library/node:14.17.3 AS builder
 WORKDIR /app
 COPY . /app
 RUN yarn install

--- a/Dockerfile.mco.ci
+++ b/Dockerfile.mco.ci
@@ -1,4 +1,4 @@
-FROM node:15 AS builder
+FROM docker.io/library/node:14.17.3 AS builder
 WORKDIR /app
 COPY . /app
 RUN yarn install


### PR DESCRIPTION
[Node.js EOL releases](https://github.com/nodejs/Release#end-of-life-releases) should not be supported as they do not receive neither security updates nor critical bug fixes.

* The Node.js version selected for CI is the same as in `Dockerfile.prod`.

Signed-off-by: Alfonso Martínez <almartin@redhat.com>