### PR TITLE
Bug 2141095: [RDR] Storage System page on ACM Hub is visible even when data observability is not enabled

### DIFF
--- a/packages/mco/constants/common.ts
+++ b/packages/mco/constants/common.ts
@@ -1,3 +1,5 @@
 export const ODFMCO_OPERATOR = 'odf-multicluster-orchestrator';
 export const HUB_CLUSTER_NAME = 'local-cluster';
 export const MAX_ALLOWED_CLUSTERS = 2;
+export const SECOND = 1000;
+export const DEFAULT_SYNC_TIME = 15;

--- a/packages/mco/features.ts
+++ b/packages/mco/features.ts
@@ -1,0 +1,70 @@
+import {
+  k8sList,
+  K8sResourceCommon,
+  SetFeatureFlag,
+} from '@openshift-console/dynamic-plugin-sdk';
+import { SECOND, DEFAULT_SYNC_TIME } from './constants';
+import { AcmMultiClusterObservabilityModel } from './models';
+import { ACMMultiClusterObservability } from './types';
+
+let intervals: NodeJS.Timeout[] = [];
+
+type FeatureDetector = (
+  setFlag: SetFeatureFlag,
+  flagKey: string,
+  intervalId: any
+) => Promise<void>;
+
+type FlagController = {
+  flagKey: string;
+  featureDetector: FeatureDetector;
+  syncTime?: number;
+};
+
+const acmMcoDetector: FeatureDetector = async (
+  setFlag: SetFeatureFlag,
+  flagKey: string,
+  id: any
+) => {
+  // This set the flag to true only when ACM MultiClusterObservability CRD is in ready state.
+  // which is later used by enable storage system.
+  try {
+    const managedClusters: ACMMultiClusterObservability[] =
+      (await k8sList<K8sResourceCommon>({
+        model: AcmMultiClusterObservabilityModel,
+        queryParams: {},
+      })) as ACMMultiClusterObservability[];
+    const isEnabled = managedClusters?.[0]?.status?.conditions?.some(
+      (condition) => condition.status === 'True' && condition.type === 'Ready'
+    );
+    if (isEnabled) {
+      setFlag(flagKey, true);
+      clearInterval(intervals[id]);
+    }
+  } catch (error) {
+    setFlag(flagKey, false);
+  }
+};
+
+const flagController: FlagController[] = [
+  {
+    flagKey: 'ACM_MCO',
+    featureDetector: acmMcoDetector,
+  },
+];
+
+export const setFeatureFlag = async (
+  setFlag: SetFeatureFlag
+): Promise<void> => {
+  flagController.map(async (controller, id) => {
+    await controller.featureDetector(setFlag, controller.flagKey, id);
+    const intervalId = setInterval(
+      controller.featureDetector,
+      (controller.syncTime || DEFAULT_SYNC_TIME) * SECOND,
+      setFlag,
+      controller.flagKey,
+      id
+    );
+    intervals[id] = intervalId;
+  });
+};

--- a/packages/mco/models/acm.ts
+++ b/packages/mco/models/acm.ts
@@ -35,3 +35,16 @@ export const ACMManagedClusterModel: K8sModel = {
   abbr: 'MCL',
   namespaced: false,
 };
+
+export const AcmMultiClusterObservabilityModel: K8sModel = {
+  label: 'multiclusterobservability',
+  labelPlural: 'multiclusterobservabilities',
+  apiVersion: 'v1beta2',
+  apiGroup: 'observability.open-cluster-management.io',
+  plural: 'multiclusterobservabilities',
+  abbr: 'mco',
+  namespaced: false,
+  kind: 'MultiClusterObservability',
+  id: 'acmobservability',
+  crd: true,
+};

--- a/packages/mco/types/acm.ts
+++ b/packages/mco/types/acm.ts
@@ -60,3 +60,9 @@ export type AppToPlacementRule = {
     };
   };
 };
+
+export type ACMMultiClusterObservability = K8sResourceCommon & {
+  status?: {
+    conditions: K8sResourceCondition[];
+  };
+};

--- a/plugins/mco/console-extensions.json
+++ b/plugins/mco/console-extensions.json
@@ -1,5 +1,13 @@
 [
   {
+    "type": "console.flag",
+    "properties": {
+      "handler": {
+        "$codeRef": "features.setFeatureFlag"
+      }
+    }
+  },
+  {
     "type": "console.flag/model",
     "properties": {
       "model": {
@@ -57,6 +65,9 @@
       "section": "mco-data-services",
       "name": "%plugin__odf-plugin~Storage System%",
       "href": "/multicloud/data-services/storagesystem"
+    },
+    "flags": {
+      "required": ["ACM_MCO"]
     }
   },
   {

--- a/plugins/mco/console-plugin.json
+++ b/plugins/mco/console-plugin.json
@@ -7,6 +7,7 @@
     "@console/pluginAPI": "*"
   },
   "exposedModules": {
+    "features": "@odf/mco/features",
     "dataPolicies": "@odf/mco/components/data-policies/data-policies-page",
     "createDataPolicy": "@odf/mco/components/disaster-recovery/create-dr-policy/create-dr-policy",
     "mcoDashboard": "@odf/mco/components/mco-dashboard/storage-system/dashboard",


### PR DESCRIPTION
Storage system page visible since acm observability is present: 

![image](https://user-images.githubusercontent.com/22158580/201950278-fcd8234d-5c4b-460d-beb1-aff10ae1a11d.png)
![image](https://user-images.githubusercontent.com/22158580/201950493-b06d130b-34bb-4c57-8254-2955ed90f9e2.png)
