### PR TITLE
Fix input value print over control buttons

### DIFF
--- a/packages/shared/modals/Selector.tsx
+++ b/packages/shared/modals/Selector.tsx
@@ -282,7 +282,7 @@ export class SelectorInput extends React.Component<
     };
 
     return (
-      <div className="co-search-input pf-c-form-control">
+      <div className="co-search-input">
         <tags-input>
           <TagsInput
             ref={this.setRef}

--- a/packages/shared/modals/modal.scss
+++ b/packages/shared/modals/modal.scss
@@ -14,12 +14,18 @@
 .modalBody tags-input .tags {
   background-color: rgba(255, 255, 255, 0.5);
   background-image: none;
+  border: 1px solid #e9e9e9;
+  border-bottom: 1px solid #b2afaf;
   border-radius: 4px;
   color: rgb(85, 85, 85);
   cursor: text;
   line-height: 20px;
   margin-bottom: 1rem;
   min-height: 120px;
+}
+
+.modalBody tags-input .tags:hover {
+  border-bottom: 1px solid rgb(0, 132, 255);
 }
 
 .modal--overflow {


### PR DESCRIPTION
Expand the dialog dynamically to allow more input
and fix overprinting to the control buttons.

Signed-off-by: Timothy Asir <tjeyasin@redhat.com>