### PR TITLE
Bug 2167299: Change version formatting for details card

### DIFF
--- a/packages/ocs/dashboards/object-service/details-card/details-card.tsx
+++ b/packages/ocs/dashboards/object-service/details-card/details-card.tsx
@@ -1,52 +1,37 @@
 import * as React from 'react';
+import { OCS_OPERATOR } from '@odf/core/constants';
 import { ODF_MODEL_FLAG } from '@odf/core/features';
 import { RGW_FLAG } from '@odf/core/features';
-import { getODFVersion } from '@odf/core/utils';
-import { CEPH_STORAGE_NAMESPACE } from '@odf/shared/constants';
+import { getOperatorVersion } from '@odf/core/utils';
+import { CEPH_STORAGE_NAMESPACE, ODF_OPERATOR } from '@odf/shared/constants';
 import {
   useCustomPrometheusPoll,
   usePrometheusBasePath,
 } from '@odf/shared/hooks/custom-prometheus-poll';
 import { useK8sGet } from '@odf/shared/hooks/k8s-get-hook';
+import { useFetchCsv } from '@odf/shared/hooks/use-fetch-csv';
 import {
   InfrastructureModel,
-  SubscriptionModel,
   ClusterServiceVersionModel,
 } from '@odf/shared/models';
 import { K8sResourceKind } from '@odf/shared/types';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
-import {
-  referenceForModel,
-  getInfrastructurePlatform,
-} from '@odf/shared/utils';
+import { getInfrastructurePlatform } from '@odf/shared/utils';
 import { resourcePathFromModel } from '@odf/shared/utils';
 import { getMetric } from '@odf/shared/utils';
-import {
-  useK8sWatchResource,
-  useFlag,
-} from '@openshift-console/dynamic-plugin-sdk';
+import { useFlag } from '@openshift-console/dynamic-plugin-sdk';
 import { DetailsBody } from '@openshift-console/dynamic-plugin-sdk-internal';
 import { OverviewDetailItem as DetailItem } from '@openshift-console/plugin-shared';
 import { Link } from 'react-router-dom';
 import { Card, CardBody, CardHeader, CardTitle } from '@patternfly/react-core';
-import { getOCSVersion } from '../../../utils';
 import './details-card.scss';
 
 const NOOBAA_SYSTEM_NAME_QUERY = 'NooBaa_system_info';
 const NOOBAA_DASHBOARD_LINK_QUERY = 'NooBaa_system_links';
 
-const SubscriptionResource = {
-  kind: referenceForModel(SubscriptionModel),
-  namespaced: false,
-  isList: true,
-};
-
 export const ObjectServiceDetailsCard: React.FC<{}> = () => {
   const [infrastructure, infrastructureLoaded, infrastructureError] =
     useK8sGet<K8sResourceKind>(InfrastructureModel, 'cluster');
-
-  const [subscription, subscriptionLoaded, subscriptionLoadError] =
-    useK8sWatchResource<K8sResourceKind[]>(SubscriptionResource);
 
   const [systemResult, systemLoadError] = useCustomPrometheusPoll({
     query: NOOBAA_SYSTEM_NAME_QUERY,
@@ -69,9 +54,11 @@ export const ObjectServiceDetailsCard: React.FC<{}> = () => {
 
   const infrastructurePlatform = getInfrastructurePlatform(infrastructure);
 
-  const serviceVersion = !isODF
-    ? getOCSVersion(subscription)
-    : getODFVersion(subscription);
+  const [csv, csvLoaded, csvLoadError] = useFetchCsv({
+    specName: !isODF ? OCS_OPERATOR : ODF_OPERATOR,
+  });
+
+  const serviceVersion = getOperatorVersion(csv);
 
   const serviceName = isODF
     ? t('Data Foundation')
@@ -131,8 +118,8 @@ export const ObjectServiceDetailsCard: React.FC<{}> = () => {
           <DetailItem
             key="version"
             title={t('Version')}
-            isLoading={!subscriptionLoaded}
-            error={subscriptionLoadError}
+            isLoading={!csvLoaded}
+            error={csvLoadError}
           >
             {serviceVersion}
           </DetailItem>

--- a/packages/ocs/dashboards/persistent-internal/details-card.tsx
+++ b/packages/ocs/dashboards/persistent-internal/details-card.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
-import { getODFVersion } from '@odf/core/utils';
+import { getOperatorVersion } from '@odf/core/utils';
+import { ODF_OPERATOR } from '@odf/shared/constants';
 import { useK8sGet } from '@odf/shared/hooks/k8s-get-hook';
+import { useFetchCsv } from '@odf/shared/hooks/use-fetch-csv';
 import { useK8sList } from '@odf/shared/hooks/useK8sList';
 import {
   ClusterServiceVersionModel,
   InfrastructureModel,
-  SubscriptionModel,
 } from '@odf/shared/models';
 import { getName } from '@odf/shared/selectors';
 import { K8sResourceKind, StorageClusterKind } from '@odf/shared/types';
@@ -29,15 +30,14 @@ const DetailsCard: React.FC = () => {
     StorageClusterModel,
     CEPH_NS
   );
-  const [subscription, subscriptionLoaded, subscriptionError] =
-    useK8sList(SubscriptionModel);
+  const [csv, csvLoaded, csvError] = useFetchCsv({ specName: ODF_OPERATOR });
   const infrastructurePlatform = getInfrastructurePlatform(infrastructure);
   const cluster = ocsData?.find(
     (item: StorageClusterKind) => item.status.phase !== 'Ignored'
   );
   const ocsName = getName(cluster);
 
-  const serviceVersion = getODFVersion(subscription);
+  const serviceVersion = getOperatorVersion(csv);
   const servicePath = `${resourcePathFromModel(
     ClusterServiceVersionModel,
     serviceVersion,
@@ -80,8 +80,8 @@ const DetailsCard: React.FC = () => {
           <DetailItem
             key="version"
             title={t('Version')}
-            isLoading={!subscriptionLoaded}
-            error={subscriptionError}
+            isLoading={!csvLoaded}
+            error={csvError}
           >
             {serviceVersion}
           </DetailItem>

--- a/packages/ocs/utils/common.ts
+++ b/packages/ocs/utils/common.ts
@@ -19,8 +19,6 @@ import { EventKind } from '@openshift-console/dynamic-plugin-sdk-internal/lib/ap
 import * as _ from 'lodash-es';
 import { cephStorageLabel, CEPH_NS } from '../constants';
 
-const OCS_OPERATOR = 'ocs-operator';
-
 export const cephStorageProvisioners = [
   'ceph.rook.io/block',
   'cephfs.csi.ceph.com',
@@ -64,15 +62,7 @@ export const isPersistentStorageEvent =
   };
 
 export const getOperatorVersion = (operator: K8sResourceKind): string =>
-  operator?.status?.installedCSV;
-
-export const getOCSVersion = (items: K8sResourceKind[]): string => {
-  const operator: K8sResourceKind = _.find(
-    items,
-    (item) => item?.spec?.name === OCS_OPERATOR
-  );
-  return getOperatorVersion(operator);
-};
+  operator?.spec?.version;
 
 export const getCephSC = (
   scData: StorageClassResourceKind[]

--- a/packages/odf/utils/odf.ts
+++ b/packages/odf/utils/odf.ts
@@ -1,4 +1,3 @@
-import { ODF_OPERATOR } from '@odf/shared/constants';
 import { ClusterServiceVersionKind } from '@odf/shared/types';
 import { K8sResourceKind } from '@odf/shared/types';
 import { StorageClassResourceKind } from '@odf/shared/types';
@@ -37,12 +36,4 @@ export const getStorageClassDescription = (
 };
 
 export const getOperatorVersion = (operator: K8sResourceKind): string =>
-  operator?.status?.installedCSV;
-
-export const getODFVersion = (items: K8sResourceKind[]): string => {
-  const operator: K8sResourceKind = _.find(
-    items,
-    (item) => item?.spec?.name === ODF_OPERATOR
-  );
-  return getOperatorVersion(operator);
-};
+  operator?.spec?.version;


### PR DESCRIPTION
This commit changes the way the version is formatted in the details cards (internal, external and object service dashboards)

Instead of odf-operator.v4.12.0, we will just show the semver of the operator.

This is done as part of the bluewash changes

![Screenshot from 2023-02-06 15-09-45](https://user-images.githubusercontent.com/57935785/216938386-c1e47372-0da8-4a84-8fff-5cf2f1f36310.png)
![Screenshot from 2023-02-06 15-09-33](https://user-images.githubusercontent.com/57935785/216938396-23dd03c1-dad8-4772-8d61-4773f817ca26.png)


Edit : 
PR updated to pick the version from the respective operator csvs and updated in all the details card.
The screenshots are the same, just with the `v` removed 


Signed-off-by: Vineet Badrinath <vineetbnath@gmail.com>