### PR TITLE
Bug 2178262: Fix for toggle selection issue in apply policy modal

### DIFF
--- a/locales/en/plugin__odf-console.json
+++ b/locales/en/plugin__odf-console.json
@@ -758,7 +758,6 @@
   "StorageClass": "StorageClass",
   "Defines the object-store service and the bucket provisioner.": "Defines the object-store service and the bucket provisioner.",
   "BucketClass": "BucketClass",
-  "Replication Policy": "Replication Policy",
   "For higher resiliency, set a replication configuration for objects which are stored in NooBaa namespace buckets": "For higher resiliency, set a replication configuration for objects which are stored in NooBaa namespace buckets",
   "Create ObjectBucketClaim": "Create ObjectBucketClaim",
   "Edit YAML": "Edit YAML",

--- a/packages/mco/components/modals/drpolicy-apps-apply/apply-policy-dual-list-selector.scss
+++ b/packages/mco/components/modals/drpolicy-apps-apply/apply-policy-dual-list-selector.scss
@@ -1,10 +1,31 @@
 .mco-apply-policy-dual-selector {
-    &__listItem {
+    &__listRow{
         display: flex;
         flex-direction: column;
         text-align: start;
     }
+    &__listItem{
+        display: flex;
+        padding: 0;
+    }
+    
     &__ItemDescription--color {
         color: var(--pf-global--Color--200);
+    }
+    &__button {
+        padding: 0;
+        display: flex;
+        background-color: transparent;
+        border: none;
+    }
+    &__listItem--text {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        flex-grow: 1;
+        color: var(--pf-c-dual-list-selector__item-text--Color);
+    }
+    &__ExpandItem--indent {
+        padding-left: var(--pf-global--spacer--lg);
     }
   }

--- a/packages/shared/modals/Selector.tsx
+++ b/packages/shared/modals/Selector.tsx
@@ -293,7 +293,11 @@ export class SelectorInput extends React.Component<
             removeKeys={removeKeys}
             inputProps={inputProps}
             renderTag={renderTag}
-            onChange={this.handleChange.bind(this)}
+            onChange={
+              !this.props.disabled
+                ? this.handleChange.bind(this)
+                : () => undefined
+            }
             disabled={this.props.disabled}
             addOnBlur
           />


### PR DESCRIPTION
Problem:
  ExpandView is a child component for DualListSelectorListItem, the selection count got increased and decreased even when we click the arrow icon.  Sometimes it confuses the user whether the app got selected or unselected. 
  
Fix:
  The app selection won't work when the user clicks the arrow button, it simply expands the view. 
  For more: https://github.com/patternfly/patternfly-react/blob/v5/packages/react-core/src/components/DualListSelector/DualListSelectorListItem.tsx#L55