### PR TITLE
Enabling MCO and DR dashboard based on admin privilege

### DIFF
--- a/packages/mco/components/data-policies/data-policies-page.tsx
+++ b/packages/mco/components/data-policies/data-policies-page.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import PageHeading from '@odf/shared/heading/page-heading';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
-import { HorizontalNav } from '@openshift-console/dynamic-plugin-sdk';
+import { HorizontalNav, useFlag } from '@openshift-console/dynamic-plugin-sdk';
 import { Helmet } from 'react-helmet';
 import { RouteComponentProps } from 'react-router';
+import { ACM_OBSERVABILITY_FLAG, ADMIN_FLAG } from '../../constants';
 import { DRPolicyListPage } from '../disaster-recovery/drpolicy-list-page/drpolicy-list-page';
 import DRDashboard from '../mco-dashboard/data-policy/dr-dashboard';
 
@@ -14,18 +15,30 @@ type DataPoliciesPageProps = {
 export const DataPoliciesPage: React.FC<DataPoliciesPageProps> = () => {
   const { t } = useCustomTranslation();
   const title = t('Data policies');
-  const pages = [
-    {
-      href: '',
-      name: t('Overview'),
-      component: DRDashboard,
-    },
-    {
-      href: 'recovery',
-      name: t('Disaster recovery'),
-      component: DRPolicyListPage,
-    },
-  ];
+  const acmMCOFlag = useFlag(ACM_OBSERVABILITY_FLAG);
+  const adminFlag = useFlag(ADMIN_FLAG);
+  const pages =
+    // Enabling dashboard only when ACM observability is enabled and admin user is detected
+    acmMCOFlag && adminFlag
+      ? [
+          {
+            href: '',
+            name: t('Overview'),
+            component: DRDashboard,
+          },
+          {
+            href: 'recovery',
+            name: t('Disaster recovery'),
+            component: DRPolicyListPage,
+          },
+        ]
+      : [
+          {
+            href: '',
+            name: t('Disaster recovery'),
+            component: DRPolicyListPage,
+          },
+        ];
 
   return (
     <>

--- a/packages/mco/constants/common.ts
+++ b/packages/mco/constants/common.ts
@@ -11,3 +11,5 @@ export const enum SLA_STATUS {
   WARNING = 'warning',
   HEALTHY = 'healthy',
 }
+export const ACM_OBSERVABILITY_FLAG = 'ACM_OBSERVABILITY';
+export const ADMIN_FLAG = 'ADMIN';

--- a/packages/mco/features.ts
+++ b/packages/mco/features.ts
@@ -1,10 +1,20 @@
+import { SelfSubjectAccessReviewModel } from '@odf/shared/models';
 import {
+  k8sCreate,
   k8sList,
   K8sResourceCommon,
+  SelfSubjectAccessReviewKind,
   SetFeatureFlag,
 } from '@openshift-console/dynamic-plugin-sdk';
-import { SECOND, DEFAULT_SYNC_TIME } from './constants';
-import { AcmMultiClusterObservabilityModel } from './models';
+import * as _ from 'lodash-es';
+import {
+  SECOND,
+  DEFAULT_SYNC_TIME,
+  ACM_OBSERVABILITY_FLAG,
+  ADMIN_FLAG,
+  HUB_CLUSTER_NAME,
+} from './constants';
+import { AcmMultiClusterObservabilityModel, MirrorPeerModel } from './models';
 import { ACMMultiClusterObservability } from './types';
 
 let intervals: NodeJS.Timeout[] = [];
@@ -21,7 +31,37 @@ type FlagController = {
   syncTime?: number;
 };
 
-const acmMcoDetector: FeatureDetector = async (
+// Check the user's access to some resources.
+const ssarChecks = {
+  [ADMIN_FLAG]: {
+    group: MirrorPeerModel.apiGroup,
+    resource: MirrorPeerModel.plural,
+    verb: 'create',
+  },
+};
+
+const handleError = (
+  res: any,
+  flagKey: string,
+  setFlag: SetFeatureFlag,
+  intervalId: any
+) => {
+  if (res?.response instanceof Response) {
+    const status = res?.response?.status;
+    if (_.includes([502], status)) {
+      setFlag(flagKey, undefined);
+      clearInterval(intervals[intervalId]);
+    }
+    if (!_.includes([401, 403, 500], status)) {
+      setFlag(flagKey, undefined);
+    }
+  } else {
+    setFlag(flagKey, undefined);
+    clearInterval(intervals[intervalId]);
+  }
+};
+
+const acmObservabilityDetector: FeatureDetector = async (
   setFlag: SetFeatureFlag,
   flagKey: string,
   id: any
@@ -29,27 +69,57 @@ const acmMcoDetector: FeatureDetector = async (
   // This set the flag to true only when ACM MultiClusterObservability CRD is in ready state.
   // which is later used by enable storage system.
   try {
-    const managedClusters: ACMMultiClusterObservability[] =
+    const acmObservability: ACMMultiClusterObservability[] =
       (await k8sList<K8sResourceCommon>({
         model: AcmMultiClusterObservabilityModel,
-        queryParams: {},
+        queryParams: { cluster: HUB_CLUSTER_NAME },
       })) as ACMMultiClusterObservability[];
-    const isEnabled = managedClusters?.[0]?.status?.conditions?.some(
-      (condition) => condition.status === 'True' && condition.type === 'Ready'
-    );
-    if (isEnabled) {
-      setFlag(flagKey, true);
+    if (!!acmObservability.length) {
+      const isEnabled = acmObservability?.[0]?.status?.conditions?.some(
+        (condition) => condition.status === 'True' && condition.type === 'Ready'
+      );
+      setFlag(flagKey, isEnabled);
+      isEnabled && clearInterval(intervals[id]);
+    } else {
+      setFlag(flagKey, undefined);
       clearInterval(intervals[id]);
     }
   } catch (error) {
-    setFlag(flagKey, false);
+    handleError(error, flagKey, setFlag, id);
+  }
+};
+
+export const detectSSAR = async (
+  setFlag: SetFeatureFlag,
+  flagKey: string,
+  id: any
+) => {
+  try {
+    const result: SelfSubjectAccessReviewKind = (await k8sCreate({
+      model: SelfSubjectAccessReviewModel,
+      data: {
+        apiVersion: 'authorization.k8s.io/v1',
+        kind: 'SelfSubjectAccessReview',
+        spec: { resourceAttributes: ssarChecks[flagKey] },
+      },
+      cluster: HUB_CLUSTER_NAME,
+    })) as SelfSubjectAccessReviewKind;
+    const isAllowed = result?.status?.allowed;
+    setFlag(flagKey, isAllowed);
+    _.isBoolean(isAllowed) && clearInterval(intervals[id]);
+  } catch (error) {
+    handleError(error, flagKey, setFlag, id);
   }
 };
 
 const flagController: FlagController[] = [
   {
-    flagKey: 'ACM_MCO',
-    featureDetector: acmMcoDetector,
+    flagKey: ACM_OBSERVABILITY_FLAG,
+    featureDetector: acmObservabilityDetector,
+  },
+  {
+    flagKey: ADMIN_FLAG,
+    featureDetector: detectSSAR,
   },
 ];
 

--- a/plugins/mco/console-extensions.json
+++ b/plugins/mco/console-extensions.json
@@ -46,6 +46,9 @@
       "path": "/multicloud/data-services/data-policies/ramendr.openshift.io~v1alpha1~DRPolicy/~new",
       "exact": true,
       "component": { "$codeRef": "createDataPolicy.CreateDRPolicy" }
+    },
+    "flags": {
+      "required": ["ADMIN"]
     }
   },
   {
@@ -67,7 +70,7 @@
       "href": "/multicloud/data-services/storagesystem"
     },
     "flags": {
-      "required": ["ACM_MCO"]
+      "required": ["ACM_OBSERVABILITY", "ADMIN"]
     }
   },
   {


### PR DESCRIPTION
1. Only the admin user can access the DR dashboard.
2. Only the admin user can access the storage system dashboard.
3. Restricting the create the DRPolicy page route from non-admin users.