### PR TITLE
CI: Add build step for mco

### DIFF
--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -24,3 +24,5 @@ jobs:
       - run: yarn format-test
       - run: yarn test-coverage
       - run: yarn analyze-odf
+      - run: yarn build-mco
+      - run: yarn analyze-mco


### PR DESCRIPTION
https://github.com/red-hat-storage/odf-console/issues/673 We add the mco test along with odf this
to avoid a fresh instance of a runner image.