### PR TITLE
CI build: constrain the memory usage of node processes

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -2,7 +2,7 @@ FROM docker.io/library/node:14.17.3 AS builder
 WORKDIR /app
 COPY . /app
 RUN yarn install
-RUN NODE_OPTIONS="--max-old-space-size=1000" yarn build
+RUN NODE_OPTIONS="--max-old-space-size=1024" yarn build
 
 
 FROM quay.io/ocs-dev/cypress:latest as serverpackage

--- a/Dockerfile.mco.ci
+++ b/Dockerfile.mco.ci
@@ -2,7 +2,7 @@ FROM docker.io/library/node:14.17.3 AS builder
 WORKDIR /app
 COPY . /app
 RUN yarn install
-RUN NODE_OPTIONS="--max-old-space-size=1000" yarn build-mco
+RUN NODE_OPTIONS="--max-old-space-size=1024" yarn build-mco
 
 
 FROM quay.io/ocs-dev/cypress:latest as serverpackage

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -18,6 +18,7 @@ const resolveLocale = (dirName: string, ns: string) =>
 const NODE_ENV = (process.env.NODE_ENV ||
   'development') as webpack.Configuration['mode'];
 const PLUGIN = process.env.PLUGIN;
+const OPENSHIFT_CI = process.env.OPENSHIFT_CI;
 
 if (PLUGIN === undefined) {
   process.exit(1);
@@ -57,7 +58,14 @@ const config: webpack.Configuration & DevServerConfiguration = {
           {
             loader: 'thread-loader',
             options: {
-              ...(NODE_ENV === 'development' ? { poolTimeout: Infinity } : {}),
+              ...(NODE_ENV === 'development'
+                ? { poolTimeout: Infinity, poolRespawn: false }
+                : OPENSHIFT_CI
+                ? {
+                    workers: 2,
+                    workerNodeArgs: ['--max-old-space-size=1024'],
+                  }
+                : {}),
             },
           },
           {
@@ -82,7 +90,14 @@ const config: webpack.Configuration & DevServerConfiguration = {
           {
             loader: 'thread-loader',
             options: {
-              ...(NODE_ENV === 'development' ? { poolTimeout: Infinity } : {}),
+              ...(NODE_ENV === 'development'
+                ? { poolTimeout: Infinity, poolRespawn: false }
+                : OPENSHIFT_CI
+                ? {
+                    workers: 4,
+                    workerNodeArgs: ['--max-old-space-size=1024'],
+                  }
+                : {}),
             },
           },
           { loader: 'style-loader' },


### PR DESCRIPTION
As the CI memory hard limit has been [increased to 12 GB](https://github.com/openshift/release/pull/37326), here we limit & constrain the memory usage of the node processes to stay below that limit:
- Generic: for any node process during CI `yarn build`: 1GB.
- thread-loader: limit the amount of workers; memory allowed for each worker: 1GB.
- fork-ts-checker-webpack-plugin: the default: 2GB.