### PR TITLE
CI: add .ci-operator.yaml

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  name: odf-console-ci-runner
+  namespace: ci
+  tag: latest

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 node_modules
+coverage
 dist
 .cache-loader
 locales

--- a/Dockerfile.ci.runner
+++ b/Dockerfile.ci.runner
@@ -1,0 +1,8 @@
+FROM quay.io/coreos/tectonic-console-builder:v24
+ENV NODE_VERSION="v14.17.3"
+RUN cd /tmp \
+  && wget --quiet -O /tmp/node.tar.gz http://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.gz \
+  && tar xf node.tar.gz && rm -f /tmp/node.tar.gz && cd node-* && cp -r lib/node_modules /usr/local/lib/node_modules \
+  && cp bin/node /usr/local/bin && ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm
+RUN chmod 777 /usr/local/lib/node_modules
+RUN rm -rf /tmp/node-v*

--- a/README.md
+++ b/README.md
@@ -48,3 +48,11 @@ yarn test-cypress-headless
 ```
 
 By default, it will look for Chrome in the system and use it, but if you want to use Firefox instead, set BRIDGE_E2E_BROWSER_NAME environment variable in your shell with the value firefox.
+
+#### Build the CI runner image:
+
+- Build examples:
+
+```
+docker build -t quay.io/<dev-repository>/odf-console-ci-runner:4.13 -f Dockerfile.ci.runner .
+```


### PR DESCRIPTION
This PR adds the [.ci-operator.yaml](https://github.com/alfonsomthd/odf-console/pull/new/ci-op-yaml) as prerequisite for using our custom CI runner image so it's noe needed to be built on the fly during every run (which causing errors some times).