### PR TITLE
CI: update runner image periodically

### DIFF
--- a/.github/workflows/ci-runner-image.yml
+++ b/.github/workflows/ci-runner-image.yml
@@ -6,6 +6,8 @@ on:
       - master
     paths:
       - Dockerfile.ci.runner
+  schedule:
+    - cron: '0 2 15 * *'
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -15,6 +17,6 @@ jobs:
       - name: Login to Quay Registry
         run: echo ${{ secrets.QUAY_SECRET }} | docker login quay.io -u ${{ secrets.QUAY_UNAME }} --password-stdin
       - name: Build the CI runner image
-        run: docker build . --file Dockerfile.ci.runner --tag quay.io/ocs-dev/odf-console-ci:current
+        run: docker build . --file Dockerfile.ci.runner --tag quay.io/ocs-dev/odf-console-ci:node18
       - name: Push the CI runner image to ocs-dev
-        run: docker push quay.io/ocs-dev/odf-console-ci-runner:current
+        run: docker push quay.io/ocs-dev/odf-console-ci-runner:node18


### PR DESCRIPTION
Update the CI runner image once a month in order to have the latest version of Google Chrome.