### PR TITLE
Fix for the issue DRPolicy doesn't show connected application

### DIFF
--- a/packages/mco/hooks/applications-hook.ts
+++ b/packages/mco/hooks/applications-hook.ts
@@ -127,7 +127,8 @@ export const findAndUpdateApplicationRef = (
         (plsRef) =>
           drpc?.spec?.placementRef?.kind === plsRef?.kind &&
           drpc?.spec?.placementRef?.name === plsRef?.name &&
-          drpc?.spec?.placementRef?.namespace === plsRef?.namespace
+          (drpc?.spec?.placementRef?.namespace === plsRef?.namespace ||
+            appRef?.applicationNamespace === plsRef?.namespace)
       )
     );
     if (!!filteredDRPCs?.length) {


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2196298

From 4.13, I have added an extra check on placementRef namespace. The problem is 4.12 UI is not adding this namespace info on DRPC placementRef, so UI is ignoring this from the connected application list.


