### PR TITLE
Placement support for subscription

### DIFF
--- a/packages/mco/components/modals/app-failover-relocate/subscriptions/dr-policy-selector.tsx
+++ b/packages/mco/components/modals/app-failover-relocate/subscriptions/dr-policy-selector.tsx
@@ -2,10 +2,9 @@ import * as React from 'react';
 import { useDeepCompareMemoize } from '@odf/shared/hooks/deep-compare-memoize';
 import { getName, getUID } from '@odf/shared/selectors';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
-import { referenceForModel } from '@odf/shared/utils';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { Dropdown, DropdownToggle, DropdownItem } from '@patternfly/react-core';
-import { DRPolicyModel } from '../../../../models';
+import { getDRPolicyResourceObj } from '../../../../hooks';
 import { DRPolicyKind } from '../../../../types';
 import {
   DRPolicyControlState,
@@ -20,7 +19,7 @@ const getDRPolicyNames = (drpcState: DRPolicyControlState[]): string[] => [
   ...new Set(
     drpcState.map(
       (currentDrpcState) =>
-        currentDrpcState?.drPolicyControl?.spec?.drPolicyRef?.name
+        currentDrpcState?.drPlacementControl?.spec?.drPolicyRef?.name
     )
   ),
 ];
@@ -37,11 +36,7 @@ export const DRPolicySelector: React.FC<DRPolicySelectorProps> = ({
 }) => {
   const { t } = useCustomTranslation();
   const [drPolicies, drPoliciesLoaded, drPoliciesLoadError] =
-    useK8sWatchResource<DRPolicyKind[]>({
-      kind: referenceForModel(DRPolicyModel),
-      isList: true,
-    });
-  const memoizedDRPolicies = useDeepCompareMemoize(drPolicies, true);
+    useK8sWatchResource<DRPolicyKind[]>(getDRPolicyResourceObj());
   const memoizedDRPCState = useDeepCompareMemoize(
     state.drPolicyControlState,
     true
@@ -60,18 +55,10 @@ export const DRPolicySelector: React.FC<DRPolicySelectorProps> = ({
       drPoliciesLoaded &&
       !drPoliciesLoadError &&
       !!memoizedDRPCState.length &&
-      !!memoizedDRPolicies.length
-        ? getDRPolicyList(
-            getDRPolicyNames(memoizedDRPCState),
-            memoizedDRPolicies
-          )
+      !!drPolicies.length
+        ? getDRPolicyList(getDRPolicyNames(memoizedDRPCState), drPolicies)
         : [],
-    [
-      memoizedDRPCState,
-      memoizedDRPolicies,
-      drPoliciesLoaded,
-      drPoliciesLoadError,
-    ]
+    [memoizedDRPCState, drPolicies, drPoliciesLoaded, drPoliciesLoadError]
   );
 
   const dropdownItems = React.useMemo(

--- a/packages/mco/components/modals/app-failover-relocate/subscriptions/failover-relocate-modal.tsx
+++ b/packages/mco/components/modals/app-failover-relocate/subscriptions/failover-relocate-modal.tsx
@@ -118,7 +118,7 @@ export const SubscriptionFailoverRelocateModal: React.FC<FailoverRelocateModalPr
       state.drPolicyControlState.forEach((acmToDRState) => {
         if (
           state.selectedSubsGroups.includes(
-            getName(acmToDRState?.drPolicyControl)
+            getName(acmToDRState?.drPlacementControl)
           )
         ) {
           const patch = [
@@ -141,7 +141,7 @@ export const SubscriptionFailoverRelocateModal: React.FC<FailoverRelocateModalPr
           promises.push(
             k8sPatch({
               model: DRPlacementControlModel,
-              resource: acmToDRState?.drPolicyControl,
+              resource: acmToDRState?.drPlacementControl,
               data: patch,
             })
           );

--- a/packages/mco/components/modals/app-failover-relocate/subscriptions/peer-cluster-status.tsx
+++ b/packages/mco/components/modals/app-failover-relocate/subscriptions/peer-cluster-status.tsx
@@ -47,7 +47,7 @@ const getPeerReadiness = (
   t: TFunction
 ): StatusProps =>
   peerReadiness.text !== 'Not ready'
-    ? checkDRActionReadiness(drpcState?.drPolicyControl, actionType)
+    ? checkDRActionReadiness(drpcState?.drPlacementControl, actionType)
       ? {
           text: PEER_READINESS(t).PEER_READY,
           icon: <GreenCheckCircleIcon />,
@@ -62,7 +62,7 @@ const getDataLastSyncTime = (
   dataLastSyncStatus: StatusProps,
   drpcState: DRPolicyControlState
 ): StatusProps => {
-  const lastSyncTime = drpcState?.drPolicyControl?.status?.lastGroupSyncTime;
+  const lastSyncTime = drpcState?.drPlacementControl?.status?.lastGroupSyncTime;
   return !!lastSyncTime
     ? dataLastSyncStatus.text !== 'Unknown'
       ? {
@@ -88,7 +88,7 @@ const getPeerStatusSummary = (
   // Verify all DRPC has Peer ready status
   drpcStateList?.reduce(
     (acc, drpcState) =>
-      subsGroups.includes(getName(drpcState?.drPolicyControl))
+      subsGroups.includes(getName(drpcState?.drPlacementControl))
         ? {
             ...acc,
             peerReadiness: getPeerReadiness(
@@ -151,12 +151,12 @@ export const PeerClusterStatus: React.FC<PeerClusterStatusProps> = ({
               ? ErrorMessageType.FAILOVER_READINESS_CHECK_FAILED
               : ErrorMessageType.RELOCATE_READINESS_CHECK_FAILED
           )
-        : setErrorMessage(0);
+        : setErrorMessage(0 as ErrorMessageType);
       setPeerStatus(peerCurrentStatus);
     } else {
       // Default peer status is Unknown
       setPeerStatus(initalPeerStatus(t));
-      setErrorMessage(0);
+      setErrorMessage(0 as ErrorMessageType);
     }
   }, [
     selectedSubsGroups,

--- a/packages/mco/components/modals/app-failover-relocate/subscriptions/subscription-group-selector.tsx
+++ b/packages/mco/components/modals/app-failover-relocate/subscriptions/subscription-group-selector.tsx
@@ -25,7 +25,7 @@ const validateDRPolicy = (
   drPolicyControlState: DRPolicyControlState,
   drPolicyName: string
 ) =>
-  drPolicyControlState.drPolicyControl?.spec?.drPolicyRef?.name ===
+  drPolicyControlState.drPlacementControl?.spec?.drPolicyRef?.name ===
   drPolicyName;
 
 const validateTargetCluster = (
@@ -63,11 +63,11 @@ const getOptions = (
   t: TFunction
 ) => (
   <SelectOption
-    key={getUID(drPolicyControlState?.drPolicyControl)}
-    value={getName(drPolicyControlState?.drPolicyControl)}
+    key={getUID(drPolicyControlState?.drPlacementControl)}
+    value={getName(drPolicyControlState?.drPlacementControl)}
     isChecked={isValid}
     isDisabled={!isValid}
-    data-test={`option-${getName(drPolicyControlState?.drPolicyControl)}`}
+    data-test={`option-${getName(drPolicyControlState?.drPlacementControl)}`}
   >
     {drPolicyControlState?.subscriptions.map((subName) => (
       <p key={subName}> {subName} </p>
@@ -133,12 +133,12 @@ export const SubscriptionGroupSelector: React.FC<SubscriptionGroupSelectorProps>
                 selectedTargetCluster?.clusterInfo
               );
               const isDRActionReady = checkDRActionReadiness(
-                drpcState?.drPolicyControl,
+                drpcState?.drPlacementControl,
                 actionType
               );
               isValidTargetCluster &&
                 isDRActionReady &&
-                validState.push(getName(drpcState.drPolicyControl));
+                validState.push(getName(drpcState.drPlacementControl));
               const option = getOptions(drpcState, isValidTargetCluster, t);
               return {
                 validOptions: getValidOptions(

--- a/packages/mco/components/modals/app-failover-relocate/subscriptions/target-cluster-selector.tsx
+++ b/packages/mco/components/modals/app-failover-relocate/subscriptions/target-cluster-selector.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { utcDateTimeFormatterWithTimeZone } from '@odf/shared/details-page/datetime';
-import { useDeepCompareMemoize } from '@odf/shared/hooks/deep-compare-memoize';
 import { getName, getNamespace } from '@odf/shared/selectors';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
-import { referenceForModel } from '@odf/shared/utils';
 import {
   GreenCheckCircleIcon,
   RedExclamationCircleIcon,
@@ -21,7 +19,10 @@ import {
 } from '@patternfly/react-core';
 import { UnknownIcon } from '@patternfly/react-icons';
 import { DRActionType, REPLICATION_TYPE } from '../../../../constants';
-import { ACMManagedClusterModel, DRClusterModel } from '../../../../models';
+import {
+  getDRClusterResourceObj,
+  getManagedClusterResourceObj,
+} from '../../../../hooks';
 import { ACMManagedClusterKind, DRClusterKind } from '../../../../types';
 import { ErrorMessageType } from './error-messages';
 import {
@@ -78,16 +79,8 @@ const TargetClusterStatus: React.FC<TargetClusterStatusProps> = ({
 };
 
 const resources = {
-  drClusters: {
-    kind: referenceForModel(DRClusterModel),
-    namespaced: false,
-    isList: true,
-  },
-  managedClusters: {
-    kind: referenceForModel(ACMManagedClusterModel),
-    namespaced: false,
-    isList: true,
-  },
+  drClusters: getDRClusterResourceObj(),
+  managedClusters: getManagedClusterResourceObj(),
 };
 
 export const TargetClusterSelector: React.FC<TargetClusterSelectorProps> = ({
@@ -98,24 +91,19 @@ export const TargetClusterSelector: React.FC<TargetClusterSelectorProps> = ({
   const response =
     useK8sWatchResources<TargetClusterWatchResourceType>(resources);
 
-  const memoizedDRClusters = useDeepCompareMemoize(response.drClusters, true);
-  const memoizedManagedClusters = useDeepCompareMemoize(
-    response.managedClusters,
-    true
-  );
-  const selectdDRPolicy = state.selectedDRPolicy;
+  const { selectedDRPolicy } = state;
 
   const {
     data: drClusters,
     loaded: drClustersLoaded,
     loadError: drClustersLoadError,
-  } = memoizedDRClusters;
+  } = response?.drClusters;
 
   const {
     data: managedClusters,
     loaded: managedClustersLoaded,
     loadError: managedClustersLoadError,
-  } = memoizedManagedClusters;
+  } = response?.managedClusters;
 
   const [isOpen, setOpen] = React.useState(false);
 
@@ -123,24 +111,24 @@ export const TargetClusterSelector: React.FC<TargetClusterSelectorProps> = ({
     () =>
       drClustersLoaded && !drClustersLoadError
         ? drClusters?.filter((drCluster) =>
-            selectdDRPolicy?.drClusters?.includes(getName(drCluster))
+            selectedDRPolicy?.drClusters?.includes(getName(drCluster))
           )
         : [],
-    [drClusters, drClustersLoaded, drClustersLoadError, selectdDRPolicy]
+    [drClusters, drClustersLoaded, drClustersLoadError, selectedDRPolicy]
   );
 
   const managedClusterList = React.useMemo(
     () =>
       managedClustersLoaded && !managedClustersLoadError
         ? managedClusters?.filter((managedCluster) =>
-            selectdDRPolicy?.drClusters?.includes(getName(managedCluster))
+            selectedDRPolicy?.drClusters?.includes(getName(managedCluster))
           )
         : [],
     [
       managedClusters,
       managedClustersLoaded,
       managedClustersLoadError,
-      selectdDRPolicy,
+      selectedDRPolicy,
     ]
   );
 

--- a/packages/mco/components/modals/drpolicy-apps-apply/subscriptions/application-selector.tsx
+++ b/packages/mco/components/modals/drpolicy-apps-apply/subscriptions/application-selector.tsx
@@ -13,7 +13,7 @@ import {
   SearchInput,
   Bullseye,
 } from '@patternfly/react-core';
-import { AppToPlacementRule } from '../../../../types';
+import { AppToPlacementType } from '../../../../types';
 import './application-selector.scss';
 
 type TreeViewDataItemMap = {
@@ -26,7 +26,7 @@ type BadgeProps = {
 };
 
 type ApplicationSelectorProps = {
-  applicationToPlacementRuleMap: AppToPlacementRule;
+  applicationToPlacementMap: AppToPlacementType;
   selectedNames: TreeViewDataItemMap;
   setSelectedNames: React.Dispatch<React.SetStateAction<TreeViewDataItemMap>>;
 };
@@ -125,8 +125,7 @@ const filterOptions = (option: TreeViewDataItem, searchValue: string) =>
 export const ApplicationSelector: React.FC<ApplicationSelectorProps> = (
   props
 ) => {
-  const { applicationToPlacementRuleMap, selectedNames, setSelectedNames } =
-    props;
+  const { applicationToPlacementMap, selectedNames, setSelectedNames } = props;
 
   const { t } = useCustomTranslation();
   const [options, setOptions] = React.useState<TreeViewDataItem[]>([]);
@@ -137,33 +136,31 @@ export const ApplicationSelector: React.FC<ApplicationSelectorProps> = (
 
   React.useEffect(() => {
     const tempItem: TreeViewDataItem[] = [];
-    Object.keys(applicationToPlacementRuleMap).forEach((appUniqueName) => {
+    Object.keys(applicationToPlacementMap).forEach((appUniqueName) => {
       const childerns: TreeViewDataItem[] = [];
-      Object.keys(
-        applicationToPlacementRuleMap[appUniqueName]?.placements
-      ).forEach((placementUniqueName) => {
-        const placementName =
-          applicationToPlacementRuleMap[appUniqueName].placements[
-            placementUniqueName
-          ];
-        const { subscriptions, placementRules } = placementName || {};
-        const subNames = subscriptions?.map(getName);
-        childerns.push({
-          name: (
-            <Badge
-              subNames={subNames}
-              plsRule={getName(placementRules)}
-              key={getName(placementRules)}
-            />
-          ),
-          id: `${appUniqueName}:${placementUniqueName}`,
-          checkProps: { checked: false },
-        });
-      });
+      Object.keys(applicationToPlacementMap[appUniqueName]?.placements).forEach(
+        (placementUniqueName) => {
+          const placementName =
+            applicationToPlacementMap[appUniqueName].placements[
+              placementUniqueName
+            ];
+          const { subscriptions, placement } = placementName || {};
+          const subNames = subscriptions?.map(getName);
+          childerns.push({
+            name: (
+              <Badge
+                subNames={subNames}
+                plsRule={getName(placement)}
+                key={getName(placement)}
+              />
+            ),
+            id: `${appUniqueName}:${placementUniqueName}`,
+            checkProps: { checked: false },
+          });
+        }
+      );
       tempItem.push({
-        name: getName(
-          applicationToPlacementRuleMap?.[appUniqueName]?.application
-        ),
+        name: getName(applicationToPlacementMap?.[appUniqueName]?.application),
         id: appUniqueName,
         checkProps: { checked: false },
         children: childerns,
@@ -171,7 +168,7 @@ export const ApplicationSelector: React.FC<ApplicationSelectorProps> = (
       });
       setOptions(tempItem);
     });
-  }, [applicationToPlacementRuleMap]);
+  }, [applicationToPlacementMap]);
 
   React.useEffect(() => {
     searchAppName === '' && setFilteredOptions(options);

--- a/packages/mco/hooks/applications-hook.ts
+++ b/packages/mco/hooks/applications-hook.ts
@@ -5,7 +5,7 @@ import {
   ObjectReference,
   useK8sWatchResources,
 } from '@openshift-console/dynamic-plugin-sdk';
-import { ACMPlacementModel, ACMPlacementRuleModel } from '../models';
+import { ACMPlacementModel } from '../models';
 import {
   ACMSubscriptionKind,
   ArgoApplicationSetKind,
@@ -63,20 +63,19 @@ const createSubsApplicationReferences = (
     applications?.forEach((application) => {
       const namespace = getNamespace(application);
       const filteredSubs = filterSubsUsingApplication(subsMapping, application);
-      const placementRuleRefs: ObjectReference[] = filteredSubs?.map((sub) => ({
-        apiVersion: `${ACMPlacementRuleModel.apiGroup}/${ACMPlacementRuleModel.apiVersion}`,
-        kind: ACMPlacementRuleModel.kind,
+      const placementRefs: ObjectReference[] = filteredSubs?.map((sub) => ({
+        kind: sub?.spec?.placement?.placementRef?.kind,
         name: sub?.spec?.placement?.placementRef?.name,
         namespace,
       }));
-      applicationRefs = !!placementRuleRefs?.length
+      applicationRefs = !!placementRefs?.length
         ? [
             ...applicationRefs,
             {
               applicationName: getName(application),
               applicationNamespace: namespace,
               applicationType: SubscriptionType,
-              placementRef: placementRuleRefs,
+              placementRef: placementRefs,
               workLoadNamespace: namespace,
             },
           ]
@@ -102,7 +101,6 @@ const createApplicationSetReferences = (
           applicationType: ApplicaitonSetType,
           placementRef: [
             {
-              apiVersion: `${ACMPlacementModel.apiGroup}/${ACMPlacementModel.apiVersion}`,
               kind: ACMPlacementModel.kind,
               name: findPlacementNameFromAppSet(application),
               namespace,

--- a/packages/mco/hooks/mco-resources.ts
+++ b/packages/mco/hooks/mco-resources.ts
@@ -5,6 +5,7 @@ import {
   ACMManagedClusterModel,
   ACMPlacementDecisionModel,
   ACMPlacementModel,
+  ACMPlacementRuleModel,
   ACMSubscriptionModel,
   ArgoApplicationSetModel,
   DRClusterModel,
@@ -80,6 +81,16 @@ export const getPlacementDecisionsResourceObj = (
   ...(!!props?.name ? { name: props?.name } : {}),
   ...(!!props?.namespace ? { namespace: props?.namespace } : {}),
   kind: referenceForModel(ACMPlacementDecisionModel),
+  ...(!props?.name ? { isList: true } : {}),
+  namespaced: !!props?.namespace ? true : false,
+  optional: true,
+});
+
+export const getPlacementRuleResourceObj = (props?: NamespacedObjectType) => ({
+  cluster: HUB_CLUSTER_NAME,
+  ...(!!props?.name ? { name: props?.name } : {}),
+  ...(!!props?.namespace ? { namespace: props?.namespace } : {}),
+  kind: referenceForModel(ACMPlacementRuleModel),
   ...(!props?.name ? { isList: true } : {}),
   namespaced: !!props?.namespace ? true : false,
   optional: true,

--- a/packages/mco/types/acm.ts
+++ b/packages/mco/types/acm.ts
@@ -77,15 +77,20 @@ export type ACMPlacementDecisionKind = K8sResourceCommon & {
   };
 };
 
-export type AppToPlacementRule = {
+export type ACMPlacementType = ACMPlacementRuleKind | ACMPlacementKind;
+
+export type PlacementInfoType = {
+  [placementUniqueKey: string]: {
+    placement: ACMPlacementType;
+    subscriptions: ACMSubscriptionKind[];
+    deploymentClusterName: string;
+  };
+};
+
+export type AppToPlacementType = {
   [appUniqueKey: string]: {
     application: ApplicationKind;
-    placements: {
-      [placementUniqueKey: string]: {
-        placementRules: ACMPlacementRuleKind;
-        subscriptions: ACMSubscriptionKind[];
-      };
-    };
+    placements: PlacementInfoType;
   };
 };
 


### PR DESCRIPTION
Upto ACM 2.7, Subscription application type using **PlacementRule** to decide the deployment cluster. But from ACM 2.8, the ACM console is made **Placement** as the default type, and supports **PlacementRule** only from CLI for backward compatibility. ACM decided to extend the backward-compatible support up to ACM 2.10.

DR UI is only supporting **PlacementRule** for subscription applications, It is unable to detect any application which is created using **Placement**.  The task is to support both **Placement** as well as **PlacementRule** for the subscription applications. (BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2196236)
