### PR TITLE
Fix cant initiate failover of applicationSet based apps after hub recovery

### DIFF
--- a/packages/mco/components/modals/app-failover-relocate/argo-application-set.tsx
+++ b/packages/mco/components/modals/app-failover-relocate/argo-application-set.tsx
@@ -97,7 +97,11 @@ export const ArogoApplicationSetModal = (
       placementDecision,
       placement,
     } = resourcePlacements?.[0] || {};
-    const deploymentClusterName = findDeploymentClusterName(placementDecision);
+    let deploymentClusterName = findDeploymentClusterName(
+      placementDecision,
+      drPlacementControl,
+      drClusters
+    );
     const targetCluster = findCluster(managedClusters, deploymentClusterName);
     const primaryCluster = findCluster(
       managedClusters,

--- a/packages/mco/components/modals/app-failover-relocate/failover-relocate-modal-body.tsx
+++ b/packages/mco/components/modals/app-failover-relocate/failover-relocate-modal-body.tsx
@@ -156,28 +156,17 @@ const DateTimeFormat = ({
   );
 };
 
-const DRActionReadiness = ({
-  isDRActionReady,
-}: {
-  isDRActionReady: boolean;
-}) => {
+const DRActionReadiness = ({ canInitiate }: { canInitiate: boolean }) => {
   const { t } = useCustomTranslation();
   return (
     <>
-      {isDRActionReady !== undefined ? (
-        isDRActionReady ? (
-          <StatusIconAndText
-            title={t('Ready')}
-            icon={<GreenCheckCircleIcon />}
-          />
-        ) : (
-          <StatusIconAndText
-            title={t('Not ready')}
-            icon={<RedExclamationCircleIcon />}
-          />
-        )
+      {canInitiate ? (
+        <StatusIconAndText title={t('Ready')} icon={<GreenCheckCircleIcon />} />
       ) : (
-        <StatusIconAndText title={t('Unknown')} icon={<UnknownIcon />} />
+        <StatusIconAndText
+          title={t('Not ready')}
+          icon={<RedExclamationCircleIcon />}
+        />
       )}
     </>
   );
@@ -189,6 +178,7 @@ export const FailoverRelocateModalBody: React.FC<FailoverRelocateModalBodyProps>
     const {
       action,
       applicationName,
+      canInitiate,
       setCanInitiate,
       setPlacement,
       placements,
@@ -276,7 +266,7 @@ export const FailoverRelocateModalBody: React.FC<FailoverRelocateModalBodyProps>
             </strong>
           </FlexItem>
           <FlexItem>
-            <DRActionReadiness isDRActionReady={placement?.isDRActionReady} />
+            <DRActionReadiness canInitiate={canInitiate} />
           </FlexItem>
         </Flex>
         {placement?.replicationType === REPLICATION_TYPE.ASYNC && (
@@ -331,6 +321,7 @@ export type ApplicationProps = {
 };
 
 export type FailoverRelocateModalBodyProps = ApplicationProps & {
+  canInitiate: boolean;
   setCanInitiate: React.Dispatch<React.SetStateAction<boolean>>;
   setPlacement: React.Dispatch<React.SetStateAction<PlacementProps>>;
 };

--- a/packages/mco/components/modals/app-failover-relocate/failover-relocate-modal.tsx
+++ b/packages/mco/components/modals/app-failover-relocate/failover-relocate-modal.tsx
@@ -102,6 +102,7 @@ export const FailoverRelocateModal: React.FC<FailoverRelocateModalProps> = (
       <ModalBody>
         <FailoverRelocateModalBody
           {...props}
+          canInitiate={canInitiate}
           setCanInitiate={setCanInitiate}
           setPlacement={setPlacement}
         />

--- a/packages/mco/utils/acm.ts
+++ b/packages/mco/utils/acm.ts
@@ -1,4 +1,4 @@
-import { getName, getNamespace } from '@odf/shared/selectors';
+import { getLabel, getName, getNamespace } from '@odf/shared/selectors';
 import { PLACEMENT_REF_LABEL } from '../constants';
 import {
   ArgoApplicationSetKind,
@@ -18,19 +18,12 @@ export const findPlacementDecisionUsingPlacement = (
   placement: ACMPlacementKind,
   placementDecisions: ACMPlacementDecisionKind[]
 ) =>
-  placementDecisions?.find((placementDecision) =>
-    placementDecision?.metadata?.ownerReferences?.find(
-      (ownerReference) =>
-        placement?.metadata?.uid === ownerReference?.uid &&
-        getNamespace(placementDecision) === getNamespace(placement)
-    )
+  placementDecisions?.find(
+    (placementDecision) =>
+      getLabel(placementDecision, PLACEMENT_REF_LABEL, '') ===
+        getName(placement) &&
+      getNamespace(placementDecision) === getNamespace(placement)
   );
-
-export const findDeploymentClusterName = (
-  placementDecision: ACMPlacementDecisionKind
-): string => {
-  return placementDecision?.status?.decisions?.[0]?.clusterName || '';
-};
 
 export const getManagedClusterAvailableCondition = (
   managedCluster: ACMManagedClusterKind

--- a/packages/mco/utils/disaster-recovery.tsx
+++ b/packages/mco/utils/disaster-recovery.tsx
@@ -54,6 +54,7 @@ import {
   DRVolumeReplicationGroupKind,
   ProtectedPVCData,
   ProtectedAppSetsMap,
+  ACMPlacementDecisionKind,
 } from '../types';
 
 export type PlacementRuleMap = {
@@ -244,13 +245,13 @@ export const checkDRActionReadiness = (
 
 export const findCluster = (
   clusters: K8sResourceCommon[],
-  deploymentClusterName: string,
-  isDeploymentCluster = false
+  matchClusterName: string,
+  matchCluster = false
 ) =>
   clusters?.find((cluster) =>
-    isDeploymentCluster
-      ? getName(cluster) === deploymentClusterName
-      : getName(cluster) !== deploymentClusterName
+    matchCluster
+      ? getName(cluster) === matchClusterName
+      : getName(cluster) !== matchClusterName
   );
 
 export const findDRType = (drClusters: DRClusterKind[]) =>
@@ -488,3 +489,28 @@ export const filterPVCDataUsingAppsets = (
 
 export const filterDRAlerts = (alert: Alert) =>
   alert?.annotations?.alert_type === 'DisasterRecovery';
+
+export const findDeploymentClusterName = (
+  plsDecision: ACMPlacementDecisionKind,
+  drpc: DRPlacementControlKind,
+  drClusters: DRClusterKind[]
+): string => {
+  let deploymentClusterName =
+    plsDecision?.status?.decisions?.[0]?.clusterName || '';
+  // During failover/relocating ramen removing cluser name from placement decision
+  if (!deploymentClusterName) {
+    const currStatus: DRPC_STATUS = drpc?.status?.phase as DRPC_STATUS;
+    if (currStatus === DRPC_STATUS.Relocating) {
+      // While relocating, preferredCluster spec is the target cluster
+      // Find deployment cluster from drclusters using target cluster
+      const cluster = findCluster(drClusters, drpc?.spec?.preferredCluster);
+      deploymentClusterName = getName(cluster);
+    } else if (currStatus === DRPC_STATUS.FailingOver) {
+      // While failover, failoverCluster spec is the target cluster
+      // Find deployment cluster from drclusters using target cluster
+      const cluster = findCluster(drClusters, drpc?.spec?.failoverCluster);
+      deploymentClusterName = getName(cluster);
+    }
+  }
+  return deploymentClusterName;
+};


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2209288

Fix explanation:
  1. Earlier, Failover/Relocate component is using placement ownerRef to match placement and its placement decision.  It is failing in some cases. So Switching to label-based matching.
  
Other errors observed from QE setup once after fixing the above one:
  2. Failover/Relocation readiness text in UI should not rely only on DRPC peer-ready conditions and available conditions. It is common for all errors, So if any error occurs the readiness should display  "Not Ready".
  3. While Failing/Relocating ramen is removing the cluster name from the placement rule, and adding it back once the failover/relocation operation is completed.  In between if the cluster went down, and if a user wants to trigger Failover, Then UI is unable to find out the target cluster and deployment cluster.
  The fix is, Find the deployment cluster name from DRPC, which is only possible at the time of failover and relocation operation is ongoing.
  - If the status is in the FailingOver state then the target cluster can be found using failoverCluster spec from DRPC.
  - If the status is in the Relocating state then the target cluster can be found using preferedCluster spec from DRPC.
  - If a target cluster is found then finding a deployment cluster is possible using the list of DR Clusters.
    