### PR TITLE
Genric DR hook to handle different cases

### DIFF
--- a/packages/mco/components/disaster-recovery/drpolicy-list-page/drpolicy-list-page.tsx
+++ b/packages/mco/components/disaster-recovery/drpolicy-list-page/drpolicy-list-page.tsx
@@ -23,13 +23,9 @@ import {
 import { Trans } from 'react-i18next';
 import { useHistory, useLocation } from 'react-router';
 import { HUB_CLUSTER_NAME } from '../../../constants';
-import {
-  ApplicationRefKind,
-  getDRPolicyResourceObj,
-  useApplicationsWatch,
-} from '../../../hooks';
+import { getDRPolicyResourceObj, useApplicationsWatch } from '../../../hooks';
 import { DRPolicyModel } from '../../../models';
-import { DRPolicyKind } from '../../../types';
+import { DRPolicyKind, ApplicationRefKind } from '../../../types';
 import { getReplicationType, findAppsUsingDRPolicy } from '../../../utils';
 import EmptyPage from '../../empty-state-page/empty-page';
 import { ConnectedApplicationsModal } from '../../modals/connected-apps-modal/connected-apps-modal';

--- a/packages/mco/components/modals/connected-apps-modal/connected-apps-modal.tsx
+++ b/packages/mco/components/modals/connected-apps-modal/connected-apps-modal.tsx
@@ -24,7 +24,7 @@ import {
   Thead,
   ThProps,
 } from '@patternfly/react-table';
-import { ApplicationRefKind } from '../../../hooks/applications-hook';
+import { ApplicationRefKind } from '../../../types';
 import './connected-apps-modal.scss';
 
 const reactPropFix = {

--- a/packages/mco/hooks/applications-hook.ts
+++ b/packages/mco/hooks/applications-hook.ts
@@ -10,6 +10,7 @@ import {
   ACMSubscriptionKind,
   ArgoApplicationSetKind,
   DRPlacementControlKind,
+  ApplicationRefKind,
 } from '../types';
 import {
   matchApplicationToSubscription,
@@ -221,13 +222,4 @@ type UseApplicationsWatch = () => [ApplicationRefKind[], boolean, any];
 
 type SubcsriptionMapping = {
   [namespace in string]: ACMSubscriptionKind[];
-};
-
-export type ApplicationRefKind = {
-  applicationName: string;
-  applicationNamespace: string;
-  applicationType: string;
-  workLoadNamespace: string;
-  drPolicyRefs?: string[];
-  placementRef?: ObjectReference[];
 };

--- a/packages/mco/hooks/argo-application-set.ts
+++ b/packages/mco/hooks/argo-application-set.ts
@@ -1,216 +1,155 @@
+/* To find ApplicationSet's DR hierarchy*/
+
 import * as React from 'react';
 import { getName, getNamespace } from '@odf/shared/selectors';
-import {
-  useK8sWatchResources,
-  WatchK8sResource,
-  WatchK8sResultsObject,
-} from '@openshift-console/dynamic-plugin-sdk';
+import { WatchK8sResultsObject } from '@openshift-console/dynamic-plugin-sdk';
 import {
   ArgoApplicationSetKind,
   ACMPlacementDecisionKind,
   ACMPlacementKind,
-  ACMManagedClusterKind,
-  DRPlacementControlKind,
-  DRPolicyKind,
-  DRClusterKind,
+  ApplicationResourceType,
 } from '../types';
 import {
   findSiblingArgoAppSetsFromPlacement,
   findPlacementFromArgoAppSet,
   findPlacementDecisionUsingPlacement,
   findDRResourceUsingPlacement,
-  filerManagedClusterUsingDRClusters,
 } from '../utils';
-import { DisasterRecoveryResourceKind } from './disaster-recovery';
-import {
-  getApplicationSetResourceObj,
-  getManagedClusterResourceObj,
-  getPlacementDecisionsResourceObj,
-  getPlacementResourceObj,
-} from './mco-resources';
+import { DRParserResultsType } from './disaster-recovery';
 
-const getResources = () => ({
-  managedClusters: getManagedClusterResourceObj(),
-  applications: getApplicationSetResourceObj(),
-  placements: getPlacementResourceObj(),
-  placementDecisions: getPlacementDecisionsResourceObj(),
-});
+export const useArgoAppSetResourceParser: UseArgoAppSetResourceParserType = (
+  props
+) => {
+  const {
+    data: placements,
+    loaded: placementsLoaded,
+    loadError: placementsLoadError,
+  } = props?.resources?.placements || {};
 
-export const useArgoApplicationSetResourceWatch: UseArgoApplicationSetResourceWatch =
-  (resource) => {
-    const response = useK8sWatchResources<WatchResourceType>(
-      resource?.resources || getResources()
-    );
+  const {
+    data: placementDecisions,
+    loaded: placementDecisionsLoaded,
+    loadError: placementDecisionsLoadError,
+  } = props?.resources?.placementDecisions || {};
 
-    const {
-      data: placements,
-      loaded: placementsLoaded,
-      loadError: placementsLoadError,
-    } = response?.placements || resource?.overrides?.placements || {};
+  const {
+    data: applications,
+    loaded: applicationsLoaded,
+    loadError: applicationsLoadError,
+  } = props?.resources?.applications || {};
 
-    const {
-      data: placementDecisions,
-      loaded: placementDecisionsLoaded,
-      loadError: placementDecisionsLoadError,
-    } = response?.placementDecisions ||
-    resource?.overrides?.placementDecisions ||
-    {};
+  const {
+    data: drResources,
+    loaded: drLoaded,
+    loadError: drLoadError,
+  } = props?.resources?.drResources || {};
 
-    const {
-      data: applications,
-      loaded: applicationsLoaded,
-      loadError: applicationsLoadError,
-    } = response?.applications || resource?.overrides?.applications || {};
+  const filterByAppName = props?.conditions?.filterByAppName;
 
-    const {
-      data: managedClusters,
-      loaded: managedClustersLoaded,
-      loadError: managedClustersLoadedError,
-    } = response?.managedClusters || resource?.overrides?.managedClusters || {};
+  const loaded =
+    placementsLoaded &&
+    placementDecisionsLoaded &&
+    applicationsLoaded &&
+    drLoaded;
 
-    const {
-      data: drResources,
-      loaded: drLoaded,
-      loadError: drLoadError,
-    } = resource?.drResources || {};
+  const loadError =
+    placementsLoadError ||
+    placementDecisionsLoadError ||
+    applicationsLoadError ||
+    drLoadError;
 
-    const filterByAppName = resource?.conditions?.filterByAppName;
-
-    const loaded =
-      placementsLoaded &&
-      placementDecisionsLoaded &&
-      applicationsLoaded &&
-      managedClustersLoaded &&
-      drLoaded;
-
-    const loadError =
-      placementsLoadError ||
-      placementDecisionsLoadError ||
-      applicationsLoadError ||
-      managedClustersLoadedError ||
-      drLoadError;
-
-    return React.useMemo(() => {
-      let argoApplicationSetResources: ArgoApplicationSetResourceKind = {};
-      const argoApplicationSetFormatted: ArgoApplicationSetFormattedKind[] = [];
-      if (loaded && !loadError) {
-        const appList = Array.isArray(applications)
-          ? applications
-          : [applications];
-        const placementList = Array.isArray(placements)
-          ? placements
-          : [placements];
-        const placementDecisionList = Array.isArray(placementDecisions)
-          ? placementDecisions
-          : [placementDecisions];
-        const managedClusterList = Array.isArray(managedClusters)
-          ? managedClusters
-          : [managedClusters];
-        appList.forEach((application) => {
-          if (!filterByAppName || getName(application) === filterByAppName) {
-            // For now ACM is supporting one placement per ApplicationSet
-            const placement = findPlacementFromArgoAppSet(
-              placementList,
-              application
-            );
-            const drResource = findDRResourceUsingPlacement(
-              getName(placement),
-              getNamespace(placement),
-              drResources?.formattedResources
-            );
-            argoApplicationSetFormatted.push({
+  return React.useMemo(() => {
+    let argoAppSetResources: ApplicationResourceType[] = [];
+    if (loaded && !loadError) {
+      const appList = Array.isArray(applications)
+        ? applications
+        : [applications];
+      const placementList = Array.isArray(placements)
+        ? placements
+        : [placements];
+      const placementDecisionList = Array.isArray(placementDecisions)
+        ? placementDecisions
+        : [placementDecisions];
+      appList.forEach((application) => {
+        if (!filterByAppName || getName(application) === filterByAppName) {
+          // For now ACM is supporting one placement per ApplicationSet
+          const placement = findPlacementFromArgoAppSet(
+            placementList,
+            application
+          );
+          const drResource = findDRResourceUsingPlacement(
+            getName(placement),
+            getNamespace(placement),
+            drResources
+          );
+          argoAppSetResources.push({
+            applicationInfo: {
               application,
-              placements: [
+              deploymentInfo: [
                 {
-                  placement,
-                  placementDecision: findPlacementDecisionUsingPlacement(
+                  placementInfo: {
                     placement,
-                    placementDecisionList
-                  ),
-                  drPolicy: drResource?.drPolicy,
-                  drClusters: drResource?.drClusters,
-                  drPlacementControl: drResource?.drPlacementControls?.[0],
+                    placementDecision: findPlacementDecisionUsingPlacement(
+                      placement,
+                      placementDecisionList
+                    ),
+                  },
+                  drInfo: {
+                    drPolicy: drResource?.drPolicy,
+                    drClusters: drResource?.drClusters,
+                    drPlacementControl: drResource?.drPlacementControls?.[0],
+                  },
                 },
               ],
-              siblingApplications: findSiblingArgoAppSetsFromPlacement(
-                filterByAppName,
-                placement,
-                appList
-              ),
-              managedClusters: filerManagedClusterUsingDRClusters(
-                drResource?.drClusters,
-                managedClusterList
-              ),
-            });
-          }
-        });
-        argoApplicationSetResources = {
-          formattedResources: argoApplicationSetFormatted,
-          managedClusters: managedClusterList,
-        };
-      }
+            },
+            siblingApplications: findSiblingArgoAppSetsFromPlacement(
+              filterByAppName,
+              placement,
+              appList
+            ),
+          });
+        }
+      });
+    }
 
-      return [argoApplicationSetResources, loaded, loadError];
-    }, [
-      applications,
-      placements,
-      placementDecisions,
-      drResources,
-      managedClusters,
-      filterByAppName,
+    return {
+      data: argoAppSetResources,
       loaded,
       loadError,
-    ]);
-  };
-
-type WatchResourceType = {
-  applications?: ArgoApplicationSetKind | ArgoApplicationSetKind[];
-  placements?: ACMPlacementKind | ACMPlacementKind[];
-  placementDecisions?: ACMPlacementDecisionKind | ACMPlacementDecisionKind[];
-  managedClusters?: ACMManagedClusterKind | ACMManagedClusterKind[];
+    };
+  }, [
+    applications,
+    placements,
+    placementDecisions,
+    drResources,
+    filterByAppName,
+    loaded,
+    loadError,
+  ]);
 };
 
-type WatchResources = {
+type ParserResources = {
   resources?: {
-    applications?: WatchK8sResource;
-    placements?: WatchK8sResource;
-    placementDecisions?: WatchK8sResource;
-    managedClusters?: WatchK8sResource;
+    applications?: WatchK8sResultsObject<
+      ArgoApplicationSetKind | ArgoApplicationSetKind[]
+    >;
+    placements?: WatchK8sResultsObject<ACMPlacementKind | ACMPlacementKind[]>;
+    placementDecisions?: WatchK8sResultsObject<
+      ACMPlacementDecisionKind | ACMPlacementDecisionKind[]
+    >;
+    drResources?: DRParserResultsType;
   };
   conditions?: {
     filterByAppName: string;
   };
-  overrides?: {
-    applications?: WatchK8sResultsObject<ArgoApplicationSetKind>;
-    placements?: WatchK8sResultsObject<ACMPlacementKind>;
-    placementDecisions?: WatchK8sResultsObject<ACMPlacementDecisionKind>;
-    managedClusters?: WatchK8sResultsObject<ACMManagedClusterKind>;
-  };
-  drResources?: {
-    data: DisasterRecoveryResourceKind;
-    loaded: boolean;
-    loadError: any;
-  };
 };
 
-export type UseArgoApplicationSetResourceWatch = (
-  resource?: WatchResources
-) => [ArgoApplicationSetResourceKind, boolean, any];
-
-export type ArgoApplicationSetFormattedKind = {
-  application: ArgoApplicationSetKind;
-  placements: {
-    placement: ACMPlacementKind;
-    placementDecision: ACMPlacementDecisionKind;
-    drPlacementControl: DRPlacementControlKind;
-    drPolicy: DRPolicyKind;
-    drClusters: DRClusterKind[];
-  }[];
-  siblingApplications: ArgoApplicationSetKind[];
-  managedClusters: ACMManagedClusterKind[];
+type ArgoAppSetParserResultsType = {
+  data: ApplicationResourceType[];
+  loaded: boolean;
+  loadError: any;
 };
 
-export type ArgoApplicationSetResourceKind = {
-  formattedResources?: ArgoApplicationSetFormattedKind[];
-  managedClusters?: ACMManagedClusterKind[];
-};
+export type UseArgoAppSetResourceParserType = (
+  resource?: ParserResources
+) => ArgoAppSetParserResultsType;

--- a/packages/mco/types/hooks.ts
+++ b/packages/mco/types/hooks.ts
@@ -1,0 +1,64 @@
+import { ObjectReference } from '@openshift-console/dynamic-plugin-sdk';
+import {
+  ACMApplicationKind,
+  ACMPlacementDecisionKind,
+  ACMPlacementKind,
+} from './acm';
+import { ArgoApplicationSetKind } from './argo-cd';
+import { DRClusterKind, DRPlacementControlKind, DRPolicyKind } from './ramen';
+
+export type AppDeploymentProps = {
+  placementInfo: {
+    placement: ACMPlacementKind;
+    placementDecision: ACMPlacementDecisionKind;
+  };
+  drInfo: {
+    drPolicy?: DRPolicyKind;
+    drClusters?: DRClusterKind[];
+    drPlacementControl?: DRPlacementControlKind;
+  };
+};
+
+export type ApplicationProps = {
+  application: ACMApplicationKind;
+  deploymentInfo: AppDeploymentProps[];
+};
+
+// Common application parser result type
+export type ApplicationResourceType = {
+  applicationInfo: ApplicationProps;
+  siblingApplications: ACMApplicationKind[];
+};
+
+export type DRResourceType = {
+  drPolicy?: DRPolicyKind;
+  drClusters?: DRClusterKind[];
+  drPlacementControls?: DRPlacementControlKind[];
+};
+
+export type ApplicationRefKind = {
+  applicationName: string;
+  applicationNamespace: string;
+  applicationType: string;
+  workLoadNamespace: string;
+  drPolicyRefs?: string[];
+  placementRef?: ObjectReference[];
+};
+
+// Common watch type for dr resources
+export type WatchDRResourceType = {
+  drPolicies: DRPolicyKind[];
+  drClusters: DRClusterKind[];
+  drPlacementControls: DRPlacementControlKind[];
+};
+
+// Common watch type for placements
+export type WatchPlacementResourceType = {
+  placements: ACMPlacementKind[];
+  placementDecisions: ACMPlacementDecisionKind[];
+};
+
+// Common watch type for argo app sets
+export type WatchArgoAppSetResourceType = WatchPlacementResourceType & {
+  applications: ArgoApplicationSetKind[];
+};

--- a/packages/mco/types/index.ts
+++ b/packages/mco/types/index.ts
@@ -3,3 +3,4 @@ export * from './acm';
 export * from './odf-mco';
 export * from './argo-cd';
 export * from './dashboard';
+export * from './hooks';

--- a/packages/mco/utils/disaster-recovery.tsx
+++ b/packages/mco/utils/disaster-recovery.tsx
@@ -37,7 +37,6 @@ import {
   TIME_UNITS,
   PROTECTED_APP_ANNOTATION,
 } from '../constants/disaster-recovery';
-import { DisasterRecoveryFormatted, ApplicationRefKind } from '../hooks';
 import {
   ACMPlacementModel,
   ACMPlacementRuleModel,
@@ -57,6 +56,8 @@ import {
   ProtectedAppSetsMap,
   ACMPlacementDecisionKind,
   ACMPlacementKind,
+  ApplicationRefKind,
+  DRResourceType,
 } from '../types';
 import { findPlacementDecisionUsingPlacement } from './acm';
 
@@ -280,9 +281,9 @@ export const findDRType = (drClusters: DRClusterKind[]) =>
 export const findDRResourceUsingPlacement = (
   placementName: string,
   workloadNamespace: string,
-  drResources: DisasterRecoveryFormatted[]
-): DisasterRecoveryFormatted => {
-  let result: DisasterRecoveryFormatted = {};
+  drResources: DRResourceType[]
+): DRResourceType => {
+  let result: DRResourceType = {};
   drResources?.forEach((drResource) => {
     const drpc = drResource?.drPlacementControls?.find((drpc) => {
       const placementRef = drpc.spec?.placementRef;


### PR DESCRIPTION
1. Moved watcher logic out of ACM and DR resource parse logic, Now parser is generic to handle watcher as well as get.
2. Optimized placement decision fetch from the application-related page by using placement label.
3.  Tuned parser types to reuse in multiple places.