### PR TITLE
Bump core sdk + update "odf.dashboard/tab" extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "memsource-download": "./scripts/i18n/memsource-download.sh"
   },
   "dependencies": {
-    "@openshift-console/dynamic-plugin-sdk": "0.0.15",
+    "@openshift-console/dynamic-plugin-sdk": "0.0.19",
     "@openshift-console/dynamic-plugin-sdk-internal": "0.0.7",
     "@openshift-console/dynamic-plugin-sdk-webpack": "0.0.6",
     "@openshift-console/plugin-shared": "^0.0.1",

--- a/packages/odf-plugin-sdk/extensions/horizontal-nav-tab.ts
+++ b/packages/odf-plugin-sdk/extensions/horizontal-nav-tab.ts
@@ -6,11 +6,13 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk/lib/types';
 import { RouteComponentProps } from 'react-router';
 
-export type DashboardTabExtensionProps = {
+export type HorizontalNavTabExtensionProps = {
   /** Unique string to identify the tab */
   id: string;
   /** Name of the tab */
   name: string;
+  /** Context ID according to which tab will be injected to a particular page. */
+  contextId: string;
   /** ID of the tab before which this should be placed */
   before?: string;
   /** ID of the tab after which this should be placecd */
@@ -21,10 +23,12 @@ export type DashboardTabExtensionProps = {
   component: CodeRef<React.ComponentType<RouteComponentProps>>;
 };
 
-export type DashboardTab = ExtensionDeclaration<
-  'odf.dashboard/tab',
-  DashboardTabExtensionProps
+export type HorizontalNavTab = ExtensionDeclaration<
+  'odf.horizontalNav/tab',
+  HorizontalNavTabExtensionProps
 >;
 
-export const isDashboardTab = (e: Extension): e is DashboardTab =>
-  e.type === 'odf.dashboard/tab';
+export const isHorizontalNavTab =
+  (contextId: string) =>
+  (e: Extension): e is HorizontalNavTab =>
+    e.type === 'odf.horizontalNav/tab' && e.properties.contextId === contextId;

--- a/packages/odf-plugin-sdk/extensions/index.ts
+++ b/packages/odf-plugin-sdk/extensions/index.ts
@@ -1,2 +1,2 @@
-export * from './dashboard';
+export * from './horizontal-nav-tab';
 export * from './external-storage/external-storage';

--- a/packages/odf/components/odf-dashboard/dashboard.tsx
+++ b/packages/odf/components/odf-dashboard/dashboard.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import {
-  DashboardTab,
-  DashboardTabExtensionProps as UnresolvedTabProps,
-  isDashboardTab,
+  HorizontalNavTab,
+  HorizontalNavTabExtensionProps as UnresolvedTabProps,
+  isHorizontalNavTab,
 } from '@odf/odf-plugin-sdk/extensions';
 import PageHeading from '@odf/shared/heading/page-heading';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
@@ -25,6 +25,8 @@ import { StatusCard } from './status-card/status-card';
 import SystemCapacityCard from './system-capacity-card/capacity-card';
 import { convertDashboardTabToNav, sortPages } from './utils';
 import './dashboard.scss';
+
+const CONTEXT_ID = 'odf-dashboard';
 
 type ODFDashboardPageProps = {
   history: RouteComponentProps['history'];
@@ -71,17 +73,21 @@ const ODFDashboardPage: React.FC<ODFDashboardPageProps> = (props) => {
       href: '',
       name: t('Overview'),
       component: ODFDashboard,
+      contextId: CONTEXT_ID,
     },
     {
       id: 'systems',
       href: 'systems',
       name: t('Storage Systems'),
       component: StorageSystemListPage,
+      contextId: CONTEXT_ID,
     },
   ]);
 
+  const isTab = React.useMemo(() => isHorizontalNavTab(CONTEXT_ID), []);
+
   const [extensions, isLoaded, error] =
-    useResolvedExtensions<DashboardTab>(isDashboardTab);
+    useResolvedExtensions<HorizontalNavTab>(isTab);
 
   React.useEffect(() => {
     const updatedPages = [...pages];
@@ -98,6 +104,7 @@ const ODFDashboardPage: React.FC<ODFDashboardPageProps> = (props) => {
             href: extension.properties.href,
             name: extension.properties.name,
             component: extension.properties.component,
+            contextId: extension.properties.contextId,
             before: extension.properties.before,
             after: extension.properties.after,
           };

--- a/packages/odf/components/odf-dashboard/utils.ts
+++ b/packages/odf/components/odf-dashboard/utils.ts
@@ -1,10 +1,10 @@
 import { NavPage } from '@openshift-console/dynamic-plugin-sdk';
 import { ResolvedCodeRefProperties } from '@openshift-console/dynamic-plugin-sdk/lib/types';
 import * as _ from 'lodash-es';
-import { DashboardTabExtensionProps } from 'packages/odf-plugin-sdk/extensions';
+import { HorizontalNavTabExtensionProps } from 'packages/odf-plugin-sdk/extensions';
 
 export const sortPages = (
-  dashboardTabs: ResolvedCodeRefProperties<DashboardTabExtensionProps>[]
+  dashboardTabs: ResolvedCodeRefProperties<HorizontalNavTabExtensionProps>[]
 ): void => {
   for (let i = 0; i < dashboardTabs.length; i++) {
     const element = dashboardTabs[i];
@@ -50,7 +50,7 @@ export const sortPages = (
 };
 
 export const convertDashboardTabToNav = (
-  dashboardTabs: ResolvedCodeRefProperties<DashboardTabExtensionProps>[]
+  dashboardTabs: ResolvedCodeRefProperties<HorizontalNavTabExtensionProps>[]
 ): NavPage[] =>
   dashboardTabs.map((tab) => ({
     name: tab.name,

--- a/plugins/odf/console-extensions.json
+++ b/plugins/odf/console-extensions.json
@@ -594,10 +594,11 @@
     }
   },
   {
-    "type": "odf.dashboard/tab",
+    "type": "odf.horizontalNav/tab",
     "properties": {
       "id": "backing-store",
       "name": "Backing Store",
+      "contextId": "odf-dashboard",
       "after": "systems",
       "href": "resource/noobaa.io~v1alpha1~BackingStore",
       "component": {
@@ -609,10 +610,11 @@
     }
   },
   {
-    "type": "odf.dashboard/tab",
+    "type": "odf.horizontalNav/tab",
     "properties": {
       "id": "bucket-class",
       "name": "Bucket Class",
+      "contextId": "odf-dashboard",
       "after": "backing-store",
       "href": "resource/noobaa.io~v1alpha1~BucketClass",
       "component": {
@@ -624,10 +626,11 @@
     }
   },
   {
-    "type": "odf.dashboard/tab",
+    "type": "odf.horizontalNav/tab",
     "properties": {
       "id": "namespace-store",
       "name": "Namespace Store",
+      "contextId": "odf-dashboard",
       "after": "bucket-class",
       "href": "resource/noobaa.io~v1alpha1~NamespaceStore",
       "component": {
@@ -639,10 +642,11 @@
     }
   },
   {
-    "type": "odf.dashboard/tab",
+    "type": "odf.horizontalNav/tab",
     "properties": {
       "id": "topology",
       "name": "Topology",
+      "contextId": "odf-dashboard",
       "before": "systems",
       "href": "topology",
       "component": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1013,14 +1013,14 @@
     semver "6.x"
     webpack "^5.68.0"
 
-"@openshift-console/dynamic-plugin-sdk@0.0.15":
-  version "0.0.15"
-  resolved "https://registry.yarnpkg.com/@openshift-console/dynamic-plugin-sdk/-/dynamic-plugin-sdk-0.0.15.tgz#5052addfc16e360c93ef814bf582db5876345420"
-  integrity sha512-oFZ5Y8efbIpDITNNCw7YFTibt1uYuamTMYyUZlEzCej0zKwqZdn3UYzEZt/2YR2uhyV935KiyL7Pm7Z0g5UAsw==
+"@openshift-console/dynamic-plugin-sdk@0.0.19":
+  version "0.0.19"
+  resolved "https://registry.yarnpkg.com/@openshift-console/dynamic-plugin-sdk/-/dynamic-plugin-sdk-0.0.19.tgz#96c373603bc68703459c2a21afe230dc73c19001"
+  integrity sha512-q9URuloSyvZRAMUkhDqiZGV76j7YP96cOqmp/jXAfdnNHYshssr4HaqV2MZj1lx2DeIv+BHtqlq8z8xcsyNWvg==
   dependencies:
-    "@patternfly/quickstarts" "2.0.1"
-    "@patternfly/react-core" "4.231.8"
-    "@patternfly/react-table" "4.100.8"
+    "@patternfly/quickstarts" "2.4.0"
+    "@patternfly/react-core" "4.276.8"
+    "@patternfly/react-table" "4.113.0"
     classnames "2.x"
     immutable "3.x"
     lodash "^4.17.21"
@@ -1048,30 +1048,29 @@
   resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.103.6.tgz#a01b1dced931eb4971a6c7366901fdde81a52284"
   integrity sha512-veWpHv/Dlk0P7tu96QUjLzD2Aq4IysUSGOjGPXlbb/KOUfnIrErLRmQnljY01ykXLJ7kxQSnC3yaJqCU+4fDPQ==
 
-"@patternfly/patternfly@4.122.2":
-  version "4.122.2"
-  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.122.2.tgz#3e774d78996c7027b8c528edb2e90990676458a5"
-  integrity sha512-kSoW8mt9eEJcAZX2lX4r/SYvFd44GGb8PUSDjMrpKDZqgn9/9VFh1rSChG4v5kCK6cpS99/gdTapZc3ylf8Rpw==
+"@patternfly/patternfly@^4.224.2":
+  version "4.224.2"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.224.2.tgz#9d1b000c3c43457ae47c3556a334412d164fad90"
+  integrity sha512-HGNV26uyHSIECuhjPg/WGn0mXbAotcs6ODfhAOkfYjIgGylddgiwElxUe1rpEHV5mQJJ2rMn4OdeJIIpzRX61g==
 
-"@patternfly/quickstarts@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@patternfly/quickstarts/-/quickstarts-2.0.1.tgz#8e8270782eae0e2476ccf4cdbbaa22c7c095097e"
-  integrity sha512-tbF1sqlkVb9rEriiHPnKAN5SercMxP27ty+PB87uZ/aF9YkvDD5BUuCbU3JR0e2qe189WksvLrgrAEaamh3gig==
+"@patternfly/quickstarts@2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@patternfly/quickstarts/-/quickstarts-2.4.0.tgz#2244fc93fe72d9936609ffa1dff25fcd1efc28b3"
+  integrity sha512-dlGtAX8iQarFvmflEvZ7rHaJb1aaBrcqkbzwx0wy2QLL/BID7Y+UQ9ht7k+TBNfnxhPOljM2YTp0rugG5S9q4g==
   dependencies:
-    "@patternfly/react-catalog-view-extension" "4.12.15"
+    "@patternfly/react-catalog-view-extension" "^4.93.15"
     dompurify "^2.2.6"
     history "^5.0.0"
     showdown "1.8.6"
 
-"@patternfly/react-catalog-view-extension@4.12.15":
-  version "4.12.15"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-catalog-view-extension/-/react-catalog-view-extension-4.12.15.tgz#edb0d6b97b3adf060129fdd1e0c1edc25c31d22e"
-  integrity sha512-1mp+Ogi7fJfgh5wV9q+PolmplbMj3Tcias8xs0eeD5GCirdzOQxG+wihEM5k6CAGhBAr7jHg5fRSgO8QLTt3UQ==
+"@patternfly/react-catalog-view-extension@^4.93.15":
+  version "4.96.0"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-catalog-view-extension/-/react-catalog-view-extension-4.96.0.tgz#b3e3e8875b0dc37c204cf71c29ea8a95d0442ad4"
+  integrity sha512-ZMPvaE6KOjbLioCdi1wPtxughsce4+sPq6Us5s4JKu2xgn+e83NcfSD3pAcS5e+M8K3SWwdXd3ycgkD8F+Obvg==
   dependencies:
-    "@patternfly/patternfly" "4.122.2"
-    "@patternfly/react-core" "^4.135.15"
-    "@patternfly/react-styles" "^4.11.4"
-    classnames "^2.2.5"
+    "@patternfly/patternfly" "^4.224.2"
+    "@patternfly/react-core" "^4.276.6"
+    "@patternfly/react-styles" "^4.92.6"
 
 "@patternfly/react-charts@^6.15.3":
   version "6.15.3"
@@ -1112,19 +1111,6 @@
     tippy.js "5.1.2"
     tslib "^2.0.0"
 
-"@patternfly/react-core@4.231.8":
-  version "4.231.8"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.231.8.tgz#2f9de38ecdd2fc53c63aff55433984fcf93a5fe6"
-  integrity sha512-2ClqlYCvSADppMfVfkUGIA/8XlO6jX8batoClXLxZDwqGoOfr61XyUgQ6SSlE4w60czoNeX4Nf6cfQKUH4RIKw==
-  dependencies:
-    "@patternfly/react-icons" "^4.82.8"
-    "@patternfly/react-styles" "^4.81.8"
-    "@patternfly/react-tokens" "^4.83.8"
-    focus-trap "6.9.2"
-    react-dropzone "9.0.0"
-    tippy.js "5.1.2"
-    tslib "^2.0.0"
-
 "@patternfly/react-core@4.267.5":
   version "4.267.5"
   resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.267.5.tgz#5080bfe5126be72d4258f33707470169a31ae046"
@@ -1138,7 +1124,20 @@
     tippy.js "5.1.2"
     tslib "^2.0.0"
 
-"@patternfly/react-core@^4.135.15", "@patternfly/react-core@^4.231.8", "@patternfly/react-core@^4.235.7":
+"@patternfly/react-core@4.276.8", "@patternfly/react-core@^4.276.6", "@patternfly/react-core@^4.276.8":
+  version "4.276.8"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.276.8.tgz#7ef52830dcdda954bd5bec40132da6eef49aba6f"
+  integrity sha512-dn322rEzBeiVztZEuCZMUUittNb8l1hk30h9ZN31FLZLLVtXGlThFNV9ieqOJYA9zrYxYZrHMkTnOxSWVacMZg==
+  dependencies:
+    "@patternfly/react-icons" "^4.93.6"
+    "@patternfly/react-styles" "^4.92.6"
+    "@patternfly/react-tokens" "^4.94.6"
+    focus-trap "6.9.2"
+    react-dropzone "9.0.0"
+    tippy.js "5.1.2"
+    tslib "^2.0.0"
+
+"@patternfly/react-core@^4.235.7":
   version "4.235.7"
   resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.235.7.tgz#70f2492cb2464f000e0e3d046859e9eb57945657"
   integrity sha512-I26IE75kI2P3kIfPsw0N4/pUSzXxWw2dinGw50fDN0qBMTnSCwwiJnyCFImF0f7YF30QWOO4VPs45zdM4iiQeg==
@@ -1174,7 +1173,7 @@
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.57.2.tgz#233db7d497c48ab8442687970bbe5d11036ea88f"
   integrity sha512-ajpOEKDcDAgrpwMQZ56VtZP1JIgCjyuJ9DQWnbo17C5zShDpT4NZQ0GcoEY2htQS0cgkiXRxYE+Ebakx6Rgkyw==
 
-"@patternfly/react-icons@^4.82.8", "@patternfly/react-icons@^4.86.7":
+"@patternfly/react-icons@^4.86.7":
   version "4.86.7"
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.86.7.tgz#a385e052c8e4d9772e5f12bfde9698ea1a5b9609"
   integrity sha512-QYurZzfjOKqHWRI8zeUweXy583C11NVeRAWbxVhOhPT/aFtgkd75iZNlLpv6XI1EN/uLpa9WdkZzyuLY1txYnA==
@@ -1189,15 +1188,15 @@
   resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.11.0.tgz#0068dcb18e1343242f93fa6024dcc077acd57fb9"
   integrity sha512-4eIqTwGI4mjt9DMqX6hnan4eRS+3LUWNaneTEJdmk+flKxtAE/O/OmQHvH4GetDnlSbyfATcA0VFbVtR0aRJAg==
 
-"@patternfly/react-styles@^4.11.4", "@patternfly/react-styles@^4.81.8", "@patternfly/react-styles@^4.85.7":
-  version "4.85.7"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.85.7.tgz#93afa64c81cf74f7fa050fb787f02348113d62a6"
-  integrity sha512-XSa8Loaouj1XEmbJmEeURXxKu5ub1VCRV0yN5YOnRo7j7XI4Yw9QarSHODzhkquI3AhkD0dPyMOaefz4P6lJKw==
-
 "@patternfly/react-styles@^4.56.2":
   version "4.56.2"
   resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.56.2.tgz#73fba536568d81e19648cf9ae88f7802799d791f"
   integrity sha512-6UWiyf9hz9ljIIDqD12XpWMq+TKjd83NN7K5X8yOFvKk7MltUyd01tiHYhKRrS4O84XAEwuw9mvBl7vGLKKEbg==
+
+"@patternfly/react-styles@^4.85.7":
+  version "4.85.7"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.85.7.tgz#93afa64c81cf74f7fa050fb787f02348113d62a6"
+  integrity sha512-XSa8Loaouj1XEmbJmEeURXxKu5ub1VCRV0yN5YOnRo7j7XI4Yw9QarSHODzhkquI3AhkD0dPyMOaefz4P6lJKw==
 
 "@patternfly/react-styles@^4.92.3":
   version "4.92.3"
@@ -1209,18 +1208,6 @@
   resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.92.6.tgz#a72c5f0b7896ce1c419d1db79f8e39ba6632057d"
   integrity sha512-b8uQdEReMyeoMzjpMri845QxqtupY/tIFFYfVeKoB2neno8gkcW1RvDdDe62LF88q45OktCwAe/8A99ker10Iw==
 
-"@patternfly/react-table@4.100.8":
-  version "4.100.8"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-table/-/react-table-4.100.8.tgz#86bce4fc528b87d8136c3b0c13f11c15e1b65cc1"
-  integrity sha512-80XZCZzoYN9gsoufNdXUB/dk33SuWF9lUnOJs7ilezD6noTSD7ARqO1h532eaEPIbPBp4uIVkEUdfGSHd0HJtg==
-  dependencies:
-    "@patternfly/react-core" "^4.231.8"
-    "@patternfly/react-icons" "^4.82.8"
-    "@patternfly/react-styles" "^4.81.8"
-    "@patternfly/react-tokens" "^4.83.8"
-    lodash "^4.17.19"
-    tslib "^2.0.0"
-
 "@patternfly/react-table@4.104.7":
   version "4.104.7"
   resolved "https://registry.yarnpkg.com/@patternfly/react-table/-/react-table-4.104.7.tgz#943d8bde095201e85c3a1b39a406c8c2aca9827a"
@@ -1230,6 +1217,18 @@
     "@patternfly/react-icons" "^4.86.7"
     "@patternfly/react-styles" "^4.85.7"
     "@patternfly/react-tokens" "^4.87.7"
+    lodash "^4.17.19"
+    tslib "^2.0.0"
+
+"@patternfly/react-table@4.113.0":
+  version "4.113.0"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-table/-/react-table-4.113.0.tgz#e9c92b5f323863c1bd546574f02083d1a76c7a81"
+  integrity sha512-qxa3NWCdYasqQQL1rqEd8DyNa8oWr6HNveNW5YJRakE7imWZhUPG2Nd6Op60+KYX8kbCSl7gwSmgAZAYMBMZkQ==
+  dependencies:
+    "@patternfly/react-core" "^4.276.8"
+    "@patternfly/react-icons" "^4.93.6"
+    "@patternfly/react-styles" "^4.92.6"
+    "@patternfly/react-tokens" "^4.94.6"
     lodash "^4.17.19"
     tslib "^2.0.0"
 
@@ -1255,7 +1254,7 @@
   resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.58.2.tgz#9d6d183af2046dbe62662eeb4fa69a1605098d40"
   integrity sha512-gsEz5z3+6pOHTy/fChZJHR8qUBPO87gRIUrQZlN5+gkrY6y0pT2UIs/WbRdsgV8xJDMev1iZaC9RMGwfR9mtfQ==
 
-"@patternfly/react-tokens@^4.83.8", "@patternfly/react-tokens@^4.87.7":
+"@patternfly/react-tokens@^4.87.7":
   version "4.87.7"
   resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.87.7.tgz#f96de3d2469b23ba86ead36bf8bac4ae9e7e0559"
   integrity sha512-07A7Ya4zIAYyYn3mOCG82wMC3/Y8mtTw95a//Onu/H0oDPMJ5oT7Vd14YN7pHexCAtWvc36Mp46iZ1osIQ7yVQ==
@@ -3447,7 +3446,7 @@ clap@^1.0.9:
   dependencies:
     chalk "^1.1.3"
 
-classnames@2.x, classnames@^2.2.5, classnames@^2.3.1:
+classnames@2.x, classnames@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
   integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==


### PR DESCRIPTION
Changes added:
1. Bumps core sdk to latest 0.0.19, to use types for exposed "NamespaceBar" FC.
2.  Updates "odf.dashboard/tab" to a generic "odf.horizontalNav/tab" extension point, which will support adding a new tab to any odf specific page based upon filtering on the "contextId" field.