### PR TITLE
Fix KMIP file upload error message

### DIFF
--- a/locales/en/plugin__odf-console.json
+++ b/locales/en/plugin__odf-console.json
@@ -748,7 +748,7 @@
   "Client certificate": "Client certificate",
   "CA certificate": "CA certificate",
   "Client private key": "Client private key",
-  "Maximum file size exceeded. File limit is 4MB.": "Maximum file size exceeded. File limit is 4MB.",
+  "Invalid file: File size exceeds 4MB limit or incorrect file extension (only .pem files allowed).": "Invalid file: File size exceeds 4MB limit or incorrect file extension (only .pem files allowed).",
   "File read failed. Please try again.": "File read failed. Please try again.",
   "Upload a .PEM file here...": "Upload a .PEM file here...",
   "Unique identifier": "Unique identifier",

--- a/packages/odf/components/kms-config/thales-config.tsx
+++ b/packages/odf/components/kms-config/thales-config.tsx
@@ -37,7 +37,7 @@ const FileUploadInput: React.FC<FileUploadInputProps> = ({
   const { t } = useCustomTranslation();
 
   const KMSFileSizeErrorMsg = t(
-    'Maximum file size exceeded. File limit is 4MB.'
+    'Invalid file: File size exceeds 4MB limit or incorrect file extension (only .pem files allowed).'
   );
   const KMSFileReadErrorMsg = t('File read failed. Please try again.');
 

--- a/packages/odf/modals/advanced-kms-modal/advanced-vault-modal.tsx
+++ b/packages/odf/modals/advanced-kms-modal/advanced-vault-modal.tsx
@@ -65,7 +65,7 @@ const AdvancedVaultModal = (props: AdvancedKMSModalProps) => {
   );
 
   const KMSFileSizeErrorMsg = t(
-    'Maximum file size exceeded. File limit is 4MB.'
+    'Invalid file: File size exceeds 4MB limit or incorrect file extension (only .pem files allowed).'
   );
 
   const vaultCACertTooltip = t(


### PR DESCRIPTION
Turns out that the drop is also rejected if the file extension is not '.pem' (even though PEM encoded files can be in many names, e.g. cert-manager uses .crt in its secret keys). Let's make sure the error message represents this, to avoid wasting more time from other people.