### PR TITLE
Removes 304 logs for local development server

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -45,6 +45,9 @@ const config: webpack.Configuration & DevServerConfiguration = {
     devMiddleware: {
       writeToDisk: true,
     },
+    headers: {
+      'Cache-Control': 'no-store',
+    },
     static: ['dist'],
   },
   resolve: {


### PR DESCRIPTION
This doesn't fix https://bugzilla.redhat.com/show_bug.cgi?id=2217958 for the product. But serves as an enhancement for development server as 304 message floods are seen in our local setup as well.