### PR TITLE
fix: added Rack info for the topology details screen

### DIFF
--- a/locales/en/plugin__odf-console.json
+++ b/locales/en/plugin__odf-console.json
@@ -1097,6 +1097,7 @@
   "Receive bandwidth": "Receive bandwidth",
   "Node details": "Node details",
   "Instance type": "Instance type",
+  "Rack": "Rack",
   "External ID": "External ID",
   "Node addresses": "Node addresses",
   "Machine": "Machine",

--- a/packages/odf/components/topology/utils.ts
+++ b/packages/odf/components/topology/utils.ts
@@ -8,12 +8,13 @@ import {
 } from '@odf/shared/topology';
 import { resolveResourceUntilDeployment } from '@odf/shared/topology/utils/resource';
 import { NodeKind, PodKind } from '@odf/shared/types';
+import { getRack } from '@odf/shared/utils';
 import {
   Alert,
   K8sResourceCommon,
 } from '@openshift-console/dynamic-plugin-sdk';
 import * as _ from 'lodash-es';
-import { getRack, getZone } from '../../utils';
+import { getZone } from '../../utils';
 
 export const generateNodeDeploymentsMap = (
   nodes: NodeKind[],

--- a/packages/odf/components/utils/common.ts
+++ b/packages/odf/components/utils/common.ts
@@ -8,7 +8,6 @@ import {
   getNodeCPUCapacity,
   getNodeAllocatableMemory,
   getZone,
-  getRack,
   isFlexibleScaling,
   getDeviceSetCount,
   createDeviceSet,
@@ -26,6 +25,7 @@ import {
   getNodeRoles,
   humanizeCpuCores,
   convertToBaseValue,
+  getRack,
 } from '@odf/shared/utils';
 import { Base64 } from 'js-base64';
 import * as _ from 'lodash-es';

--- a/packages/odf/constants/common.ts
+++ b/packages/odf/constants/common.ts
@@ -8,7 +8,6 @@ export const OCS_EXTERNAL_CR_NAME = 'ocs-external-storagecluster';
 export const OCS_INTERNAL_CR_NAME = 'ocs-storagecluster';
 export const HOSTNAME_LABEL_KEY = 'kubernetes.io/hostname';
 export const LABEL_OPERATOR = 'In';
-export const RACK_LABEL = 'topology.rook.io/rack';
 export const OCS_SUPPORT_ANNOTATION = 'features.ocs.openshift.io/enabled';
 export const OCS_DISABLED_ANNOTATION = 'features.ocs.openshift.io/disabled';
 export const ODF_VENDOR_ANNOTATION = 'vendors.odf.openshift.io/kind';

--- a/packages/odf/utils/ocs.ts
+++ b/packages/odf/utils/ocs.ts
@@ -9,7 +9,11 @@ import {
   StorageClusterKind,
   Taint,
 } from '@odf/shared/types';
-import { humanizeCpuCores, convertToBaseValue } from '@odf/shared/utils';
+import {
+  humanizeCpuCores,
+  convertToBaseValue,
+  getRack,
+} from '@odf/shared/utils';
 import { humanizeBinaryBytes } from '@odf/shared/utils';
 import {
   k8sPatch,
@@ -22,7 +26,6 @@ import {
   MINIMUM_NODES,
   ocsTaint,
   OCS_PROVISIONERS,
-  RACK_LABEL,
   ZONE_LABELS,
 } from '../constants';
 
@@ -74,8 +77,6 @@ const countNodesPerZone = (nodes: NodeKind[]) =>
     acc.hasOwnProperty(zone) ? (acc[zone] += 1) : (acc[zone] = 1);
     return acc;
   }, {});
-
-export const getRack = (node: NodeKind) => node.metadata.labels?.[RACK_LABEL];
 
 const getTopologyInfo = (nodes: NodeKind[]) =>
   nodes.reduce(

--- a/packages/shared/src/constants/common.ts
+++ b/packages/shared/src/constants/common.ts
@@ -7,3 +7,4 @@ export const ONE_MINUTE = 60 * ONE_SECOND;
 export const ONE_HOUR = 60 * ONE_MINUTE;
 export const ALL_NAMESPACES = 'all-namespaces';
 export const DEFAULT_NS = 'default';
+export const RACK_LABEL = 'topology.rook.io/rack';

--- a/packages/shared/src/topology/sidebar/node/NodeDetails.tsx
+++ b/packages/shared/src/topology/sidebar/node/NodeDetails.tsx
@@ -15,6 +15,7 @@ import {
   getNodeMachineNameAndNamespace,
   getNodeInstanceType,
   referenceForModel,
+  getRack,
 } from '@odf/shared/utils';
 import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
 import * as _ from 'lodash-es';
@@ -28,6 +29,8 @@ export const NodeDetails: React.FC<NodeDetailsProps> = ({ resource: node }) => {
   const machine = getNodeMachineNameAndNamespace(node);
   const roles = getNodeRoles(node).sort();
   const { t } = useCustomTranslation();
+  const availableZone = getNodeZone(node);
+  const availableRack = getRack(node);
 
   return (
     <div className="odf-m-pane__body">
@@ -41,8 +44,18 @@ export const NodeDetails: React.FC<NodeDetailsProps> = ({ resource: node }) => {
             <dd>{roles}</dd>
             <dt>{t('Instance type')}</dt>
             <dd>{getNodeInstanceType(node)}</dd>
-            <dt>{t('Zone')}</dt>
-            <dd>{getNodeZone(node)}</dd>
+            {availableZone && (
+              <>
+                <dt>{t('Zone')}</dt>
+                <dd>{availableZone}</dd>
+              </>
+            )}
+            {availableRack && (
+              <>
+                <dt>{t('Rack')}</dt>
+                <dd>{availableRack}</dd>
+              </>
+            )}
             <dt>{t('External ID')}</dt>
             <dd>{_.get(node, 'spec.externalID', '-')}</dd>
             <dt>{t('Node addresses')}</dt>

--- a/packages/shared/src/utils/node.spec.ts
+++ b/packages/shared/src/utils/node.spec.ts
@@ -1,5 +1,6 @@
+import { RACK_LABEL } from '../constants';
 import { NodeKind } from '../types';
-import { getCloudProviderID } from './node';
+import { getCloudProviderID, getRack } from './node';
 
 describe('getCloudProviderID', () => {
   it('should return empty string when providerID does not exist', () => {
@@ -17,5 +18,40 @@ describe('getCloudProviderID', () => {
   it('should return the providerID when the string has no separator', () => {
     const node: NodeKind = { spec: { providerID: 'aws' } };
     expect(getCloudProviderID(node)).toBe('aws');
+  });
+});
+
+describe('getRack function', () => {
+  test('should return rack label if it exists', () => {
+    const mockNode = {
+      metadata: {
+        labels: {
+          [RACK_LABEL]: 'rack-123',
+        },
+      },
+    };
+
+    const result = getRack(mockNode);
+    expect(result).toBe('rack-123');
+  });
+
+  test('should return undefined if rack label is not present', () => {
+    const mockNode = {
+      metadata: {
+        labels: {},
+      },
+    };
+
+    const result = getRack(mockNode);
+    expect(result).toBeUndefined();
+  });
+
+  test('should handle missing labels', () => {
+    const mockNode = {
+      metadata: {},
+    };
+
+    const result = getRack(mockNode);
+    expect(result).toBeUndefined();
   });
 });

--- a/packages/shared/src/utils/node.ts
+++ b/packages/shared/src/utils/node.ts
@@ -4,6 +4,7 @@ import {
   NodeMachineAndNamespace,
 } from '@odf/shared/types';
 import * as _ from 'lodash-es';
+import { RACK_LABEL } from '../constants';
 
 const NODE_ROLE_PREFIX = 'node-role.kubernetes.io/';
 
@@ -55,3 +56,5 @@ export const getNodeRoles = (node: NodeKind): string[] => {
 
 export const getNodeZone = (node: NodeKind): string =>
   node.metadata.labels?.['topology.kubernetes.io/zone'];
+
+export const getRack = (node: NodeKind) => node.metadata.labels?.[RACK_LABEL];


### PR DESCRIPTION
fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2214023

when only zone is present
![image](https://github.com/red-hat-storage/odf-console/assets/22158580/e6e65df5-cb3c-47c3-adce-a999e940e79f)

when only rack is present
![image](https://github.com/red-hat-storage/odf-console/assets/22158580/12e152e4-0d8f-4589-919f-7bdfaed307dd)

just in case we have both of them
![image](https://github.com/red-hat-storage/odf-console/assets/22158580/f57ef1e7-6fec-4aa7-af0c-482f5514dfb5)
