### PR TITLE
Running OCP console as a container

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ ODF Console is the UI plugin for Openshift Data Foundation Operator. It works as
 ## Running in Development Mode
 
 ODF console works as a remote bundle for OCP console. To run ODF Console there should be a instance of OCP console up and running.
-Follow these steps to run OCP Console in development mode:
+
+### Steps to run OCP Console as a server in development mode:
 
 1. Follow everything as mentioned in the console [README.md](https://github.com/openshift/console) to build the application.
 2. Run the console bridge as follows `./bin/bridge -plugins odf-console=http://localhost:9001/`
@@ -18,6 +19,15 @@ After the OCP console is set as required by ODF Console. Performs the following 
 3. Clone this repo.
 4. Pull all required dependencies by running `yarn install`.
 5. Run the development mode of odf-console using `yarn run dev`. This runs a webserver in port 9001.
+
+### Steps to run OCP Console as a container in development mode:
+
+1. Install ODF Operator.
+2. Create a Storage System.
+3. Clone this repo.
+4. Pull all required dependencies by running `yarn install`.
+5. Run the development mode of odf-console using `I8N_NS=plugin__odf-console PLUGIN=odf yarn run dev:c`. This runs a container running both the console bridge and a webserver in port 9001.
+6. For more OCP container related environment variables [Refer](https://github.com/red-hat-storage/odf-console/scripts/start-ocp-console.sh).
 
 ### Unit Tests
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,9 @@
     "po-to-i18n": "node ./scripts/i18n/po-to-i18n.js",
     "export-pos": "./scripts/i18n/export-pos.sh",
     "memsource-upload": "./scripts/i18n/memsource-upload.sh",
-    "memsource-download": "./scripts/i18n/memsource-download.sh"
+    "memsource-download": "./scripts/i18n/memsource-download.sh",
+    "ocp-console": "./scripts/start-ocp-console.sh",
+    "dev:c": "yarn ocp-console & PLUGIN=${PLUGIN} I8N_NS=${I8N_NS} yarn server:plugin & wait"
   },
   "dependencies": {
     "@openshift-console/dynamic-plugin-sdk": "0.0.19",

--- a/scripts/start-ocp-console.sh
+++ b/scripts/start-ocp-console.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+CONSOLE_VERSION=${CONSOLE_VERSION:=4.14}
+CONSOLE_PORT=${CONSOLE_PORT:=9000}
+CONSOLE_IMAGE="quay.io/openshift/origin-console:${CONSOLE_VERSION}"
+
+echo "Starting local OpenShift console..."
+
+BRIDGE_BASE_ADDRESS=${BRIDGE_BASE_ADDRESS:="http://localhost:9000"}
+BRIDGE_USER_AUTH=${BRIDGE_USER_AUTH:="disabled"}
+BRIDGE_K8S_MODE=${BRIDGE_K8S_MODE:="off-cluster"}
+BRIDGE_K8S_AUTH=${BRIDGE_K8S_AUTH:="bearer-token"}
+BRIDGE_K8S_MODE_OFF_CLUSTER_SKIP_VERIFY_TLS=${BRIDGE_K8S_MODE_OFF_CLUSTER_SKIP_VERIFY_TLS:=true}
+BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT=$(oc whoami --show-server)
+BRIDGE_PLUGINS=${BRIDGE_PLUGINS:=odf-console="http://localhost:9001"}
+BRIDGE_PLUGIN_PROXY=${BRIDGE_PLUGIN_PROXY:=""}
+
+# The monitoring operator is not always installed (e.g. for local OpenShift). Tolerate missing config maps.
+set +e
+BRIDGE_K8S_MODE_OFF_CLUSTER_THANOS=$(oc -n openshift-config-managed get configmap monitoring-shared-config -o jsonpath='{.data.thanosPublicURL}' 2>/dev/null)
+BRIDGE_K8S_MODE_OFF_CLUSTER_ALERTMANAGER=$(oc -n openshift-config-managed get configmap monitoring-shared-config -o jsonpath='{.data.alertmanagerPublicURL}' 2>/dev/null)
+set -e
+BRIDGE_K8S_AUTH_BEARER_TOKEN=$(oc whoami --show-token 2>/dev/null)
+BRIDGE_USER_SETTINGS_LOCATION="localstorage"
+
+# Don't fail if the cluster doesn't have gitops.
+set +e
+GITOPS_HOSTNAME=$(oc -n openshift-gitops get route cluster -o jsonpath='{.spec.host}' 2>/dev/null)
+set -e
+if [ -n "$GITOPS_HOSTNAME" ]; then
+    BRIDGE_K8S_MODE_OFF_CLUSTER_GITOPS="https://$GITOPS_HOSTNAME"
+fi
+
+echo "API Server: $BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT"
+echo "Console Image: $CONSOLE_IMAGE"
+echo "Console URL: http://localhost:${CONSOLE_PORT}"
+echo "$BRIDGE_PLUGIN_PROXY"
+
+# Prefer podman if installed. Otherwise, fall back to docker.
+if [ -x "$(command -v podman)" ]; then
+    podman run \
+      --pull always -p "$CONSOLE_PORT":9000 \
+      --rm --network=host \
+      --env BRIDGE_PLUGIN_PROXY="$BRIDGE_PLUGIN_PROXY" \
+      --env-file <(set | grep BRIDGE) \
+      $CONSOLE_IMAGE
+else
+    docker run \
+      --pull always -p "$CONSOLE_PORT":9000 \
+      --rm --network=host \
+      --env BRIDGE_PLUGIN_PROXY="$BRIDGE_PLUGIN_PROXY" \
+      --env-file <(set | grep BRIDGE) \
+      $CONSOLE_IMAGE
+fi


### PR DESCRIPTION
A basic env variable to run:

For odf-console:
---------------------------------------------------
export I8N_NS=plugin__odf-console
export PLUGIN=odf
export BRIDGE_PLUGINS="odf-console=http://localhost:9001"  (Optional, by default script will use odf-console plugin)
yarn dev:c

(or)

I8N_NS=plugin__odf-console PLUGIN=odf BRIDGE_PLUGINS="odf-console=http://localhost:9001"  yarn dev:c

For mco-console:
--------------------------------------------
export I8N_NS=plugin__odf-multicluster-console
export PLUGIN=mco
export BRIDGE_PLUGINS="mce=http://localhost:3001,acm=http://localhost:3002,odf-multicluster-console=http://localhost:9001" 
yarn dev:c

(or)

I8N_NS=plugin__odf-multicluster-console PLUGIN=mco BRIDGE_PLUGINS="mce=http://localhost:3001,acm=http://localhost:3002,odf-multicluster-console=http://localhost:9001"  yarn dev:c


"yarn dev:c" is an generic command for all ODF realted plugins
