### PR TITLE
Fetching alerts from OCP thanos instead of ACM thanos

### DIFF
--- a/packages/mco/components/mco-dashboard/data-policy/alert-card/alert-card.tsx
+++ b/packages/mco/components/mco-dashboard/data-policy/alert-card/alert-card.tsx
@@ -3,12 +3,11 @@ import { filterDRAlerts } from '@odf/mco/utils';
 import AlertsPanel from '@odf/shared/alert/AlertsPanel';
 import useAlerts from '@odf/shared/monitoring/useAlert';
 import { Card, CardBody } from '@patternfly/react-core';
-import { ACM_ENDPOINT, HUB_CLUSTER_NAME } from '../../../../constants';
 import AlertItem from './alert-item';
 import './alert-card.scss';
 
 export const AlertsCard: React.FC = () => {
-  const [alerts, loaded, loadError] = useAlerts(ACM_ENDPOINT, HUB_CLUSTER_NAME);
+  const [alerts, loaded, loadError] = useAlerts();
 
   return (
     <Card data-test="alerts-card">

--- a/packages/mco/components/mco-dashboard/data-policy/cluster-app-card/cluster-app-card.tsx
+++ b/packages/mco/components/mco-dashboard/data-policy/cluster-app-card/cluster-app-card.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import {
-  ACM_ENDPOINT,
   HUB_CLUSTER_NAME,
   ALL_APPS,
   applicationDetails,
@@ -15,7 +14,10 @@ import {
 } from '@odf/mco/types';
 import { getClusterNamesFromMirrorPeers } from '@odf/mco/utils';
 import { DataUnavailableError } from '@odf/shared/generic/Error';
-import { useCustomPrometheusPoll } from '@odf/shared/hooks/custom-prometheus-poll';
+import {
+  useCustomPrometheusPoll,
+  usePrometheusBasePath,
+} from '@odf/shared/hooks/custom-prometheus-poll';
 import { referenceForModel } from '@odf/shared/utils';
 import {
   PrometheusResponse,
@@ -161,8 +163,7 @@ export const ClusterAppCard: React.FC = () => {
     useCustomPrometheusPoll({
       endpoint: 'api/v1/query' as any,
       query: !!cluster ? getLastSyncPerClusterQuery() : null,
-      basePath: ACM_ENDPOINT,
-      cluster: HUB_CLUSTER_NAME,
+      basePath: usePrometheusBasePath(),
     });
 
   const { csvData, csvError, csvLoading } =

--- a/packages/mco/components/mco-dashboard/queries.ts
+++ b/packages/mco/components/mco-dashboard/queries.ts
@@ -3,7 +3,6 @@ import {
   USED_CAPACITY_FILE_BLOCK_METRIC,
   SYSTEM_HEALTH_METRIC,
 } from '@odf/shared/queries';
-import { HUB_CLUSTER_NAME } from '../../constants';
 
 export const RAMEN_HUB_OPERATOR_METRICS_SERVICE =
   'job="ramen-hub-operator-metrics-service"';
@@ -30,7 +29,7 @@ export const getTotalPVCCountPerClusterQuery = (clusterName: string) =>
 
 export const LAST_SYNC_TIME_QUERY = 'ramen_sync_duration_seconds';
 export const getLastSyncPerClusterQuery = () =>
-  `${LAST_SYNC_TIME_QUERY}{${DRPC_OBJECT_TYPE}, ${RAMEN_HUB_OPERATOR_METRICS_SERVICE}, cluster="${HUB_CLUSTER_NAME}"}`;
+  `${LAST_SYNC_TIME_QUERY}{${DRPC_OBJECT_TYPE}, ${RAMEN_HUB_OPERATOR_METRICS_SERVICE}}`;
 
 export const CAPACITY_QUERIES = {
   [StorageDashboard.TOTAL_CAPACITY_FILE_BLOCK]: `(label_replace(odf_system_map{target_namespace="openshift-storage"} , "managedBy", "$1", "target_name", "(.*)"))  * on (namespace, managedBy, cluster) group_right(storage_system, target_kind) ${TOTAL_CAPACITY_FILE_BLOCK_METRIC}`,

--- a/packages/mco/utils/disaster-recovery.tsx
+++ b/packages/mco/utils/disaster-recovery.tsx
@@ -18,6 +18,7 @@ import {
   K8sResourceCommon,
   GreenCheckCircleIcon,
   Alert,
+  AlertStates,
 } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Operator,
@@ -524,7 +525,8 @@ export const filterPVCDataUsingAppsets = (
   );
 
 export const filterDRAlerts = (alert: Alert) =>
-  alert?.annotations?.alert_type === 'DisasterRecovery';
+  alert?.annotations?.alert_type === 'DisasterRecovery' &&
+  alert.state === AlertStates.Firing;
 
 export const isDRPolicyValidated = (drPolicy: DRPolicyKind) =>
   drPolicy?.status?.conditions?.some(


### PR DESCRIPTION
Blocked by: https://github.com/RamenDR/ramen/pull/1006
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2221660

For 4.14, We dont have any alert from ACM thanos, Replication delay alert is moved to OCP thanos by ramen operation to raise the alert even when observability is not enabled.

In future, UI need to fetch alert from both OCP thanos as well as ACM thanos.