### PR TITLE
Improves warning message handling for selector input

### DIFF
--- a/packages/shared/src/modals/EditLabelModal.tsx
+++ b/packages/shared/src/modals/EditLabelModal.tsx
@@ -171,7 +171,12 @@ export const EditLabelModal: React.FC<EditLabelModalProps> = ({
           {t('Cancel')}
         </Button>
         {!loading ? (
-          <Button key="Save" variant="primary" onClick={onSubmit}>
+          <Button
+            key="Save"
+            variant="primary"
+            onClick={onSubmit}
+            isDisabled={loading || errorMessage}
+          >
             {t('Save')}
           </Button>
         ) : (


### PR DESCRIPTION
This blocks the save button if there are any warning messages

<img width="569" alt="Screenshot 2023-09-01 at 4 32 55 PM" src="https://github.com/red-hat-storage/odf-console/assets/57935785/e0263bd5-a1e0-4abc-af98-0048b6e736a2">
