### PR TITLE
libuv update in 18.18.0 breaks webpack's thread-loader

### DIFF
--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14, 16, 18]
+        node-version: [14, 16, 18.17.1]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
Ref: https://github.com/nodejs/node/issues/49911

Reverting back the node version to 18.17.1 for a temporary fix.