### PR TITLE
Unit tests for CreateNamespaceStore & NamespaceStoreForm

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^12",
     "@testing-library/react-hooks": "^8.0.1",
+    "@testing-library/user-event": "^14.5.1",
     "@types/jest": "29.2.2",
     "@types/node": "^14.14.34",
     "@typescript-eslint/eslint-plugin": "^5.42",

--- a/packages/odf/components/namespace-store/create-namespace-store.spec.tsx
+++ b/packages/odf/components/namespace-store/create-namespace-store.spec.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import { CEPH_STORAGE_NAMESPACE } from '@odf/shared/constants';
+import { render } from '@testing-library/react';
+import CreateNamespaceStore from './create-namespace-store';
+
+const params = {
+  ns: 'test-ns',
+};
+
+const mockNamespaceStoreForm = jest.fn();
+jest.mock('./namespace-store-form', () => (props) => {
+  mockNamespaceStoreForm(props);
+  return <mock-NamespaceStoreForm />;
+});
+
+describe('CreateNamespaceStore test', () => {
+  it('shows the correct heading texts', () => {
+    const { container } = render(<CreateNamespaceStore match={{ params }} />);
+    const heading = container.getElementsByClassName(
+      'odf-create-operand__header-text'
+    )[0];
+    const titleHeading = container.getElementsByClassName('help-block')[0];
+    expect(heading).toBeInTheDocument();
+    expect(heading).toHaveTextContent(/Create NamespaceStore/);
+    expect(titleHeading).toBeInTheDocument();
+    expect(titleHeading).toHaveTextContent(
+      /Represents an underlying storage to be used as read or write target for the data in the namespace buckets\./
+    );
+  });
+
+  it('Check the title size and heading level', () => {
+    const { container } = render(<CreateNamespaceStore match={{ params }} />);
+    const fontSize = container.getElementsByClassName('pf-m-2xl')[0];
+    expect(fontSize).toBeInTheDocument();
+    expect(
+      container.querySelectorAll('h1.odf-create-operand__header-text')[0]
+    ).toBeTruthy();
+  });
+
+  it('pass the received namespace to the form', () => {
+    render(<CreateNamespaceStore match={{ params }} />);
+    expect(mockNamespaceStoreForm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        namespace: 'test-ns',
+      })
+    );
+  });
+
+  it('pass the default namespace to the form when no namespace is received', () => {
+    render(<CreateNamespaceStore match={{ params: {} }} />);
+    expect(mockNamespaceStoreForm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        namespace: CEPH_STORAGE_NAMESPACE,
+      })
+    );
+  });
+});

--- a/packages/odf/components/namespace-store/namespace-store-form.spec.tsx
+++ b/packages/odf/components/namespace-store/namespace-store-form.spec.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import NamespaceStoreForm from './namespace-store-form';
+
+const mockOnCancel = jest.fn();
+const props = {
+  redirectHandler: () => undefined,
+  namespace: 'test-ns',
+  onCancel: mockOnCancel,
+};
+
+jest.mock('@odf/shared/hooks/useK8sList', () => ({
+  __esModule: true,
+  useK8sList: () => [
+    [
+      {
+        metadata: {
+          name: 'existing-ns-name',
+        },
+      },
+    ],
+    true,
+    undefined,
+  ],
+}));
+
+jest.mock('@odf/shared/dropdown/ResourceDropdown', () => () => {
+  return <mock-ResourceDropdown />;
+});
+
+describe('NamespaceStoreForm', () => {
+  it('renders the form', () => {
+    render(<NamespaceStoreForm {...props} />);
+
+    const nameInput = screen.getByPlaceholderText('my-namespacestore');
+    expect(nameInput).toBeInTheDocument();
+  });
+
+  it('clicks on Cancel button', async () => {
+    const user = userEvent.setup();
+    render(<NamespaceStoreForm {...props} />);
+
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(mockOnCancel).toHaveBeenCalled();
+  });
+
+  it('clicks on Create button', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<NamespaceStoreForm {...props} />);
+
+    const mockOnSubmit = jest.fn();
+    container.getElementsByClassName('nb-endpoints-form')[0].onsubmit =
+      mockOnSubmit;
+    await user.click(screen.getByRole('button', { name: /create/i }));
+    expect(mockOnSubmit).toHaveBeenCalled();
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1480,6 +1480,11 @@
     "@testing-library/dom" "^8.0.0"
     "@types/react-dom" "<18.0.0"
 
+"@testing-library/user-event@^14.5.1":
+  version "14.5.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.5.1.tgz#27337d72046d5236b32fd977edee3f74c71d332f"
+  integrity sha512-UCcUKrUYGj7ClomOo2SpNVvx4/fkd/2BbIHDCle8A0ax+P3bU7yJwDBDrS6ZwdTMARWTGODX1hEsCcO+7beJjg==
+
 "@tootallnate/once@2":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"


### PR DESCRIPTION
- Refactoring of https://github.com/red-hat-storage/odf-console/pull/827
- Prefer `@testing-library/user-event` over usage of `fireEvent` (as recommended).