### PR TITLE
Fix Volume replication health shows healthy post failover

### DIFF
--- a/packages/mco/components/mco-dashboard/data-policy/cluster-app-card/common.tsx
+++ b/packages/mco/components/mco-dashboard/data-policy/cluster-app-card/common.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import {
   ALL_APPS,
   ALL_APPS_ITEM_ID,
+  LEAST_SECONDS_IN_PROMETHEUS,
   VOLUME_REPLICATION_HEALTH,
 } from '@odf/mco/constants';
 import {
@@ -74,8 +75,11 @@ export const VolumeSummarySection: React.FC<VolumeSummarySectionProps> = ({
     const volumeHealth = { critical: 0, warning: 0, healthy: 0 };
     const placementInfo: PlacementInfo = selectedAppSet?.placementInfo?.[0];
     protectedPVCData?.forEach((pvcData) => {
+      const pvcLastSyncTime = pvcData?.lastSyncTime;
       const health = getVolumeReplicationHealth(
-        getTimeDifferenceInSeconds(pvcData?.lastSyncTime),
+        !!pvcLastSyncTime
+          ? getTimeDifferenceInSeconds(pvcLastSyncTime)
+          : LEAST_SECONDS_IN_PROMETHEUS,
         pvcData?.schedulingInterval
       )[0];
       if (!!selectedAppSet) {
@@ -354,8 +358,11 @@ export const ProtectedPVCsSection: React.FC<ProtectedPVCsSectionProps> = ({
     const placementInfo = selectedAppSet?.placementInfo?.[0];
     const issueCount =
       protectedPVCData?.reduce((acc, protectedPVCItem) => {
+        const pvcLastSyncTime = protectedPVCItem?.lastSyncTime;
         const replicationHealth = getVolumeReplicationHealth(
-          getTimeDifferenceInSeconds(protectedPVCItem?.lastSyncTime),
+          !!pvcLastSyncTime
+            ? getTimeDifferenceInSeconds(pvcLastSyncTime)
+            : LEAST_SECONDS_IN_PROMETHEUS,
           protectedPVCItem?.schedulingInterval
         )[0];
 

--- a/packages/mco/constants/dashboard.ts
+++ b/packages/mco/constants/dashboard.ts
@@ -14,3 +14,7 @@ export const enum VOLUME_REPLICATION_HEALTH {
   WARNING = 'warning',
   HEALTHY = 'healthy',
 }
+
+// Prometheus time() - 0 in seconds
+// For more info: https://github.com/RamenDR/ramen/blob/5b80317c82cb484f6a639e24967967adb38d708d/config/prometheus/alerts.yaml#L14
+export const LEAST_SECONDS_IN_PROMETHEUS = 1697788182;


### PR DESCRIPTION
To align the dashboard with ramen alerts, the Dashboard will reflect volume replication health is critical for the last group sync time empty.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2244842