### PR TITLE
E2E: make 'selectOrCreateProject' helper more reliable

### DIFF
--- a/cypress/support/pages/app.ts
+++ b/cypress/support/pages/app.ts
@@ -38,9 +38,7 @@ export const projectNameSpace = {
       .then(() =>
         cy.byTestID('dropdown-text-filter').should('have.value', projectName)
       );
-    cy.get(
-      '[data-test-id="namespace-bar-dropdown"] span.pf-c-menu-toggle__text'
-    )
+    cy.get('[data-test-id="namespace-bar-dropdown"] span')
       .first()
       .as('projectNameSpaceDropdown');
     app.waitForDocumentLoad();


### PR DESCRIPTION
- Do not rely on PF class name when getting the current project text element.
![image](https://github.com/red-hat-storage/odf-console/assets/6780162/86327800-492c-486c-8571-a3000be76735)
- Needed by https://github.com/openshift/release/pull/45951