### PR TITLE
support cluster creation even if namespace already exists

### DIFF
--- a/packages/odf/components/create-storage-system/payloads.ts
+++ b/packages/odf/components/create-storage-system/payloads.ts
@@ -284,7 +284,7 @@ export const createExternalSubSystem = async (subSystemPayloads: Payload[]) => {
   }
 };
 
-export const createMultiClusterNs = async (systemNamespace: string) =>
+export const createOCSNamespace = async (systemNamespace: string) =>
   k8sCreate({
     model: NamespaceModel,
     data: {


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2255219

Multi cluster creation fails if "openshift-storage-extended" already exists. Now wizard flow will check for the existence before creating the namespace again.