### PR TITLE
Fix default RBD StorageClass option for external mode

### DIFF
--- a/packages/odf-plugin-sdk/extensions/external-storage/external-storage.ts
+++ b/packages/odf-plugin-sdk/extensions/external-storage/external-storage.ts
@@ -61,6 +61,7 @@ export type CreatePayload<S = ExternalState> = (payloadOptions: {
   namespace: string;
   storageClassName?: string;
   inTransitStatus?: boolean;
+  shouldSetCephRBDAsDefault?: boolean;
 }) => Payload[];
 
 export type Payload = { model: Model; payload: K8sResourceKind };

--- a/packages/odf/components/create-storage-system/external-ceph-storage/system-connection-details.tsx
+++ b/packages/odf/components/create-storage-system/external-ceph-storage/system-connection-details.tsx
@@ -166,6 +166,7 @@ export const rhcsPayload: CreatePayload<RHCSState> = ({
   model,
   namespace,
   inTransitStatus,
+  shouldSetCephRBDAsDefault,
 }) => {
   return [
     {
@@ -203,6 +204,9 @@ export const rhcsPayload: CreatePayload<RHCSState> = ({
           },
           externalStorage: {
             enable: true,
+          },
+          managedResources: {
+            cephBlockPools: { defaultStorageClass: shouldSetCephRBDAsDefault },
           },
           labelSelector: {
             matchExpressions: [],

--- a/packages/odf/components/create-storage-system/footer.tsx
+++ b/packages/odf/components/create-storage-system/footer.tsx
@@ -30,6 +30,7 @@ import { getExternalStorage, getTotalCpu, getTotalMemoryInGiB } from '../utils';
 import {
   createExternalSubSystem,
   createNoobaaExternalPostgresResources,
+  setCephRBDAsDefault,
   createStorageCluster,
   createStorageSystem,
   labelNodes,
@@ -187,6 +188,7 @@ const handleReviewAndCreateNext = async (
   } = state;
   const {
     systemNamespace,
+    isRBDStorageClassDefault,
     externalStorage,
     deployment,
     type,
@@ -278,6 +280,10 @@ const handleReviewAndCreateNext = async (
       const subSystemState = isRhcs ? connectionDetails : createStorageClass;
       const subSystemKind = getGVKLabel(model);
 
+      const shouldSetCephRBDAsDefault = setCephRBDAsDefault(
+        isRBDStorageClassDefault,
+        deployment
+      );
       const subSystemPayloads = createPayload({
         systemName: subSystemName,
         state: subSystemState,
@@ -285,6 +291,7 @@ const handleReviewAndCreateNext = async (
         namespace: systemNamespace,
         storageClassName: storageClass.name,
         inTransitStatus: inTransitChecked,
+        shouldSetCephRBDAsDefault: shouldSetCephRBDAsDefault,
       });
 
       await createStorageSystem(subSystemName, subSystemKind, systemNamespace);

--- a/packages/odf/components/create-storage-system/payloads.ts
+++ b/packages/odf/components/create-storage-system/payloads.ts
@@ -141,6 +141,11 @@ export const createNoobaaExternalPostgresResources = (
   return secretResources;
 };
 
+export const setCephRBDAsDefault = (
+  isRBDStorageClassDefault: boolean,
+  deployment: DeploymentType
+): boolean => isRBDStorageClassDefault && deployment === DeploymentType.FULL;
+
 export const createStorageCluster = async (
   state: WizardState,
   storageClusterNamespace: string,
@@ -195,8 +200,10 @@ export const createStorageCluster = async (
     deployment === DeploymentType.FULL &&
     type !== BackingStorageType.EXTERNAL;
 
-  const shouldSetCephRBDAsDefault =
-    isRBDStorageClassDefault && deployment === DeploymentType.FULL;
+  const shouldSetCephRBDAsDefault = setCephRBDAsDefault(
+    isRBDStorageClassDefault,
+    deployment
+  );
 
   const payload = getOCSRequestData({
     storageClass,


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2256566

`spec.managedResources.cephBlockPools.defaultStorageClass` field was not getting set for external mode StorageCluster CR.