### PR TITLE
Fix i18n NS ref in shared + publish new version

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@odf-console/shared",
   "description": "ODF console shared code.",
-  "version": "0.0.0-beta12",
+  "version": "0.0.0-beta13",
   "license": "Apache-2.0",
   "private": false,
   "main": "src/index.ts",

--- a/packages/shared/src/details-page/datetime.ts
+++ b/packages/shared/src/details-page/datetime.ts
@@ -109,9 +109,7 @@ export const fromNow = (dateTime: string | Date, now?: Date, options?) => {
 
   const d = new Date(dateTime);
   const ms = now.getTime() - d.getTime();
-  const justNow = i18n.t('plugin__odf-console~Just now', {
-    ns: 'plugin__odf-console',
-  });
+  const justNow = i18n.t('Just now');
 
   // If the event occurred less than one minute in the future, assume it's clock drift and show "Just now."
   if (!options?.omitSuffix && ms < 60000 && ms > maxClockSkewMS) {

--- a/packages/shared/src/text-inputs/password-input.tsx
+++ b/packages/shared/src/text-inputs/password-input.tsx
@@ -28,13 +28,7 @@ const PasswordInput: React.FC<PasswordInputProps> = ({
         onChange={onChange}
         isRequired={isRequired}
       />
-      <Tooltip
-        content={
-          showPassword
-            ? t('plugin__odf-console~Hide password')
-            : t('plugin__odf-console~Show password')
-        }
-      >
+      <Tooltip content={showPassword ? t('Hide password') : t('Show password')}>
         <Button
           variant="control"
           onClick={() => setShowPassword(!showPassword)}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1026,7 +1026,7 @@
     rimraf "^3.0.2"
 
 "@odf/shared@file:packages/shared":
-  version "0.0.0-beta12"
+  version "0.0.0-beta13"
   dependencies:
     "@patternfly/patternfly" "4.103.6"
     "@patternfly/react-charts" "^6.15.3"


### PR DESCRIPTION
Remove explicit reference to `plugin__odf-console` under `shared`.
This gets reflected on the library consumer side, creating a new `plugin__odf-console.json` file.