### PR TITLE
[release-4.14-compatibility] Bug 2263214: Fixes prop type accepted for StatusCardPopover

### DIFF
--- a/packages/odf/components/odf-dashboard/status-card/status-card-popover.tsx
+++ b/packages/odf/components/odf-dashboard/status-card/status-card-popover.tsx
@@ -11,7 +11,7 @@ import {
 import './status-card-popover.scss';
 
 export type ResourceHealthMap = {
-  itemName: string;
+  systemName: string;
   healthState: HealthState;
   link?: string;
   extraTexts?: string[];
@@ -47,15 +47,15 @@ const StatusCardPopover: React.FC<StatusCardPopoverProps> = ({
     >
       {resourceHealthMap.map((resource) => (
         <Status
-          key={resource.itemName}
+          key={resource.systemName}
           icon={healthStateToIcon[resource.healthState]}
         >
           <Flex direction={{ default: 'column' }}>
             <FlexItem className="odf-status-card__popup--margin">
               {resource.link ? (
-                <Link to={resource.link}>{resource.itemName}</Link>
+                <Link to={resource.link}>{resource.systemName}</Link>
               ) : (
-                <>{resource.itemName}</>
+                <>{resource.systemName}</>
               )}
             </FlexItem>
             {!!resource.extraTexts && (


### PR DESCRIPTION
Updates the ResourceHealthMap type property to systemName During parallel work on the same card changes were introduced to the property for this card and not updated on the code this used

Screenshot: 
![Screenshot from 2024-02-09 13-16-33](https://github.com/red-hat-storage/odf-console/assets/54092533/e41d8bd9-a23c-491b-af4e-bb95a8198814)
