### PR TITLE
Removing ODR_MODEL flag check from console-extensions.json

### DIFF
--- a/plugins/mco/console-extensions.json
+++ b/plugins/mco/console-extensions.json
@@ -8,17 +8,6 @@
     }
   },
   {
-    "type": "console.flag/model",
-    "properties": {
-      "model": {
-        "group": "ramendr.openshift.io",
-        "version": "v1alpha1",
-        "kind": "DRPolicy"
-      },
-      "flag": "ODR_MODEL"
-    }
-  },
-  {
     "type": "console.navigation/section",
     "properties": {
       "id": "mco-data-services",
@@ -35,9 +24,6 @@
       "section": "mco-data-services",
       "name": "%plugin__odf-multicluster-console~Disaster recovery%",
       "href": "/multicloud/data-services/disaster-recovery"
-    },
-    "flags": {
-      "required": ["ODR_MODEL"]
     }
   },
   {


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2274734

1. With OCP 4.16 nightly build, console.flag/model extension is not setting flags always. 
2. Its is a blocker for QE testing, because Data Services Nav is disappearing. 
3. We dont need this flag, because MCO and DR operators are installed together. So DRPolicy CRD will be always there.