### PR TITLE
Adds support for Noobaa standalone in cluster overview

### DIFF
--- a/packages/shared/src/selectors/k8s.ts
+++ b/packages/shared/src/selectors/k8s.ts
@@ -1,4 +1,8 @@
-import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+import {
+  K8sResourceCommon,
+  K8sResourceCondition,
+  K8sResourceKind,
+} from '@openshift-console/dynamic-plugin-sdk';
 import * as _ from 'lodash-es';
 
 type GetStringProperty<T = K8sResourceCommon> = (resource: T) => string;
@@ -51,3 +55,16 @@ export const getOwnerReferences = <
     value,
     'metadata.ownerReferences'
   ) as K8sResourceCommon['metadata']['ownerReferences'];
+
+type KnownResourceConditions = 'Available' | 'Degraded' | 'Progressing';
+
+export const getResourceCondition = <
+  A extends K8sResourceKind = K8sResourceKind
+>(
+  resource: A,
+  condition: KnownResourceConditions
+): K8sResourceCondition => {
+  return resource?.status?.conditions?.find(
+    (current: K8sResourceCondition) => current.type === condition
+  );
+};

--- a/plugins/odf/console-extensions.json
+++ b/plugins/odf/console-extensions.json
@@ -233,10 +233,11 @@
     }
   },
   {
-    "type": "console.dashboards/overview/health/resource",
+    "type": "console.dashboards/overview/health/prometheus",
     "properties": {
       "title": "Storage",
-      "resources": { "$codeRef": "healthResource.healthResource" },
+      "queries": ["NooBaa_health_status"],
+      "additionalResource": { "$codeRef": "healthResource.healthResource" },
       "healthHandler": { "$codeRef": "healthResource.healthHandler" },
       "popupComponent": { "$codeRef": "healthResource.StoragePopover" },
       "popupTitle": "Storage"


### PR DESCRIPTION
[Bug 2256563](https://bugzilla.redhat.com/show_bug.cgi?id=2256563)

Changes:
- Fixes StatusAndIconText support for HealthStates; previously it dint support for it.
- Adds text `Healthy` for OK State,
- Moves to a `console.dashboards/overview/health/prometheus` from `console.dashboards/overview/health/resource
`
 

#### Screenshot
![Screenshot from 2024-04-16 21-25-12](https://github.com/red-hat-storage/odf-console/assets/54092533/2bb55a7a-6e70-4d75-b7ae-31f6714a401c)

