### PR TITLE
remove capacity-trend card

### DIFF
--- a/packages/ocs/dashboards/ocs-system-dashboard.tsx
+++ b/packages/ocs/dashboards/ocs-system-dashboard.tsx
@@ -35,7 +35,6 @@ import { StatusCard as ExtStatusCard } from './persistent-external/status-card';
 import { default as ExtUtilizationCard } from './persistent-external/utilization-card';
 import { default as ActivityCard } from './persistent-internal/activity-card/activity-card';
 import BreakdownCard from './persistent-internal/capacity-breakdown-card/capacity-breakdown-card';
-import CapacityTrendCard from './persistent-internal/capacity-trend-card/capacity-trend-card';
 import DetailsCard from './persistent-internal/details-card';
 import InventoryCard from './persistent-internal/inventory-card';
 import RawCapacityCard from './persistent-internal/raw-capacity-card/raw-capacity-card';
@@ -78,7 +77,6 @@ const PersistentInternalDashboard: React.FC = () => {
   const mainCards: React.ComponentType[] = [
     StatusCard,
     RawCapacityCard,
-    CapacityTrendCard,
     BreakdownCard,
     UtilizationCard,
   ];


### PR DESCRIPTION
remove capacity-trend card from the maincards list

![image](https://github.com/red-hat-storage/odf-console/assets/24807435/7a530603-d4c5-47be-ae6f-001733c1f274)
