### PR TITLE
dashboard: enable capacity-trend card

### DIFF
--- a/packages/ocs/dashboards/ocs-system-dashboard.tsx
+++ b/packages/ocs/dashboards/ocs-system-dashboard.tsx
@@ -35,6 +35,7 @@ import { StatusCard as ExtStatusCard } from './persistent-external/status-card';
 import { default as ExtUtilizationCard } from './persistent-external/utilization-card';
 import { default as ActivityCard } from './persistent-internal/activity-card/activity-card';
 import BreakdownCard from './persistent-internal/capacity-breakdown-card/capacity-breakdown-card';
+import CapacityTrendCard from './persistent-internal/capacity-trend-card/capacity-trend-card';
 import DetailsCard from './persistent-internal/details-card';
 import InventoryCard from './persistent-internal/inventory-card';
 import RawCapacityCard from './persistent-internal/raw-capacity-card/raw-capacity-card';
@@ -77,6 +78,7 @@ const PersistentInternalDashboard: React.FC = () => {
   const mainCards: React.ComponentType[] = [
     StatusCard,
     RawCapacityCard,
+    CapacityTrendCard,
     BreakdownCard,
     UtilizationCard,
   ];

--- a/packages/ocs/queries/ceph-storage.ts
+++ b/packages/ocs/queries/ceph-storage.ts
@@ -333,6 +333,6 @@ export const CAPACITY_TREND_QUERIES = (
 ) => ({
   [StorageDashboardQuery.UTILIZATION_1D]: `delta(sum(ceph_cluster_total_used_raw_bytes{managedBy="${managedByOCS}"})[1d:])`,
   [StorageDashboardQuery.UTILIZATION_VECTOR]: `delta(sum(ceph_cluster_total_used_raw_bytes{managedBy="${managedByOCS}"})[${maxDays}:])`,
-  [StorageDashboardQuery.UPTIME_DAYS]: `ceph_cluster_total_used_raw_bytes{managedBy="${managedByOCS}"}[${maxDays}]`,
+  [StorageDashboardQuery.UPTIME_DAYS]: `delta(sum(timestamp(ceph_cluster_total_used_raw_bytes{managedBy="${managedByOCS}"}))[${maxDays}:])`,
   [StorageDashboardQuery.RAW_CAPACITY_AVAILABLE]: `ceph_cluster_total_bytes{managedBy="${managedByOCS}"} - ceph_cluster_total_used_raw_bytes{managedBy="${managedByOCS}"}`,
 });


### PR DESCRIPTION
this commit enables capacity-trend card in the storage system dashboard.
addition to that change the query to calculate daysUp with something in
the prometheus.