### PR TITLE
Add yarn script: dev:no-type-check

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "analyze-odf": "PLUGIN=odf yarn analyze-common && PLUGIN=odf yarn ts-node ./analyzeTest.ts",
     "analyze-mco": "PLUGIN=mco yarn analyze-common && PLUGIN=mco yarn ts-node ./analyzeTest.ts",
     "dev": "PLUGIN=odf I8N_NS=plugin__odf-console yarn server:plugin",
+    "dev:no-type-check": "DEV_NO_TYPE_CHECK=true yarn dev",
     "dev-mco": "PLUGIN=mco I8N_NS=plugin__odf-multicluster-console yarn server:plugin",
     "dev-client": "PLUGIN=client I8N_NS=plugin__odf-client-console yarn server:plugin",
     "serve-local-build": "./http-server.sh ./plugins/odf/dist",

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -146,17 +146,6 @@ const config: webpack.Configuration & DevServerConfiguration = {
     new webpack.ProvidePlugin({
       Buffer: ['buffer', 'Buffer'],
     }),
-    new ForkTsCheckerWebpackPlugin({
-      issue: {
-        exclude: [{ file: '**/node_modules/**/*' }],
-      },
-      typescript: {
-        diagnosticOptions: {
-          semantic: true,
-          syntactic: true,
-        },
-      },
-    }),
     new CircularDependencyPlugin({
       exclude: /cypress|plugins|scripts|node_modules/,
       failOnError: true,
@@ -169,6 +158,22 @@ const config: webpack.Configuration & DevServerConfiguration = {
     chunkIds: 'named',
   },
 };
+
+if (NODE_ENV === 'production' || process.env.DEV_NO_TYPE_CHECK !== 'true') {
+  config.plugins?.push(
+    new ForkTsCheckerWebpackPlugin({
+      issue: {
+        exclude: [{ file: '**/node_modules/**/*' }],
+      },
+      typescript: {
+        diagnosticOptions: {
+          semantic: true,
+          syntactic: true,
+        },
+      },
+    })
+  );
+}
 
 if (process.env.ANALYZE_BUNDLE === 'true') {
   config.plugins?.push(


### PR DESCRIPTION
This script is an option to speed up the `watch mode development` and in no way bypasses the type checking in the project: we still have the `pre-commit` & CI jobs that run the type-checking.

`yarn dev:no-type-check` skips the type checking that happens every time a change is detected, thus speeding up the compilation and avoiding potential superfluous errors (like `unused import`) that hinder the compilation when in `watch` mode adn can be fixed later by the linter.