### PR TITLE
Bug 2297447: Use ManagedClusterView for ODF info - DRPolicy creation

### DIFF
--- a/packages/mco/components/create-dr-policy/create-dr-policy.spec.tsx
+++ b/packages/mco/components/create-dr-policy/create-dr-policy.spec.tsx
@@ -24,26 +24,6 @@ const managedClusters: ACMManagedClusterKind[] = [
           name: 'region.open-cluster-management.io',
           value: 'us-east-1',
         },
-        {
-          name: 'cephfsid.odf.openshift.io',
-          value: 'e6928945-2b95-4ff8-8400-0914ee5cb2ec',
-        },
-        {
-          name: 'storageclustername.odf.openshift.io',
-          value: 'ocs-storagecluster/openshift-storage',
-        },
-        {
-          name: 'storagesystemname.odf.openshift.io',
-          value: 'ocs-storagecluster-storagesystem/openshift-storage',
-        },
-        {
-          name: 'version.odf.openshift.io',
-          value: '4.14.0-rhodf',
-        },
-        {
-          name: 'count.storagecluster.odf.openshift.io',
-          value: '1',
-        },
       ],
       conditions: [
         {
@@ -74,26 +54,6 @@ const managedClusters: ACMManagedClusterKind[] = [
         {
           name: 'region.open-cluster-management.io',
           value: 'us-west-1',
-        },
-        {
-          name: 'cephfsid.odf.openshift.io',
-          value: '84eea701-7d87-4f1f-a594-6d0c899327e3',
-        },
-        {
-          name: 'storageclustername.odf.openshift.io',
-          value: 'ocs-storagecluster/openshift-storage',
-        },
-        {
-          name: 'storagesystemname.odf.openshift.io',
-          value: 'ocs-storagecluster-storagesystem/openshift-storage',
-        },
-        {
-          name: 'version.odf.openshift.io',
-          value: '4.14.0-rhodf',
-        },
-        {
-          name: 'count.storagecluster.odf.openshift.io',
-          value: '1',
         },
       ],
       conditions: [
@@ -181,26 +141,6 @@ const managedClusters: ACMManagedClusterKind[] = [
           name: 'region.open-cluster-management.io',
           value: 'us-east-3',
         },
-        {
-          name: 'cephfsid.odf.openshift.io',
-          value: 'bc2965d7-f9b1-4c08-b8fa-dd4fdfa38f71',
-        },
-        {
-          name: 'storageclustername.odf.openshift.io',
-          value: 'ocs-storagecluster/openshift-storage',
-        },
-        {
-          name: 'storagesystemname.odf.openshift.io',
-          value: 'ocs-storagecluster-storagesystem/openshift-storage',
-        },
-        {
-          name: 'version.odf.openshift.io',
-          value: '4.14.0-rhodf',
-        },
-        {
-          name: 'count.storagecluster.odf.openshift.io',
-          value: '2',
-        },
       ],
       conditions: [
         {
@@ -263,26 +203,6 @@ const managedClusters: ACMManagedClusterKind[] = [
           name: 'region.open-cluster-management.io',
           value: 'us-east-4',
         },
-        {
-          name: 'cephfsid.odf.openshift.io',
-          value: '3e121eef-d363-42fd-93d4-744044b6e4cc',
-        },
-        {
-          name: 'storageclustername.odf.openshift.io',
-          value: 'ocs-storagecluster/openshift-storage',
-        },
-        {
-          name: 'storagesystemname.odf.openshift.io',
-          value: 'ocs-storagecluster-storagesystem/openshift-storage',
-        },
-        {
-          name: 'version.odf.openshift.io',
-          value: '4.13.0-rhodf',
-        },
-        {
-          name: 'count.storagecluster.odf.openshift.io',
-          value: '1',
-        },
       ],
       conditions: [
         {
@@ -314,26 +234,6 @@ const managedClusters: ACMManagedClusterKind[] = [
           name: 'region.open-cluster-management.io',
           value: 'us-west-4',
         },
-        {
-          name: 'cephfsid.odf.openshift.io',
-          value: '',
-        },
-        {
-          name: 'storageclustername.odf.openshift.io',
-          value: 'ocs-storagecluster/openshift-storage',
-        },
-        {
-          name: 'storagesystemname.odf.openshift.io',
-          value: 'ocs-storagecluster-storagesystem/openshift-storage',
-        },
-        {
-          name: 'version.odf.openshift.io',
-          value: '4.14.0-rhodf',
-        },
-        {
-          name: 'count.storagecluster.odf.openshift.io',
-          value: '1',
-        },
       ],
       conditions: [
         {
@@ -364,26 +264,6 @@ const managedClusters: ACMManagedClusterKind[] = [
         {
           name: 'region.open-cluster-management.io',
           value: 'us-east-5',
-        },
-        {
-          name: 'cephfsid.odf.openshift.io',
-          value: 'c1ea826f-1dc2-4faa-87b2-f0fc4665b11a',
-        },
-        {
-          name: 'storageclustername.odf.openshift.io',
-          value: 'ocs-storagecluster/openshift-storage',
-        },
-        {
-          name: 'storagesystemname.odf.openshift.io',
-          value: 'ocs-storagecluster-storagesystem/openshift-storage',
-        },
-        {
-          name: 'version.odf.openshift.io',
-          value: '4.14.0-rhodf',
-        },
-        {
-          name: 'count.storagecluster.odf.openshift.io',
-          value: '1',
         },
       ],
       conditions: [

--- a/packages/mco/components/discovered-application-wizard/utils/reducer.ts
+++ b/packages/mco/components/discovered-application-wizard/utils/reducer.ts
@@ -1,11 +1,10 @@
+import { NAME_NAMESPACE_SPLIT_CHAR } from '@odf/mco/constants';
 import { DRPolicyKind } from '@odf/mco/types';
 import {
   K8sResourceCommon,
   MatchExpression,
 } from '@openshift-console/dynamic-plugin-sdk';
 import * as _ from 'lodash-es';
-
-export const NAME_NAMESPACE_SPLIT_CHAR = '/';
 
 export enum ProtectionMethodType {
   RECIPE = 'RECIPE',

--- a/packages/mco/components/discovered-application-wizard/wizard-steps/configuration-step/recipe-selection.tsx
+++ b/packages/mco/components/discovered-application-wizard/wizard-steps/configuration-step/recipe-selection.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useACMSafeFetch } from '@odf/mco/hooks';
 import { SearchResultItemType } from '@odf/mco/types';
-import { queryRecipesFromCluster } from '@odf/mco/utils';
+import { queryRecipesFromCluster, getNameNamespace } from '@odf/mco/utils';
 import { SingleSelectDropdown } from '@odf/shared/dropdown';
 import { StatusBox } from '@odf/shared/generic/status-box';
 import { getName } from '@odf/shared/selectors';
@@ -19,16 +19,8 @@ import {
 import {
   EnrollDiscoveredApplicationAction,
   EnrollDiscoveredApplicationStateType,
-  NAME_NAMESPACE_SPLIT_CHAR,
 } from '../../utils/reducer';
 import './configuration-step.scss';
-
-const getNameNamespace = (name: string, namespace: string) =>
-  // Multiple namespace can have recipe with same name,
-  // Converting into name/namespace for unique identification in dropdown option
-  !!name && !!namespace
-    ? `${name}${NAME_NAMESPACE_SPLIT_CHAR}${namespace}`
-    : '';
 
 const getRecipeOptions = (
   searchResultItem: SearchResultItemType[]
@@ -74,6 +66,8 @@ export const RecipeSelection: React.FC<RecipeSelectionProps> = ({
       ? getRecipeOptions(searchResult?.data.searchResult?.[0]?.items || [])
       : [];
 
+  // Multiple namespace can have recipe with same name,
+  // Converting into name/namespace for unique identification in dropdown option
   const recipeNameNamespace = getNameNamespace(recipeName, recipeNamespace);
   // For no recipe found has different validation message
   // For recipe not selected has different validation message

--- a/packages/mco/constants/acm.ts
+++ b/packages/mco/constants/acm.ts
@@ -36,15 +36,6 @@ export const APPLICATION_TYPE_DISPLAY_TEXT = (
   [APPLICATION_TYPE.DISCOVERED]: t('Discovered'),
 });
 
-// Please refer to clusterclaims.go in github.com/red-hat-storage/ocs-operator before changing anything here
-export enum ClusterClaimTypes {
-  ODF_VERSION = 'version.odf.openshift.io',
-  STORAGE_CLUSTER_NAME = 'storageclustername.odf.openshift.io',
-  STORAGE_SYSTEM_NAME = 'storagesystemname.odf.openshift.io',
-  CEPH_FSID = 'cephfsid.odf.openshift.io',
-  STORAGE_CLUSTER_COUNT = 'count.storagecluster.odf.openshift.io',
-}
-
 // Managed cluster status conditions
 export const MANAGED_CLUSTER_CONDITION_AVAILABLE =
   'ManagedClusterConditionAvailable';

--- a/packages/mco/constants/common.ts
+++ b/packages/mco/constants/common.ts
@@ -21,3 +21,5 @@ export const ADMIN_FLAG = 'ADMIN';
 
 // Discovered application namespace
 export const DISCOVERED_APP_NS = 'openshift-dr-ops';
+
+export const NAME_NAMESPACE_SPLIT_CHAR = '/';

--- a/packages/mco/constants/disaster-recovery.ts
+++ b/packages/mco/constants/disaster-recovery.ts
@@ -104,3 +104,10 @@ export const EnrollDiscoveredApplicationStepNames = (t: TFunction) => ({
   [EnrollDiscoveredApplicationSteps.Replication]: t('Replication'),
   [EnrollDiscoveredApplicationSteps.Review]: t('Review'),
 });
+
+export const MCV_NAME_TEMPLATE = 'odf-multicluster-mcv-';
+
+export const MCO_CREATED_BY_LABEL_KEY =
+  'multicluster.odf.openshift.io/created-by';
+export const MCO_CREATED_BY_MC_CONTROLLER =
+  'odf-multicluster-managedcluster-controller';

--- a/packages/mco/types/odf-mco.ts
+++ b/packages/mco/types/odf-mco.ts
@@ -13,3 +13,25 @@ export type MirrorPeerKind = K8sResourceCommon & {
     type: string;
   };
 };
+
+export type ConnectedClient = {
+  name: string;
+  clusterId: string;
+};
+
+export type InfoStorageCluster = {
+  namespacedName: {
+    name: string;
+    namespace: string;
+  };
+  storageProviderEndpoint: string;
+  cephClusterFSID: string;
+};
+
+export type ODFInfoYamlObject = {
+  version: string;
+  deploymentType: string;
+  clients: ConnectedClient[];
+  storageCluster: InfoStorageCluster;
+  storageSystemName: string;
+};

--- a/packages/mco/utils/disaster-recovery.tsx
+++ b/packages/mco/utils/disaster-recovery.tsx
@@ -34,6 +34,8 @@ import {
   LABELS_SPLIT_CHAR,
   DR_BLOCK_LISTED_LABELS,
   PLACEMENT_RULE_REF_LABEL,
+  MCV_NAME_TEMPLATE,
+  NAME_NAMESPACE_SPLIT_CHAR,
 } from '../constants';
 import {
   DRPC_NAMESPACE_ANNOTATION,
@@ -630,6 +632,11 @@ export const getValueFromClusterClaim = (
 export const parseNamespaceName = (namespaceName: string) =>
   namespaceName.split('/');
 
+export const getNameNamespace = (name: string, namespace: string) =>
+  !!name && !!namespace
+    ? `${name}${NAME_NAMESPACE_SPLIT_CHAR}${namespace}`
+    : '';
+
 export const getLabelsFromSearchResult = (
   item: SearchResultItemType
 ): { [key in string]: string[] } => {
@@ -643,3 +650,6 @@ export const getLabelsFromSearchResult = (
     return acc;
   }, {});
 };
+
+export const getManagedClusterViewName = (managedClusterName: string): string =>
+  MCV_NAME_TEMPLATE + managedClusterName;


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2297447

### Before:
OCS used to create multiple ClusterClaims and MCO console used to read ODF info (StorageCluster, Ceph details) from ManageCluster CR's status.

### After:
https://github.com/red-hat-storage/ocs-operator/pull/2440
https://github.com/red-hat-storage/odf-multicluster-orchestrator/pull/219
OCS now creates a single ConfigMap (with all the StorageClusters, Clients details) and a single ClusterClaim (with ConfigMap's namespaced-name details), MCO creates the corresponding ManagedClusterView referencing this ConfigMap and MCO console reads ODF info from the ManagedClusterView CR.