### PR TITLE
Fix storage pool description visibility in modal

### DIFF
--- a/packages/ocs/modals/storage-pool/create-storage-pool-modal.tsx
+++ b/packages/ocs/modals/storage-pool/create-storage-pool-modal.tsx
@@ -206,10 +206,14 @@ export const CreateStoragePoolModal = withHandlePromise(
           onClose={props.closeModal}
           className="modal-content storage-pool__modal"
           variant={ModalVariant.medium}
-          header={<ModalTitle>{MODAL_TITLE}</ModalTitle>}
+          header={
+            <>
+              <ModalTitle>{MODAL_TITLE}</ModalTitle>
+              <StoragePoolDefinitionText className="pf-v5-u-ml-xl" />
+            </>
+          }
         >
           <ModalBody>
-            <StoragePoolDefinitionText className="storage-pool__definition-text" />
             {state.poolStatus ? (
               <div key="progress-modal">
                 <StoragePoolStatus

--- a/packages/ocs/modals/storage-pool/storage-pool-modal.scss
+++ b/packages/ocs/modals/storage-pool/storage-pool-modal.scss
@@ -1,7 +1,3 @@
 .storage-pool__modal {
     height: 77vh;
 }
-.storage-pool__definition-text {
-    margin-bottom: 5vh;
-    margin-top: -5vh;
-}

--- a/packages/ocs/modals/storage-pool/update-storage-pool-modal.tsx
+++ b/packages/ocs/modals/storage-pool/update-storage-pool-modal.tsx
@@ -246,14 +246,18 @@ const UpdateStoragePoolModalBase: React.FC<UpdateStoragePoolModalBaseProps> = (
     <Modal
       className="modal-content storage-pool__modal"
       isOpen={isOpen}
-      header={<ModalTitle>{MODAL_TITLE}</ModalTitle>}
+      header={
+        <>
+          <ModalTitle>{MODAL_TITLE}</ModalTitle>
+          <StoragePoolDefinitionText className="pf-v5-u-ml-xl" />
+        </>
+      }
       variant={ModalVariant.medium}
       onClose={closeModal}
     >
       {cephClustersLoaded && !cephClustersLoadError ? (
         <>
           <ModalBody>
-            <StoragePoolDefinitionText className="storage-pool__definition-text" />
             {state.poolStatus ? (
               <div key="progress-modal">
                 <StoragePoolStatus


### PR DESCRIPTION
NOTE: the reported issue was reproducible on an older version of Chrome (v118) in 2.5K resolution (2560x1440).
On supported Chrome versions the issue is not reproducible.
This cleanup also fixes it for a lower resolution (800x1280: Nexus 10 / Kindle Fire HDX).

Fixes: https://issues.redhat.com/browse/DFBUGS-6

Before:
![image](https://github.com/user-attachments/assets/f5f3ade4-3166-4de4-9471-dda6d60b83f4)

After:
![image](https://github.com/user-attachments/assets/273bbb66-2b8b-4be1-aa35-477e639192ad)
