### PR TITLE
Bug 2297295: Hide builtin-mgr CephBlockPool

### DIFF
--- a/packages/ocs/storage-class/sc-form.tsx
+++ b/packages/ocs/storage-class/sc-form.tsx
@@ -19,7 +19,10 @@ import {
   useODFNamespaceSelector,
   useODFSystemFlagsSelector,
 } from '@odf/core/redux';
-import { cephClusterResource } from '@odf/core/resources';
+import {
+  cephBlockPoolResource,
+  cephClusterResource,
+} from '@odf/core/resources';
 import {
   ProviderNames,
   KmsCsiConfigKeysMapping,
@@ -27,7 +30,7 @@ import {
   K8sResourceObj,
 } from '@odf/core/types';
 import { getResourceInNs } from '@odf/core/utils';
-import { CephBlockPoolModel, CephFileSystemModel } from '@odf/ocs/models';
+import { CephFileSystemModel } from '@odf/ocs/models';
 import ResourceDropdown from '@odf/shared/dropdown/ResourceDropdown';
 import { ButtonBar } from '@odf/shared/generic/ButtonBar';
 import { StatusBox } from '@odf/shared/generic/status-box';
@@ -98,11 +101,6 @@ type OnParamChange = (id: string, paramName: string, checkbox: boolean) => void;
 
 const storageSystemResource: WatchK8sResource = {
   kind: referenceForModel(ODFStorageSystem),
-  isList: true,
-};
-
-const cephBlockPoolResource: WatchK8sResource = {
-  kind: referenceForModel(CephBlockPoolModel),
   isList: true,
 };
 

--- a/packages/ocs/storage-pool/StoragePoolListPage.tsx
+++ b/packages/ocs/storage-pool/StoragePoolListPage.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { useODFSystemFlagsSelector } from '@odf/core/redux';
+import { cephBlockPoolResource } from '@odf/core/resources';
 import { healthStateMapping } from '@odf/shared/dashboards/status-card/states';
 import {
   useCustomPrometheusPoll,
@@ -428,10 +429,7 @@ const resources = {
     namespaced: false,
     isList: true,
   },
-  blockPools: {
-    kind: referenceForModel(CephBlockPoolModel),
-    isList: true,
-  },
+  blockPools: cephBlockPoolResource,
   filesystem: {
     kind: referenceForModel(CephFileSystemModel),
     isList: false,

--- a/packages/odf/resources.ts
+++ b/packages/odf/resources.ts
@@ -57,13 +57,16 @@ export const subscriptionResource: WatchK8sResource = {
   kind: referenceForModel(SubscriptionModel),
   namespaced: false,
 };
-
-export const cephBlockPoolResource: K8sResourceObj = (ns) => ({
+/**
+ * Retrieve all the CRs except those not meant to be
+ * exposed to the users. See:
+ * https://bugzilla.redhat.com/show_bug.cgi?id=2297295
+ */
+export const cephBlockPoolResource: WatchK8sResource = {
   kind: referenceForModel(CephBlockPoolModel),
-  namespaced: true,
   isList: true,
-  namespace: ns,
-});
+  fieldSelector: 'metadata.name!=builtin-mgr',
+};
 
 export const nodeResource: WatchK8sResource = {
   kind: NodeModel.kind,


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2297295

- Storage pool list
Before:
![pool-list-before](https://github.com/user-attachments/assets/535a8bc9-9dff-416f-b656-3ca017b6c70a)

After:
![pool-list-after](https://github.com/user-attachments/assets/80fb352f-bdff-4879-8307-d3b72c1afb6e)

- StorageClass creation Form:
Before:
![sc-form-before](https://github.com/user-attachments/assets/7c7fa42c-b32b-44e4-8ae8-dbd6f40a7197)

After:
![sc-form-after](https://github.com/user-attachments/assets/21dcd263-b89e-46b7-bfd6-156b45a0c610)
