### PR TITLE
Cleanup: remove duplicated resource models

### DIFF
--- a/packages/mco/components/mco-dashboard/storage-system/status-card/status-card.tsx
+++ b/packages/mco/components/mco-dashboard/storage-system/status-card/status-card.tsx
@@ -5,7 +5,7 @@ import {
   csvStatusMap,
 } from '@odf/shared/dashboards/status-card/states';
 import { useCustomPrometheusPoll } from '@odf/shared/hooks/custom-prometheus-poll';
-import { OCSStorageClusterModel } from '@odf/shared/models';
+import { StorageClusterModel } from '@odf/shared/models';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { getGVK } from '@odf/shared/utils';
 import {
@@ -86,7 +86,7 @@ const setHealthData = (
     healthData.push({
       systemName: item?.metric?.storage_system,
       rawHealthData:
-        apiGroup === OCSStorageClusterModel.apiGroup
+        apiGroup === StorageClusterModel.apiGroup
           ? unifiedHealthVal
           : healthVal,
     });

--- a/packages/ocs/dashboards/persistent-external/details-card.tsx
+++ b/packages/ocs/dashboards/persistent-external/details-card.tsx
@@ -5,7 +5,7 @@ import { useODFNamespaceSelector } from '@odf/core/redux';
 import { getStorageClusterInNs } from '@odf/core/utils';
 import { ODF_OPERATOR, OCS_OPERATOR } from '@odf/shared/constants';
 import { useFetchCsv } from '@odf/shared/hooks/use-fetch-csv';
-import { SecretModel } from '@odf/shared/models';
+import { SecretModel, StorageClusterModel } from '@odf/shared/models';
 import { getName } from '@odf/shared/selectors';
 import {
   SecretKind,
@@ -25,7 +25,6 @@ import { OverviewDetailItem as DetailItem } from '@openshift-console/plugin-shar
 import { Base64 } from 'js-base64';
 import { useParams } from 'react-router-dom-v5-compat';
 import { Card, CardBody, CardHeader, CardTitle } from '@patternfly/react-core';
-import { StorageClusterModel } from '../../models';
 import { ODFSystemParams } from '../../types';
 import { getNetworkEncryption } from '../../utils';
 

--- a/packages/ocs/dashboards/persistent-internal/activity-card/activity-card.tsx
+++ b/packages/ocs/dashboards/persistent-internal/activity-card/activity-card.tsx
@@ -13,6 +13,7 @@ import {
   usePrometheusBasePath,
 } from '@odf/shared/hooks/custom-prometheus-poll';
 import { useDeepCompareMemoize } from '@odf/shared/hooks/deep-compare-memoize';
+import { CephClusterModel, StorageClusterModel } from '@odf/shared/models';
 import {
   EventModel,
   PersistentVolumeClaimModel,
@@ -40,7 +41,6 @@ import * as _ from 'lodash-es';
 import { useParams } from 'react-router-dom-v5-compat';
 import { Card, CardHeader, CardTitle, CardBody } from '@patternfly/react-core';
 import { PVC_PROVISIONER_ANNOTATION } from '../../../constants';
-import { CephClusterModel, StorageClusterModel } from '../../../models';
 import {
   DATA_RESILIENCY_QUERY,
   StorageDashboardQuery,

--- a/packages/ocs/dashboards/persistent-internal/details-card.tsx
+++ b/packages/ocs/dashboards/persistent-internal/details-card.tsx
@@ -4,6 +4,7 @@ import { getStorageClusterInNs } from '@odf/core/utils';
 import { ODF_OPERATOR } from '@odf/shared/constants';
 import { useK8sGet } from '@odf/shared/hooks/k8s-get-hook';
 import { useFetchCsv } from '@odf/shared/hooks/use-fetch-csv';
+import { StorageClusterModel } from '@odf/shared/models';
 import {
   ClusterServiceVersionModel,
   InfrastructureModel,
@@ -26,7 +27,6 @@ import { OverviewDetailItem as DetailItem } from '@openshift-console/plugin-shar
 import { Link, useParams } from 'react-router-dom-v5-compat';
 import { Card, CardBody, CardHeader, CardTitle } from '@patternfly/react-core';
 import { PROVIDER_MODE } from '../../../odf/features';
-import { StorageClusterModel } from '../../models';
 import { ODFSystemParams } from '../../types';
 import { getNetworkEncryption } from '../../utils';
 

--- a/packages/ocs/dashboards/persistent-internal/status-card/status-card.tsx
+++ b/packages/ocs/dashboards/persistent-internal/status-card/status-card.tsx
@@ -9,6 +9,7 @@ import {
   useCustomPrometheusPoll,
   usePrometheusBasePath,
 } from '@odf/shared/hooks/custom-prometheus-poll';
+import { CephClusterModel } from '@odf/shared/models';
 import useAlerts from '@odf/shared/monitoring/useAlert';
 import { alertURL } from '@odf/shared/monitoring/utils';
 import { K8sResourceKind } from '@odf/shared/types';
@@ -37,7 +38,6 @@ import {
   CardBody,
   CardTitle,
 } from '@patternfly/react-core';
-import { CephClusterModel } from '../../../models';
 import { DATA_RESILIENCY_QUERY, StorageDashboardQuery } from '../../../queries';
 import { ODFSystemParams } from '../../../types';
 import { getDataResiliencyState } from './utils';

--- a/packages/ocs/hooks/useOcsHealth.ts
+++ b/packages/ocs/hooks/useOcsHealth.ts
@@ -3,6 +3,7 @@ import {
   useCustomPrometheusPoll,
   usePrometheusBasePath,
 } from '@odf/shared/hooks/custom-prometheus-poll';
+import { CephClusterModel } from '@odf/shared/models';
 import { getName, getNamespace } from '@odf/shared/selectors';
 import { K8sResourceKind, StorageSystemKind } from '@odf/shared/types';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
@@ -13,11 +14,7 @@ import {
   WatchK8sResource,
 } from '@openshift-console/dynamic-plugin-sdk';
 import * as _ from 'lodash-es';
-import {
-  CephClusterModel,
-  CephObjectStoreModel,
-  NooBaaSystemModel,
-} from '../models/core';
+import { CephObjectStoreModel, NooBaaSystemModel } from '../models/core';
 import { Health, HEALTH_QUERY } from '../queries';
 import {
   getCephHealthState,

--- a/packages/ocs/modals/storage-pool/create-storage-pool-modal.tsx
+++ b/packages/ocs/modals/storage-pool/create-storage-pool-modal.tsx
@@ -9,7 +9,7 @@ import {
   withHandlePromise,
 } from '@odf/shared/generic/promise-component';
 import { ModalBody } from '@odf/shared/modals/Modal';
-import { OCSStorageClusterModel } from '@odf/shared/models';
+import { StorageClusterModel } from '@odf/shared/models';
 import { getNamespace } from '@odf/shared/selectors';
 import { CephClusterKind, StorageClusterKind } from '@odf/shared/types';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
@@ -62,7 +62,7 @@ export const CreateStoragePoolModal = withHandlePromise(
     const clusterName = systemFlags[poolNs]?.ocsClusterName;
     const [storageCluster, storageClusterLoaded, storageClusterLoadError] =
       useSafeK8sGet<StorageClusterKind>(
-        OCSStorageClusterModel,
+        StorageClusterModel,
         clusterName,
         poolNs
       );
@@ -82,7 +82,7 @@ export const CreateStoragePoolModal = withHandlePromise(
     const initResource =
       poolType === POOL_TYPE.FILESYSTEM
         ? {
-            kind: referenceForModel(OCSStorageClusterModel),
+            kind: referenceForModel(StorageClusterModel),
             namespaced: true,
             isList: false,
             name: clusterName,

--- a/packages/ocs/modals/storage-pool/delete-storage-pool-modal.tsx
+++ b/packages/ocs/modals/storage-pool/delete-storage-pool-modal.tsx
@@ -10,7 +10,7 @@ import {
   ModalHeader,
 } from '@odf/shared/modals/Modal';
 import {
-  OCSStorageClusterModel,
+  StorageClusterModel,
   PersistentVolumeClaimModel,
   StorageClassModel,
 } from '@odf/shared/models';
@@ -74,7 +74,7 @@ const deleteFsPoolRequest = (
 
   return () =>
     k8sPatch({
-      model: OCSStorageClusterModel,
+      model: StorageClusterModel,
       resource: storageCluster,
       data: patches,
     });
@@ -140,7 +140,7 @@ const DeleteFsPoolModal: React.FC<DeleteFsPoolModalProps> = (props) => {
   const clusterName = systemFlags[poolNamespace]?.ocsClusterName;
   const [storageCluster, storageClusterLoaded, storageClusterLoadError] =
     useSafeK8sGet<StorageClusterKind>(
-      OCSStorageClusterModel,
+      StorageClusterModel,
       clusterName,
       poolNamespace
     );

--- a/packages/ocs/modals/storage-pool/update-storage-pool-modal.tsx
+++ b/packages/ocs/modals/storage-pool/update-storage-pool-modal.tsx
@@ -7,7 +7,7 @@ import { StoragePoolDefinitionText } from '@odf/ocs/storage-pool/CreateStoragePo
 import { ModalFooter, ModalTitle } from '@odf/shared/generic/ModalTitle';
 import { StatusBox } from '@odf/shared/generic/status-box';
 import { CommonModalProps, ModalBody } from '@odf/shared/modals/Modal';
-import { OCSStorageClusterModel } from '@odf/shared/models';
+import { CephClusterModel, StorageClusterModel } from '@odf/shared/models';
 import { getName, getNamespace } from '@odf/shared/selectors';
 import { CephClusterKind, StorageClusterKind } from '@odf/shared/types';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
@@ -27,7 +27,7 @@ import {
   POOL_PROGRESS,
   POOL_TYPE,
 } from '../../constants';
-import { CephBlockPoolModel, CephClusterModel } from '../../models';
+import { CephBlockPoolModel } from '../../models';
 import { StoragePoolBody, StoragePoolStatus } from '../../storage-pool/body';
 import {
   StoragePoolActionType,
@@ -61,7 +61,7 @@ const updateFsPoolRequest = (
 
   return () =>
     k8sPatch({
-      model: OCSStorageClusterModel,
+      model: StorageClusterModel,
       resource: storageCluster,
       data: patches,
     });
@@ -119,7 +119,7 @@ const UpdateFsPoolModal: React.FC<UpdateFsPoolModalProps> = (props) => {
   const clusterName = systemFlags[poolNamespace]?.ocsClusterName;
   const [storageCluster, storageClusterLoaded, storageClusterLoadError] =
     useSafeK8sGet<StorageClusterKind>(
-      OCSStorageClusterModel,
+      StorageClusterModel,
       clusterName,
       poolNamespace
     );

--- a/packages/ocs/models/core.ts
+++ b/packages/ocs/models/core.ts
@@ -3,19 +3,6 @@ import {
   K8sModel,
 } from '@openshift-console/dynamic-plugin-sdk/lib/api/common-types';
 
-export const CephClusterModel: K8sKind = {
-  label: 'Ceph Cluster',
-  labelPlural: 'Ceph Clusters',
-  apiVersion: 'v1',
-  apiGroup: 'ceph.rook.io',
-  plural: 'cephclusters',
-  abbr: 'CC',
-  namespaced: true,
-  kind: 'CephCluster',
-  id: 'cephcluster',
-  crd: true,
-};
-
 export const CephObjectStoreModel: K8sKind = {
   label: 'Ceph Object Store',
   labelPlural: 'Ceph Object Stores',
@@ -41,19 +28,6 @@ export const NooBaaSystemModel: K8sKind = {
   id: 'noobaasystem',
   crd: true,
   legacyPluralURL: true,
-};
-
-export const StorageClusterModel: K8sKind = {
-  label: 'Storage Cluster',
-  labelPlural: 'Storage Clusters',
-  apiVersion: 'v1',
-  apiGroup: 'ocs.openshift.io',
-  plural: 'storageclusters',
-  abbr: 'OCS',
-  namespaced: true,
-  kind: 'StorageCluster',
-  id: 'ocscluster',
-  crd: true,
 };
 
 export const CephBlockPoolModel: K8sKind = {

--- a/packages/ocs/storage-pool/BlockPoolDetailsPage.tsx
+++ b/packages/ocs/storage-pool/BlockPoolDetailsPage.tsx
@@ -2,13 +2,14 @@ import * as React from 'react';
 import DetailsPage from '@odf/shared/details-page/DetailsPage';
 import { Kebab } from '@odf/shared/kebab/kebab';
 import { ModalKeys } from '@odf/shared/modals/types';
+import { CephClusterModel } from '@odf/shared/models';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { referenceForModel } from '@odf/shared/utils';
 import { EventStreamWrapped, YAMLEditorWrapped } from '@odf/shared/utils/Tabs';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { useParams, useLocation } from 'react-router-dom-v5-compat';
 import { BlockPoolDashboard } from '../dashboards/block-pool/block-pool-dashboard';
-import { CephBlockPoolModel, CephClusterModel } from '../models';
+import { CephBlockPoolModel } from '../models';
 import { StoragePoolKind } from '../types';
 
 export const cephClusterResource = {

--- a/packages/ocs/storage-pool/CreateStoragePool.tsx
+++ b/packages/ocs/storage-pool/CreateStoragePool.tsx
@@ -7,7 +7,7 @@ import {
 import { useODFSystemFlagsSelector } from '@odf/core/redux';
 import { getResourceInNs as getCephClusterInNs } from '@odf/core/utils';
 import { StatusBox } from '@odf/shared/generic/status-box';
-import { OCSStorageClusterModel } from '@odf/shared/models';
+import { CephClusterModel, StorageClusterModel } from '@odf/shared/models';
 import { getName } from '@odf/shared/selectors';
 import {
   CephClusterKind,
@@ -37,11 +37,7 @@ import {
   POOL_STATE,
   POOL_TYPE,
 } from '../constants';
-import {
-  CephBlockPoolModel,
-  CephClusterModel,
-  CephFileSystemModel,
-} from '../models';
+import { CephBlockPoolModel, CephFileSystemModel } from '../models';
 import { CephFilesystemKind, StoragePoolKind } from '../types';
 import {
   getErrorMessage,
@@ -82,7 +78,7 @@ export const createFsPoolRequest = (
 
   return () =>
     k8sPatch({
-      model: OCSStorageClusterModel,
+      model: StorageClusterModel,
       resource: storageCluster,
       data: [patch],
     });
@@ -200,11 +196,7 @@ const CreateStoragePool: React.FC<{}> = ({}) => {
   }, [blockPools, blockPoolsLoaded, blockPoolsLoadError, defaultBlockPoolName]);
 
   const [storageCluster, storageClusterLoaded, storageClusterLoadError] =
-    useSafeK8sGet<StorageClusterKind>(
-      OCSStorageClusterModel,
-      clusterName,
-      poolNs
-    );
+    useSafeK8sGet<StorageClusterKind>(StorageClusterModel, clusterName, poolNs);
 
   const isLoaded =
     areFlagsLoaded &&

--- a/packages/ocs/storage-pool/body.tsx
+++ b/packages/ocs/storage-pool/body.tsx
@@ -6,6 +6,7 @@ import {
 } from '@odf/shared/constants';
 import { useK8sGet } from '@odf/shared/hooks';
 import { TextInputWithFieldRequirements } from '@odf/shared/input-with-requirements';
+import { StorageClusterModel } from '@odf/shared/models';
 import { getNamespace } from '@odf/shared/selectors';
 import {
   ListKind,
@@ -41,7 +42,6 @@ import {
   POOL_STATE,
   POOL_TYPE,
 } from '../constants';
-import { StorageClusterModel } from '../models';
 import {
   getErrorMessage,
   ProgressStatusProps,

--- a/packages/ocs/utils/storage-pool.tsx
+++ b/packages/ocs/utils/storage-pool.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { ModalKeys } from '@odf/shared/modals/types';
+import { StorageClusterModel } from '@odf/shared/models';
 import { getName } from '@odf/shared/selectors';
 import {
   StorageClassResourceKind,
@@ -19,7 +20,6 @@ import {
   POOL_TYPE,
   ROOK_MODEL,
 } from '../constants';
-import { StorageClusterModel } from '../models';
 import { CephFilesystemKind, StoragePool, StoragePoolKind } from '../types';
 import { LoadingComponent } from './CustomLoading';
 

--- a/packages/odf/components/alerts/alert-action-path.tsx
+++ b/packages/odf/components/alerts/alert-action-path.tsx
@@ -1,6 +1,6 @@
 import { getStorageClusterInNs } from '@odf/core/utils';
-import { StorageClusterModel } from '@odf/ocs/models';
 import { CEPH_STORAGE_NAMESPACE } from '@odf/shared/constants';
+import { StorageClusterModel } from '@odf/shared/models';
 import { StorageClusterKind } from '@odf/shared/types';
 import { k8sList } from '@openshift-console/dynamic-plugin-sdk';
 import { AddCapacityModal } from '../../modals/add-capacity/add-capacity-modal';

--- a/packages/odf/components/cluster-overview-extensions/ClusterExpansion.tsx
+++ b/packages/odf/components/cluster-overview-extensions/ClusterExpansion.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StorageClusterModel } from '@odf/ocs/models';
+import { StorageClusterModel } from '@odf/shared/models';
 import { K8sResourceKind } from '@odf/shared/types';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { referenceForModel } from '@odf/shared/utils';

--- a/packages/odf/components/create-storage-system/create-steps.tsx
+++ b/packages/odf/components/create-storage-system/create-steps.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { StorageClassWizardStepExtensionProps as ExternalStorage } from '@odf/odf-plugin-sdk/extensions';
-import { OCSStorageClusterModel } from '@odf/shared/models';
+import { StorageClusterModel } from '@odf/shared/models';
 import { WizardStep } from '@patternfly/react-core/deprecated';
 import { TFunction } from 'i18next';
 import { Steps, StepsName } from '../../constants';
@@ -259,7 +259,7 @@ export const createSteps = (
         },
       ];
     case BackingStorageType.EXTERNAL:
-      if (externalStorage === OCSStorageClusterModel.kind) {
+      if (externalStorage === StorageClusterModel.kind) {
         return rhcsExternalProviderSteps;
       }
       if (!hasOCS) {

--- a/packages/odf/components/create-storage-system/create-storage-system-steps/backing-storage-step/backing-storage-step.tsx
+++ b/packages/odf/components/create-storage-system/create-storage-system-steps/backing-storage-step/backing-storage-step.tsx
@@ -15,7 +15,7 @@ import { useK8sGet } from '@odf/shared/hooks/k8s-get-hook';
 import {
   ClusterServiceVersionModel,
   StorageClassModel,
-  OCSStorageClusterModel,
+  StorageClusterModel,
 } from '@odf/shared/models';
 import { getName } from '@odf/shared/selectors';
 import {
@@ -215,7 +215,7 @@ export const BackingStorage: React.FC<BackingStorageProps> = ({
   const isProviderMode = deployment === DeploymentType.PROVIDER_MODE;
   const isNonRHCSExternalType =
     type === BackingStorageType.EXTERNAL &&
-    externalStorage !== OCSStorageClusterModel.kind;
+    externalStorage !== StorageClusterModel.kind;
 
   const allowedExternalStorage: ExternalStorage[] = React.useMemo(() => {
     const odfCsv = getODFCsv(csvList?.items);

--- a/packages/odf/components/create-storage-system/external-ceph-storage/system-connection-details.tsx
+++ b/packages/odf/components/create-storage-system/external-ceph-storage/system-connection-details.tsx
@@ -19,11 +19,7 @@ import {
 import { ROOK_CEPH_OPERATOR, OCS_OPERATOR } from '@odf/shared/constants';
 import { useK8sGet } from '@odf/shared/hooks/k8s-get-hook';
 import { useFetchCsv } from '@odf/shared/hooks/use-fetch-csv';
-import {
-  PodModel,
-  SecretModel,
-  OCSStorageClusterModel,
-} from '@odf/shared/models';
+import { PodModel, SecretModel, StorageClusterModel } from '@odf/shared/models';
 import { getAnnotations } from '@odf/shared/selectors';
 import { ListKind, PodKind } from '@odf/shared/types';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
@@ -250,10 +246,10 @@ export const EXTERNAL_CEPH_STORAGE: ExternalStorage[] = [
   {
     displayName: 'Red Hat Ceph Storage',
     model: {
-      apiGroup: OCSStorageClusterModel.apiGroup,
-      apiVersion: OCSStorageClusterModel.apiVersion,
-      kind: OCSStorageClusterModel.kind,
-      plural: OCSStorageClusterModel.plural,
+      apiGroup: StorageClusterModel.apiGroup,
+      apiVersion: StorageClusterModel.apiVersion,
+      kind: StorageClusterModel.kind,
+      plural: StorageClusterModel.plural,
     },
     component: ConnectionDetails,
     createPayload: rhcsPayload,

--- a/packages/odf/components/create-storage-system/footer.tsx
+++ b/packages/odf/components/create-storage-system/footer.tsx
@@ -22,7 +22,7 @@ import {
   getOsdAmount,
 } from '@odf/core/utils';
 import { StorageClassWizardStepExtensionProps as ExternalStorage } from '@odf/odf-plugin-sdk/extensions';
-import { OCSStorageClusterModel } from '@odf/shared/models';
+import { StorageClusterModel } from '@odf/shared/models';
 import { getName } from '@odf/shared/selectors';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { getGVKLabel } from '@odf/shared/utils';
@@ -126,7 +126,7 @@ const canJumpToNextStep = (
   } = state;
   const { type, externalStorage, deployment } = backingStorage;
   const isExternal: boolean = type === BackingStorageType.EXTERNAL;
-  const isRHCS: boolean = externalStorage === OCSStorageClusterModel.kind;
+  const isRHCS: boolean = externalStorage === StorageClusterModel.kind;
   const {
     capacity,
     enableArbiter,
@@ -238,7 +238,7 @@ const handleReviewAndCreateNext = async (
   } = state.backingStorage;
   const inTransitChecked = state.securityAndNetwork.encryption.inTransit;
   const { encryption, kms } = state.securityAndNetwork;
-  const isRhcs: boolean = externalStorage === OCSStorageClusterModel.kind;
+  const isRhcs: boolean = externalStorage === StorageClusterModel.kind;
   const isMCG: boolean = deployment === DeploymentType.MCG;
   const nsAlreadyExists = !!existingNamespaces.find(
     (ns) => getName(ns) === systemNamespace

--- a/packages/odf/components/create-storage-system/payloads.ts
+++ b/packages/odf/components/create-storage-system/payloads.ts
@@ -8,7 +8,7 @@ import {
   NOOBA_EXTERNAL_PG_SECRET_NAME,
 } from '@odf/shared/constants';
 import {
-  OCSStorageClusterModel,
+  StorageClusterModel,
   ODFStorageSystem,
   NodeModel,
   NamespaceModel,
@@ -214,7 +214,7 @@ export const createStorageCluster = async (
     storageClusterName,
   });
 
-  return k8sCreate({ model: OCSStorageClusterModel, data: payload });
+  return k8sCreate({ model: StorageClusterModel, data: payload });
 };
 
 export const labelNodes = async (

--- a/packages/odf/components/odf-dashboard/status-card/status-card.tsx
+++ b/packages/odf/components/odf-dashboard/status-card/status-card.tsx
@@ -10,7 +10,7 @@ import {
   useCustomPrometheusPoll,
   usePrometheusBasePath,
 } from '@odf/shared/hooks/custom-prometheus-poll';
-import { OCSStorageClusterModel, ODFStorageSystem } from '@odf/shared/models';
+import { StorageClusterModel, ODFStorageSystem } from '@odf/shared/models';
 import { getName, getNamespace } from '@odf/shared/selectors';
 import {
   ClusterServiceVersionKind,
@@ -102,7 +102,7 @@ export const StatusCard: React.FC = () => {
           const systemKind =
             referenceForGroupVersionKind(apiGroup)(apiVersion)(kind);
           const systemData =
-            apiGroup === OCSStorageClusterModel.apiGroup
+            apiGroup === StorageClusterModel.apiGroup
               ? {
                   systemName,
                   rawHealthData: ocsHealthStatus.rawHealthState,

--- a/packages/odf/components/topology/sidebar/TopologySideBarContent.tsx
+++ b/packages/odf/components/topology/sidebar/TopologySideBarContent.tsx
@@ -1,11 +1,14 @@
 import * as React from 'react';
 import { useODFNamespaceSelector } from '@odf/core/redux';
-import { StorageClusterModel } from '@odf/ocs/models';
 import { DetailsPageTitle } from '@odf/shared/details-page/DetailsPage';
 import { LoadingBox } from '@odf/shared/generic/status-box';
 import PageHeading from '@odf/shared/heading/page-heading';
 import useAutoExpand from '@odf/shared/hooks/useAutoExpand';
-import { DeploymentModel, NodeModel } from '@odf/shared/models';
+import {
+  DeploymentModel,
+  NodeModel,
+  StorageClusterModel,
+} from '@odf/shared/models';
 import { nodeStatus } from '@odf/shared/status/Node';
 import AlertsDetails from '@odf/shared/topology/sidebar/alerts/AlertsDetails';
 import {

--- a/packages/odf/components/topology/utils.ts
+++ b/packages/odf/components/topology/utils.ts
@@ -1,4 +1,4 @@
-import { StorageClusterModel } from '@odf/ocs/models';
+import { StorageClusterModel } from '@odf/shared/models';
 import { NodeModel } from '@odf/shared/models';
 import { getName } from '@odf/shared/selectors';
 import {

--- a/packages/odf/features.ts
+++ b/packages/odf/features.ts
@@ -1,7 +1,7 @@
 import {
   ODFStorageSystem,
   StorageClassModel,
-  OCSStorageClusterModel,
+  StorageClusterModel,
 } from '@odf/shared/models';
 import { SelfSubjectAccessReviewModel } from '@odf/shared/models';
 import {
@@ -49,7 +49,7 @@ export const setOCSFlags = async (setFlag: SetFeatureFlag) => {
     try {
       const storageClusters: StorageClusterKind[] =
         (await k8sList<K8sResourceCommon>({
-          model: OCSStorageClusterModel,
+          model: StorageClusterModel,
           queryParams: { ns: null },
           requestInit: null,
         })) as StorageClusterKind[];

--- a/packages/odf/modals/add-capacity/add-capacity-modal.tsx
+++ b/packages/odf/modals/add-capacity/add-capacity-modal.tsx
@@ -15,8 +15,8 @@ import {
 import { useK8sGet } from '@odf/shared/hooks/k8s-get-hook';
 import { CommonModalProps } from '@odf/shared/modals/common';
 import { ModalBody, ModalFooter, ModalHeader } from '@odf/shared/modals/Modal';
+import { StorageClusterModel } from '@odf/shared/models';
 import { PersistentVolumeModel, StorageClassModel } from '@odf/shared/models';
-import { OCSStorageClusterModel } from '@odf/shared/models';
 import { getName } from '@odf/shared/selectors';
 import {
   StorageClassResourceKind,
@@ -177,7 +177,7 @@ const AddSSCapacityModal: React.FC<AddSSCapacityModalProps> = ({
   ...props
 }) => {
   const [ocs, ocsLoaded, ocsError] = useK8sGet<StorageClusterKind>(
-    OCSStorageClusterModel,
+    StorageClusterModel,
     storageSystem.spec.name,
     storageSystem.spec.namespace
   );
@@ -378,7 +378,7 @@ export const AddCapacityModal: React.FC<AddCapacityModalProps> = ({
       setProgress(false);
     } else {
       k8sPatch({
-        model: OCSStorageClusterModel,
+        model: StorageClusterModel,
         resource: ocsConfig,
         data: [patch],
       })

--- a/packages/odf/modals/configure-performance/configure-performance-modal.tsx
+++ b/packages/odf/modals/configure-performance/configure-performance-modal.tsx
@@ -20,7 +20,7 @@ import { LoadingInline } from '@odf/shared/generic/Loading';
 import { useK8sGet } from '@odf/shared/hooks';
 import { CommonModalProps } from '@odf/shared/modals/common';
 import { ModalBody, ModalFooter, ModalHeader } from '@odf/shared/modals/Modal';
-import { OCSStorageClusterModel } from '@odf/shared/models';
+import { StorageClusterModel } from '@odf/shared/models';
 import { getNamespace } from '@odf/shared/selectors';
 import {
   DeviceSet,
@@ -158,7 +158,7 @@ const ConfigurePerformanceModal: React.FC<ConfigurePerformanceModalProps> = ({
         value: resourceProfile,
       };
       await k8sPatch({
-        model: OCSStorageClusterModel,
+        model: StorageClusterModel,
         resource: storageCluster,
         data: [patch],
       });
@@ -251,7 +251,7 @@ type ConfigureSSPerformanceModalProps = CommonModalProps & {
 const ConfigureSSPerformanceModal: React.FC<ConfigureSSPerformanceModalProps> =
   ({ extraProps: { resource: storageSystem }, ...props }) => {
     const [ocs, ocsLoaded, ocsError] = useK8sGet<StorageClusterKind>(
-      OCSStorageClusterModel,
+      StorageClusterModel,
       storageSystem.spec.name,
       storageSystem.spec.namespace
     );

--- a/packages/odf/redux/provider-hooks/useODFSystemFlags.ts
+++ b/packages/odf/redux/provider-hooks/useODFSystemFlags.ts
@@ -5,14 +5,13 @@ import {
   isClusterIgnored,
   isNFSEnabled,
 } from '@odf/core/utils';
+import { CephObjectStoreModel, NooBaaSystemModel } from '@odf/ocs/models';
+import { useDeepCompareMemoize } from '@odf/shared/hooks/deep-compare-memoize';
 import {
   CephClusterModel,
-  CephObjectStoreModel,
-  NooBaaSystemModel,
   StorageClusterModel,
-} from '@odf/ocs/models';
-import { useDeepCompareMemoize } from '@odf/shared/hooks/deep-compare-memoize';
-import { ODFStorageSystem } from '@odf/shared/models';
+  ODFStorageSystem,
+} from '@odf/shared/models';
 import {
   getName,
   getNamespace,

--- a/packages/odf/resources.ts
+++ b/packages/odf/resources.ts
@@ -8,7 +8,7 @@ import { K8sResourceObj } from '@odf/core/types';
 import {
   PersistentVolumeModel,
   StorageClassModel,
-  OCSStorageClusterModel,
+  StorageClusterModel,
   NodeModel,
   PersistentVolumeClaimModel,
   SecretModel,
@@ -82,7 +82,7 @@ export const nodesDiscoveriesResource: WatchK8sResource = {
 
 export const storageClusterResource: WatchK8sResource = {
   isList: true,
-  kind: referenceForModel(OCSStorageClusterModel),
+  kind: referenceForModel(StorageClusterModel),
 };
 
 export const odfPodsResource: K8sResourceObj = (ns) => ({

--- a/packages/shared/src/models/common.ts
+++ b/packages/shared/src/models/common.ts
@@ -248,16 +248,3 @@ export const DaemonSetModel: K8sKind = {
   labelPlural: 'DaemonSets',
   labelPluralKey: 'DaemonSets',
 };
-
-export const StorageClusterModel: K8sKind = {
-  label: 'Storage Cluster',
-  labelPlural: 'Storage Clusters',
-  apiVersion: 'v1',
-  apiGroup: 'ocs.openshift.io',
-  plural: 'storageclusters',
-  abbr: 'OCS',
-  namespaced: true,
-  kind: 'StorageCluster',
-  id: 'ocscluster',
-  crd: true,
-};

--- a/packages/shared/src/models/storage.ts
+++ b/packages/shared/src/models/storage.ts
@@ -12,7 +12,7 @@ export const ODFStorageSystem: K8sModel = {
   crd: true,
 };
 
-export const OCSStorageClusterModel: K8sModel = {
+export const StorageClusterModel: K8sModel = {
   label: 'Storage Cluster',
   labelPlural: 'Storage Clusters',
   apiVersion: 'v1',
@@ -22,6 +22,7 @@ export const OCSStorageClusterModel: K8sModel = {
   namespaced: true,
   kind: 'StorageCluster',
   crd: true,
+  id: 'ocscluster',
 };
 
 export const CephClusterModel: K8sModel = {
@@ -34,4 +35,5 @@ export const CephClusterModel: K8sModel = {
   namespaced: true,
   kind: 'CephCluster',
   crd: true,
+  id: 'cephcluster',
 };

--- a/packages/shared/src/topology/factory/StyleGroup.tsx
+++ b/packages/shared/src/topology/factory/StyleGroup.tsx
@@ -1,5 +1,10 @@
 import * as React from 'react';
 import {
+  DeploymentModel,
+  NodeModel,
+  StorageClusterModel,
+} from '@odf/shared/models';
+import {
   BlueInfoCircleIcon,
   GreenCheckCircleIcon,
   K8sModel,
@@ -21,7 +26,6 @@ import {
   WithDragNodeProps,
   WithSelectionProps,
 } from '@patternfly/react-topology';
-import { DeploymentModel, NodeModel, StorageClusterModel } from '../../models';
 import { getName } from '../../selectors';
 import { getGVKofResource } from '../../utils';
 import { TopologyDataContext } from '../Context';

--- a/packages/shared/src/topology/utils/AlertFilters.ts
+++ b/packages/shared/src/topology/utils/AlertFilters.ts
@@ -1,6 +1,6 @@
+import { NodeModel, StorageClusterModel } from '@odf/shared/models';
 import { Alert, K8sModel } from '@openshift-console/dynamic-plugin-sdk';
 import * as _ from 'lodash-es';
-import { NodeModel, StorageClusterModel } from '../../models';
 import { cephFilter, noobaaFilter, rgwFilter } from '../../utils';
 
 export const commonFilter =

--- a/packages/shared/src/utils/storage.ts
+++ b/packages/shared/src/utils/storage.ts
@@ -1,5 +1,5 @@
 import { Model } from '@odf/odf-plugin-sdk/extensions';
-import { OCSStorageClusterModel } from '@odf/shared/models';
+import { StorageClusterModel } from '@odf/shared/models';
 import {
   ClusterServiceVersionKind,
   StorageSystemKind,
@@ -19,9 +19,9 @@ export const isOCSStorageSystem = (
 ): resource is StorageSystemKind =>
   resource?.spec?.kind ===
   getGVKLabel({
-    kind: OCSStorageClusterModel.kind,
-    apiVersion: OCSStorageClusterModel.apiVersion,
-    apiGroup: OCSStorageClusterModel.apiGroup,
+    kind: StorageClusterModel.kind,
+    apiVersion: StorageClusterModel.apiVersion,
+    apiGroup: StorageClusterModel.apiGroup,
   } as Model);
 
 export const getOCSStorageSystem = (ssList: StorageSystemKind[] = []) =>


### PR DESCRIPTION
- Keep `CephClusterModel` & `OCSStorageCLusterModel` in `shared` library as the library is being used by other projects.