### PR TITLE
tsconfig: set '@odf' path mapping correctly

### DIFF
--- a/packages/mco/components/modals/remove-disaster-recovery/remove-disaster-recovery.tsx
+++ b/packages/mco/components/modals/remove-disaster-recovery/remove-disaster-recovery.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { DO_NOT_DELETE_PVC_ANNOTATION_WO_SLASH } from '@odf/mco/constants';
 import { ACMPlacementModel, DRPlacementControlModel } from '@odf/mco/models';
+import { DRPlacementControlKind } from '@odf/mco/types';
 import {
   ModalBody,
   ModalFooter,
@@ -15,7 +16,6 @@ import {
   k8sDelete,
   k8sPatch,
 } from '@openshift-console/dynamic-plugin-sdk';
-import { DRPlacementControlKind } from 'packages/mco/types';
 import { Trans } from 'react-i18next';
 import {
   Alert,

--- a/packages/ocs/modals/storage-pool/delete-storage-pool-modal.tsx
+++ b/packages/ocs/modals/storage-pool/delete-storage-pool-modal.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useSafeK8sGet } from '@odf/core/hooks';
 import { useODFSystemFlagsSelector } from '@odf/core/redux';
+import { ODFSystemFlagsPayload } from '@odf/core/redux/actions';
 import { ModalFooter } from '@odf/shared/generic/ModalTitle';
 import { StatusBox } from '@odf/shared/generic/status-box';
 import { useK8sGet } from '@odf/shared/hooks/k8s-get-hook';
@@ -31,7 +32,6 @@ import {
   YellowExclamationTriangleIcon,
 } from '@openshift-console/dynamic-plugin-sdk';
 import * as _ from 'lodash-es';
-import { ODFSystemFlagsPayload } from 'packages/odf/redux/actions';
 import { Trans } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 import { Modal, ModalVariant } from '@patternfly/react-core';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,8 +16,8 @@
     "paths": {
       "@odf/shared": ["./packages/shared/src"],
       "@odf/shared/*": ["./packages/shared/src/*"],
-      "packages/shared": ["./packages/shared/src"],
-      "packages/shared/*": ["./packages/shared/src/*"]
+      "@odf/core/*": ["./packages/odf/*"],
+      "@odf/*": ["./packages/*"]
     },
     "types": ["./index"]
   },


### PR DESCRIPTION
Imports should start with `'@odf`  instead of `'packages/...`.

Before (VSCode intellisense suggestions):
![Screenshot from 2024-07-22 13-45-42](https://github.com/user-attachments/assets/26386e2f-c569-4370-a18d-2680005e4302)

After:
![Screenshot from 2024-07-22 13-46-15](https://github.com/user-attachments/assets/580e8823-520b-4de8-a814-8da47490ee5f)
