### PR TITLE
GH action: trigger build workflow on any release PR

### DIFF
--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: [master, release-4.14, release-4.14-compatibility]
+    branches: [master, release*]
 
 jobs:
   build-test:


### PR DESCRIPTION
- To be backported to branches: `release-4.15`, `release-4.16` and compats.
- Fix: trigger build workflow on 4.16/4.15 release PRs (currently not being triggered).