### PR TITLE
Fix 'PLUGIN_VERSION' export from 'shared'

### DIFF
--- a/packages/shared/src/constants/common.ts
+++ b/packages/shared/src/constants/common.ts
@@ -11,4 +11,5 @@ export const DEFAULT_NS = 'default';
 export const RACK_LABEL = 'topology.rook.io/rack';
 export const NOOBA_EXTERNAL_PG_SECRET_NAME = 'noobaa-external-pg';
 export const NOOBAA_EXTERNAL_PG_TLS_SECRET_NAME = 'noobaa-external-pg-tls';
-export const PLUGIN_VERSION = process.env.PLUGIN_VERSION;
+export const PLUGIN_VERSION =
+  typeof process === 'undefined' ? undefined : process?.env?.PLUGIN_VERSION;


### PR DESCRIPTION
There is no `process` object at runtime, this causes an issue when `shared` is consumed as a library and consumer is not explicitly defining a corresponding value of `process.env.PLUGIN_VERSION` during the bundler build.

Temporary workaround: if using webpack as a bundler, consumer of the `shared` needs to add:
```
    new webpack.DefinePlugin({
      ...
      'process.env.PLUGIN_VERSION': <SOME_DUMMY_VALUE>,
    }),
```