### PR TITLE
Update Discovered App Status Panel for Failover Instructions

### DIFF
--- a/packages/mco/__mocks__/drplacementcontrol.tsx
+++ b/packages/mco/__mocks__/drplacementcontrol.tsx
@@ -38,6 +38,7 @@ export const mockDRPC1: DRPlacementControlKind = {
       },
     ],
     phase: 'Deployed',
+    progression: 'WaitOnUserToCleanUp',
     lastGroupSyncTime: '2023-06-06T17:50:56Z',
   },
 };

--- a/packages/mco/components/protected-applications/utils.tsx
+++ b/packages/mco/components/protected-applications/utils.tsx
@@ -28,11 +28,7 @@ import {
 } from '../../constants';
 import { DRPlacementControlModel } from '../../models';
 import { DRPlacementControlKind } from '../../types';
-import {
-  getVolumeReplicationHealth,
-  isDRPCAvailable,
-  isPeerReady,
-} from '../../utils';
+import { getVolumeReplicationHealth } from '../../utils';
 import { DiscoveredApplicationParser as DiscoveredApplicationModal } from '../modals/app-failover-relocate/parser/discovered-application-parser';
 import RemoveDisasterRecoveryModal from '../modals/remove-disaster-recovery/remove-disaster-recovery';
 
@@ -84,9 +80,9 @@ export const isFailingOrRelocating = (
   );
 
 export const isCleanupPending = (drpc: DRPlacementControlKind): boolean =>
-  drpc?.status?.phase === DRPC_STATUS.FailedOver &&
-  !isPeerReady(drpc) &&
-  isDRPCAvailable(drpc);
+  drpc?.status?.phase.includes[
+    (DRPC_STATUS.FailedOver, DRPC_STATUS.Relocating)
+  ] && drpc?.status?.progression === 'WaitOnUserToCleanUp';
 
 export const getReplicationHealth = (
   lastSyncTime: string,

--- a/packages/mco/types/ramen.ts
+++ b/packages/mco/types/ramen.ts
@@ -82,6 +82,7 @@ export type DRPlacementControlKind = K8sResourceCommon & {
       };
     };
     phase: string;
+    progression?: string;
     // The time of the most recent successful synchronization of all PVCs.
     lastGroupSyncTime?: string;
     preferredDecision?: {


### PR DESCRIPTION
When Failover is initiated and the DRPC progression is stuck at "WaitForReadiness" instead of "WaitOnUserToCleanUp," the Discovered App Status panel now instructs users to delete the application on the cluster they are
failing over from. This update provides clearer guidance during the failover process.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2294234