### PR TITLE
Bug 2300332: [release-4.16-compatibility] Hide builtin-mgr CephBlockPool

### DIFF
--- a/packages/ocs/block-pool/BlockPoolListPage.tsx
+++ b/packages/ocs/block-pool/BlockPoolListPage.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { useODFSystemFlagsSelector } from '@odf/core/redux';
+import { cephBlockPoolResource } from '@odf/core/resources';
 import { healthStateMapping } from '@odf/shared/dashboards/status-card/states';
 import {
   useCustomPrometheusPoll,
@@ -15,7 +16,6 @@ import { K8sResourceKind, StorageClassResourceKind } from '@odf/shared/types';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import {
   humanizeBinaryBytes,
-  referenceForModel,
   getValidPrometheusPollObj,
 } from '@odf/shared/utils';
 import {
@@ -378,10 +378,7 @@ const resources = {
     namespaced: false,
     isList: true,
   },
-  blockPools: {
-    kind: referenceForModel(CephBlockPoolModel),
-    isList: true,
-  },
+  blockPools: cephBlockPoolResource,
 };
 
 type WatchType = {

--- a/packages/ocs/storage-class/sc-form.tsx
+++ b/packages/ocs/storage-class/sc-form.tsx
@@ -19,7 +19,10 @@ import {
   useODFNamespaceSelector,
   useODFSystemFlagsSelector,
 } from '@odf/core/redux';
-import { cephClusterResource } from '@odf/core/resources';
+import {
+  cephBlockPoolResource,
+  cephClusterResource,
+} from '@odf/core/resources';
 import {
   ProviderNames,
   KmsCsiConfigKeysMapping,
@@ -27,7 +30,6 @@ import {
   K8sResourceObj,
 } from '@odf/core/types';
 import { getResourceInNs } from '@odf/core/utils';
-import { CephBlockPoolModel } from '@odf/ocs/models';
 import { TechPreviewBadge } from '@odf/shared/badges';
 import ResourceDropdown from '@odf/shared/dropdown/ResourceDropdown';
 import { ButtonBar } from '@odf/shared/generic/ButtonBar';
@@ -91,11 +93,6 @@ type OnParamChange = (id: string, paramName: string, checkbox: boolean) => void;
 
 const storageSystemResource: WatchK8sResource = {
   kind: referenceForModel(ODFStorageSystem),
-  isList: true,
-};
-
-const cephBlockPoolResource: WatchK8sResource = {
-  kind: referenceForModel(CephBlockPoolModel),
   isList: true,
 };
 

--- a/packages/odf/resources.ts
+++ b/packages/odf/resources.ts
@@ -57,13 +57,16 @@ export const subscriptionResource: WatchK8sResource = {
   kind: referenceForModel(SubscriptionModel),
   namespaced: false,
 };
-
-export const cephBlockPoolResource: K8sResourceObj = (ns) => ({
+/**
+ * Retrieve all the CRs except those not meant to be
+ * exposed to the users. See:
+ * https://bugzilla.redhat.com/show_bug.cgi?id=2297295
+ */
+export const cephBlockPoolResource: WatchK8sResource = {
   kind: referenceForModel(CephBlockPoolModel),
-  namespaced: true,
   isList: true,
-  namespace: ns,
-});
+  fieldSelector: 'metadata.name!=builtin-mgr',
+};
 
 export const nodeResource: WatchK8sResource = {
   kind: NodeModel.kind,


### PR DESCRIPTION
NOTE: manual backport as there is some conflicts resolved.