### PR TITLE
Revert "Annotate RBD storageclasses for keyrotation"

### DIFF
--- a/packages/ocs/storage-class/mutators.ts
+++ b/packages/ocs/storage-class/mutators.ts
@@ -44,25 +44,8 @@ export const addReclaimSpaceAnnotation = (sc: StorageClass): StorageClass => {
   return sc;
 };
 
-export const addEncryptionKeyRotationAnnotation = (
-  sc: StorageClass
-): StorageClass => {
-  if (
-    sc?.parameters?.hasOwnProperty('encrypted') &&
-    sc?.parameters?.['encrypted'] === 'true'
-  ) {
-    sc.metadata.annotations = {
-      ...getAnnotations(sc, {}),
-      'keyrotation.csiaddons.openshift.io/schedule': '@weekly',
-    };
-  }
-
-  return sc;
-};
-
 export const addRBDAnnotations = (sc: StorageClass): StorageClass => {
   sc = addKubevirtAnnotations(sc);
   sc = addReclaimSpaceAnnotation(sc);
-  sc = addEncryptionKeyRotationAnnotation(sc);
   return sc;
 };


### PR DESCRIPTION
This reverts commit 5cc29ebd4fa308f7dec2854b1756563f97d24842.

We are dropping automation for SCs in this release.