### PR TITLE
Bug 2304905: [release-4.16-compatibility] Add cluster name and id on clients' list page

### DIFF
--- a/locales/en/plugin__odf-console.json
+++ b/locales/en/plugin__odf-console.json
@@ -1096,7 +1096,7 @@
   "NamespaceStore details": "NamespaceStore details",
   "Target Blob Container": "Target Blob Container",
   "Num Volumes": "Num Volumes",
-  "Cluster ID": "Cluster ID",
+  "Cluster name (ID)": "Cluster name (ID)",
   "Openshift version": "Openshift version",
   "Data Foundation version": "Data Foundation version",
   "Last heartbeat": "Last heartbeat",

--- a/packages/odf/components/storage-consumers/client-list.tsx
+++ b/packages/odf/components/storage-consumers/client-list.tsx
@@ -51,8 +51,8 @@ const tableColumns = [
     id: 'name',
   },
   {
-    className: '',
-    id: 'clusterID',
+    className: 'pf-m-width-20',
+    id: 'clusterName',
   },
   {
     className: '',
@@ -96,8 +96,8 @@ const ClientsList: React.FC<ClientListProps> = (props) => {
         id: tableColumns[0].id,
       },
       {
-        title: t('Cluster ID'),
-        sort: 'status.client.clusterId',
+        title: t('Cluster name (ID)'),
+        sort: 'status.client.clusterName',
         props: {
           className: tableColumns[1].className,
         },
@@ -268,7 +268,9 @@ const StorageClientRow: React.FC<
         {obj?.status?.client?.name || '-'}
       </TableData>
       <TableData {...tableColumns[1]} activeColumnIDs={activeColumnIDs}>
-        {obj?.status?.client?.clusterId || '-'}
+        {`${obj?.status?.client?.clusterName || '-'} (${
+          obj?.status?.client?.clusterId || '-'
+        })`}
       </TableData>
       <TableData {...tableColumns[2]} activeColumnIDs={activeColumnIDs}>
         {getOpenshiftVersion(obj) || '-'}


### PR DESCRIPTION
<img width="1420" alt="Screenshot 2024-08-22 at 6 22 50 PM" src="https://github.com/user-attachments/assets/ed2ac5a0-344b-4c26-b513-5d2d555a5f88">
