### PR TITLE
Add 'enableCrushUpdates' flag to custom block pool

### DIFF
--- a/packages/ocs/storage-pool/CreateStoragePool.tsx
+++ b/packages/ocs/storage-pool/CreateStoragePool.tsx
@@ -97,6 +97,8 @@ export const getPoolKindObj = (
   },
   spec: {
     compressionMode: state.isCompressed ? COMPRESSION_ON : 'none',
+    // without explicit "true" Rook will not allow updating CRUSH Rules ("deviceClass" will not be set)
+    enableCrushUpdates: true,
     deviceClass: deviceClass,
     failureDomain: state.failureDomain,
     parameters: {

--- a/packages/ocs/types.ts
+++ b/packages/ocs/types.ts
@@ -14,6 +14,7 @@ export enum ImageStates {
 
 export type StoragePoolKind = K8sResourceCommon & {
   spec: DataPool & {
+    enableCrushUpdates?: boolean;
     deviceClass?: string;
     failureDomain?: string;
     parameters?: {


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2306496

Corresponding Rook + OCS changes:
https://github.com/rook/rook/pull/14322
https://github.com/red-hat-storage/ocs-operator/pull/2751

<img width="1430" alt="Screenshot 2024-08-26 at 6 14 25 PM" src="https://github.com/user-attachments/assets/dfa5039e-88b5-4181-b702-13921370abca">
