### PR TITLE
Fix flaky E2E test

### DIFF
--- a/cypress/views/storage-pool.ts
+++ b/cypress/views/storage-pool.ts
@@ -178,7 +178,7 @@ export const deleteStoragePool = (poolName: string) => {
   navigateToStoragePoolList();
   openStoragePoolKebab(poolName);
   cy.byTestActionID('Delete Pool').click();
-  cy.contains('Delete Storage Pool');
+  cy.contains('Delete Storage Pool', { timeout: 5 * 1000 });
   triggerPoolFormFooterAction('delete');
 
   cy.log('Verify that the pool is not found.');


### PR DESCRIPTION
Wait for 'Delete Storage Pool' modal to load.

Error screenshot:
![image](https://github.com/user-attachments/assets/471ef31a-1be8-43a9-8f31-d7e2a4ea0f13)
