### PR TITLE
Hide In-transit Encryption checkbox when MCG deployment mode is selected

### DIFF
--- a/packages/odf/components/create-storage-system/create-storage-system-steps/security-and-network-step/encryption.tsx
+++ b/packages/odf/components/create-storage-system/create-storage-system-steps/security-and-network-step/encryption.tsx
@@ -282,20 +282,22 @@ export const Encryption: React.FC<EncryptionProps> = ({
             }
           />
         )}
-        <Checkbox
-          className="odf-in-transit-encryption"
-          data-test="in-transit-encryption-checkbox"
-          id="in-transit-encryption"
-          isChecked={encryption.inTransit}
-          data-checked-state={encryption.inTransit}
-          label={t('In-transit encryption')}
-          description={t(
-            'A secure mode that encrypts all data passing over the network'
-          )}
-          onChange={(_event, checked: boolean) =>
-            handleInTransitEncryptionOnChange(checked)
-          }
-        />
+        {!isMCG && (
+          <Checkbox
+            className="odf-in-transit-encryption"
+            data-test="in-transit-encryption-checkbox"
+            id="in-transit-encryption"
+            isChecked={encryption.inTransit}
+            data-checked-state={encryption.inTransit}
+            label={t('In-transit encryption')}
+            description={t(
+              'A secure mode that encrypts all data passing over the network'
+            )}
+            onChange={(_event, checked: boolean) =>
+              handleInTransitEncryptionOnChange(checked)
+            }
+          />
+        )}
       </FormGroup>
       {!encryption.hasHandled && (
         <ValidationMessage validation={ValidationType.ENCRYPTION} />


### PR DESCRIPTION
https://issues.redhat.com/browse/RHSTOR-6552

The encryption in transit option is based on Ceph’s MSGR v2 protocol and is meant for traffic interacting with & within the ceph cluster (client-osd, osd-osd). MCG is not covered by this, so it doesn't make sense to show the option when deployment mode is MCG Only.