### PR TITLE
Fix bundle analyzer script

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -86,6 +86,7 @@ module.exports = {
           '**/*.spec.tsx',
           './jest/setup.ts',
           './cypress/**',
+          './analyzeTest.ts',
         ],
         optionalDependencies: false,
         peerDependencies: false,

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
   },
   "devDependencies": {
     "@cypress/webpack-preprocessor": "^5.9.1",
+    "@discoveryjs/json-ext": "0.6.1",
     "@swc/core": "1.3.19",
     "@swc/jest": "^0.2.23",
     "@testing-library/jest-dom": "^6.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1278,6 +1278,11 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
+"@discoveryjs/json-ext@0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.6.1.tgz#593da7a17a31a72a874e313677183334a49b01c9"
+  integrity sha512-boghen8F0Q8D+0/Q1/1r6DUEieUJ8w2a1gIknExMSHBsJFOr2+0KUfHiVYBvucPwl3+RU5PFBK833FjFCh3BhA==
+
 "@discoveryjs/json-ext@^0.5.0":
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.3.tgz#90420f9f9c6d3987f176a19a7d8e764271a2f55d"


### PR DESCRIPTION
After the @aws-sdk/client-s3 version update, the stats.json file size for the bundle analysis became around 545M, Node has a string size limit of 500M and the current s.readFileSync(...) logic to read stats.json files fails for files >500MB. So I switched to streaming. Ref: https://github.com/webpack-contrib/webpack-bundle-analyzer/pull/423