### PR TITLE
TypeScript Lint: don't allow unused params

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -135,7 +135,18 @@ module.exports = {
     'react/no-unused-state': 'off',
     'react/sort-comp': 'off',
     'no-unused-vars': 'off',
-    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      {
+        args: 'all',
+        argsIgnorePattern: '^_',
+        caughtErrors: 'all',
+        caughtErrorsIgnorePattern: '^_',
+        destructuredArrayIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        ignoreRestSiblings: true,
+      },
+    ],
     'react/function-component-definition': [
       2,
       {

--- a/cypress/tests/multiple-storageclass-selection.spec.ts
+++ b/cypress/tests/multiple-storageclass-selection.spec.ts
@@ -78,7 +78,7 @@ describe('Add capacity using multiple storage classes', () => {
   it('Add capacity with a new storage class having EBS as provisioner', () => {
     const { name: scName } = testEbsSC.metadata;
     const iAndD: IndexAndDeviceSet = { index: 0, deviceSets: [] };
-    addCapacity(beforeCapacityAddition.uid, scName);
+    addCapacity(scName);
     fetchStorageClusterJson().then((res) => {
       withJSONResult(res, scName, iAndD);
       newStorageClassTests(beforeCapacityAddition, iAndD, true);
@@ -93,7 +93,7 @@ describe('Add capacity using multiple storage classes', () => {
     cy.log('Count is:', index.toString());
     beforeCapacityAddition.portability = deviceSets[index].portable;
     beforeCapacityAddition.devicesCount = deviceSets[index].count;
-    addCapacity(beforeCapacityAddition.uid, scName);
+    addCapacity(scName);
     fetchStorageClusterJson().then((res) => {
       withJSONResult(res, scName, iAndD);
       existingStorageClassTests(beforeCapacityAddition, iAndD);
@@ -103,7 +103,7 @@ describe('Add capacity using multiple storage classes', () => {
   it(`Add capacity with a new storage class having NO-PROVISIONER as provisioner`, () => {
     const { name: scName } = testNoProvisionerSC.metadata;
     const iAndD: IndexAndDeviceSet = { index: 0, deviceSets: [] };
-    addCapacity(beforeCapacityAddition.uid, scName);
+    addCapacity(scName);
     fetchStorageClusterJson().then((res) => {
       withJSONResult(res, scName, iAndD);
       newStorageClassTests(beforeCapacityAddition, iAndD, false);

--- a/cypress/views/multiple-storageclass.ts
+++ b/cypress/views/multiple-storageclass.ts
@@ -24,7 +24,7 @@ export const fetchStorageClusterJson = () =>
 export const fetchWorkerNodesJson = () =>
   cy.exec('oc get nodes -l "node-role.kubernetes.io/worker" -o json');
 
-export const addCapacity = (uid: string, scName: string) => {
+export const addCapacity = (scName: string) => {
   cy.byLegacyTestID('item-filter').clear();
   // eslint-disable-next-line cypress/no-unnecessary-waiting
   cy.byLegacyTestID('item-filter')

--- a/packages/mco/components/create-dr-policy/create-dr-policy.spec.tsx
+++ b/packages/mco/components/create-dr-policy/create-dr-policy.spec.tsx
@@ -422,7 +422,7 @@ xdescribe('Test drpolicy list page', () => {
     try {
       // east-2 is partially imported cluster
       screen.getByText('east-2');
-    } catch (error) {
+    } catch (_error) {
       nonExist = true;
     }
     expect(nonExist).toBe(true);

--- a/packages/odf/components/alerts/alert-action-path.tsx
+++ b/packages/odf/components/alerts/alert-action-path.tsx
@@ -9,7 +9,7 @@ export const getDiskAlertActionPath = () =>
   window.open('https://access.redhat.com/solutions/5194851');
 
 // ToDo (epic 4422): Get StorageCluster name and namespace from the Alert object and then use "k8sGet".
-export const launchClusterExpansionModal = async (alert, launchModal) => {
+export const launchClusterExpansionModal = async (_alert, launchModal) => {
   try {
     /*
     const storageCluster = await k8sGet({

--- a/packages/odf/components/bucket-class/time-duration-dropdown.tsx
+++ b/packages/odf/components/bucket-class/time-duration-dropdown.tsx
@@ -10,7 +10,6 @@ import {
 import { TimeUnits } from '../../constants';
 
 export const TimeDurationDropdown: React.FC<TimeDurationDropdownProps> = ({
-  id, // eslint-disable-line @typescript-eslint/no-unused-vars
   inputClassName,
   onChange,
   required,
@@ -59,7 +58,6 @@ export const TimeDurationDropdown: React.FC<TimeDurationDropdownProps> = ({
 };
 
 type TimeDurationDropdownProps = {
-  id: string;
   placeholder?: string;
   inputClassName?: string;
   onChange: Function;

--- a/packages/odf/components/bucket-class/wizard-pages/namespace-store-pages/cache-namespace-store.tsx
+++ b/packages/odf/components/bucket-class/wizard-pages/namespace-store-pages/cache-namespace-store.tsx
@@ -127,7 +127,6 @@ export const CacheNamespaceStorePage: React.FC<CacheNamespaceStoreProps> =
             >
               <TimeDurationDropdown
                 testID="time-to-live-input"
-                id="timetolive-input"
                 inputID="ttl-input"
                 onChange={onTTLChange}
               />

--- a/packages/odf/components/bucket-class/wizard-pages/placement-policy-page.tsx
+++ b/packages/odf/components/bucket-class/wizard-pages/placement-policy-page.tsx
@@ -22,7 +22,7 @@ const PlacementPolicyPage: React.FC<PlacementPolicyPageProps> = ({
   const [showHelp, setShowHelp] = React.useState(true);
   const showTier2 = !!tier2Policy;
 
-  const onChange = (checked: boolean, event) => {
+  const onChange = (_checked: boolean, event) => {
     const { name, value } = event.target;
     if (name === 'placement-policy-1') {
       dispatch({ type: 'setPlacementPolicyTier1', value });

--- a/packages/odf/components/kms-config/utils.tsx
+++ b/packages/odf/components/kms-config/utils.tsx
@@ -34,7 +34,7 @@ import {
 export const parseURL = (url: string) => {
   try {
     return new URL(url);
-  } catch (e) {
+  } catch (_e) {
     return null;
   }
 };

--- a/packages/odf/components/topology/TopBar/SearchComponent.tsx
+++ b/packages/odf/components/topology/TopBar/SearchComponent.tsx
@@ -67,7 +67,7 @@ const SearchBar: React.FC = () => {
 
   const { t } = useCustomTranslation();
 
-  const onChange = (event, input: string) => {
+  const onChange = (_event, input: string) => {
     setUserInput(input);
   };
 

--- a/packages/odf/components/topology/sidebar/TopologySideBarContent.tsx
+++ b/packages/odf/components/topology/sidebar/TopologySideBarContent.tsx
@@ -125,7 +125,7 @@ const TopologySideBarContent: React.FC<TopologySideBarContentProps> = ({
   const [model, inFlight] = useK8sModel(reference);
 
   const onSelect = React.useCallback(
-    (event, tabIndex) => {
+    (_event, tabIndex) => {
       setActiveTab(tabIndex);
     },
     [setActiveTab]

--- a/packages/odf/components/utils/common.ts
+++ b/packages/odf/components/utils/common.ts
@@ -249,7 +249,7 @@ export const checkError = (
         base64ErrorKeys.push(item.name ?? 'Unrecognized key');
       try {
         atob(item.data?.userKey ?? item.data?.adminKey);
-      } catch (e) {
+      } catch (_e) {
         base64ErrorKeys.push(item.name ?? 'Unrecognized key');
       }
     }
@@ -316,7 +316,7 @@ export const isValidJSON = (fData: string): boolean => {
   try {
     JSON.parse(fData);
     return true;
-  } catch (e) {
+  } catch (_e) {
     return false;
   }
 };

--- a/packages/odf/features.ts
+++ b/packages/odf/features.ts
@@ -70,7 +70,7 @@ export const setOCSFlags = async (setFlag: SetFeatureFlag) => {
         setFlagFalse = false;
         setFlag(PROVIDER_MODE, false);
       }
-    } catch (error) {
+    } catch (_error) {
       setFlag(PROVIDER_MODE, false);
     }
   };

--- a/packages/odf/modals/advanced-kms-modal/advanced-vault-modal.tsx
+++ b/packages/odf/modals/advanced-kms-modal/advanced-vault-modal.tsx
@@ -223,7 +223,7 @@ const AdvancedVaultModal: ModalComponent<AdvancedKMSModalProps> = (props) => {
             >
               <TextInput
                 value={authNamespace}
-                onChange={(ev, value) => setAuthNamespace(value)}
+                onChange={(_ev, value) => setAuthNamespace(value)}
                 type="text"
                 id="kms-service-auth-namespace"
                 name="kms-service-auth-namespace"
@@ -240,7 +240,7 @@ const AdvancedVaultModal: ModalComponent<AdvancedKMSModalProps> = (props) => {
         >
           <TextInput
             value={tlsName}
-            onChange={(ev, value) => setTLSName(value)}
+            onChange={(_ev, value) => setTLSName(value)}
             type="text"
             id="kms-service-tls"
             name="kms-service-tls"

--- a/packages/odf/modals/configure-mons/configure-mons.tsx
+++ b/packages/odf/modals/configure-mons/configure-mons.tsx
@@ -163,7 +163,7 @@ const LowMonAlertModal: ModalComponent = ({ closeModal }) => {
   );
 };
 
-export const launchLowMonAlertModal = async (alert, launchModal) => {
+export const launchLowMonAlertModal = async (_alert, launchModal) => {
   try {
     launchModal(LowMonAlertModal, { isOpen: true });
   } catch (e) {

--- a/packages/shared/src/charts/tooltip.tsx
+++ b/packages/shared/src/charts/tooltip.tsx
@@ -295,7 +295,7 @@ export const ChartLegendTooltip: React.FunctionComponent<
           ...legendTooltipProps,
           // For non-stack graphs, remove the text for "mainDataName"
           text: legendTooltipProps.text.filter(
-            (t, i) => legendTooltipProps.legendData[i].name !== mainDataName
+            (_t, i) => legendTooltipProps.legendData[i].name !== mainDataName
           ),
         };
     const _flyoutHeight =

--- a/packages/shared/src/details-page/DetailsPage.tsx
+++ b/packages/shared/src/details-page/DetailsPage.tsx
@@ -113,14 +113,9 @@ export default DetailsPage;
 
 export type ResourceSummaryProps = {
   resource: K8sResourceKind;
-  showPodSelector?: boolean;
-  showNodeSelector?: boolean;
   showAnnotations?: boolean;
-  showTolerations?: boolean;
   showLabelEditor?: boolean;
   canUpdateResource?: boolean;
-  podSelector?: string;
-  nodeSelector?: string;
   children?: React.ReactNode;
   customPathName?: string;
   resourceModel: K8sKind;
@@ -291,14 +286,9 @@ export const ResourceSummary: React.FC<ResourceSummaryProps> = ({
   children,
   resource,
   customPathName,
-  showPodSelector = false, // eslint-disable-line @typescript-eslint/no-unused-vars
-  showNodeSelector = false, // eslint-disable-line @typescript-eslint/no-unused-vars
   showAnnotations = true,
-  showTolerations = false, // eslint-disable-line @typescript-eslint/no-unused-vars
   showLabelEditor = true,
   canUpdateResource = true,
-  podSelector = 'spec.selector', // eslint-disable-line @typescript-eslint/no-unused-vars
-  nodeSelector = 'spec.template.spec.nodeSelector', // eslint-disable-line @typescript-eslint/no-unused-vars
   resourceModel,
 }) => {
   const { t } = useCustomTranslation();

--- a/packages/shared/src/details-page/datetime.ts
+++ b/packages/shared/src/details-page/datetime.ts
@@ -202,7 +202,7 @@ export const parsePrometheusDuration = (duration: string): number => {
       .split(/\s+/)
       .map((p) => p.match(/^(\d+)([wdhms])$/));
     return _.sumBy(parts, (p) => parseInt(p[1], 10) * units[p[2]]);
-  } catch (ignored) {
+  } catch (_error) {
     // Invalid duration format
     return 0;
   }

--- a/packages/shared/src/hooks/sort-list.ts
+++ b/packages/shared/src/hooks/sort-list.ts
@@ -27,7 +27,7 @@ export const useSortList = <R extends K8sResourceCommon>(
   );
 
   const onSort = React.useCallback(
-    (event: React.MouseEvent, columnIndex: number, sortByDirection: any) => {
+    (_event: React.MouseEvent, columnIndex: number, sortByDirection: any) => {
       setSortIndex(columnIndex);
       setSortDirection(sortByDirection);
     },

--- a/packages/shared/src/utils/node.ts
+++ b/packages/shared/src/utils/node.ts
@@ -32,7 +32,7 @@ export const getNodeRoles = (node: NodeKind): string[] => {
   const labels = _.get(node, 'metadata.labels');
   return _.reduce(
     labels,
-    (acc: string[], v: string, k: string) => {
+    (acc: string[], _v: string, k: string) => {
       if (k.startsWith(NODE_ROLE_PREFIX)) {
         acc.push(k.slice(NODE_ROLE_PREFIX.length));
       }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "checkJs": true,
     "experimentalDecorators": true,
     "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "skipLibCheck": true,
     "sourceMap": true,
     "noEmitOnError": false,


### PR DESCRIPTION
- Add `noUnusedParams` to `tsconfig.json`.
- Align eslint `no-unused-vars` rule to [typescript compiler style](https://typescript-eslint.io/rules/no-unused-vars/#benefits-over-typescript).
- Code cleanup.