### PR TITLE
[WIP] Rebase with target/base branch (GH workflows)

### DIFF
--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -20,7 +20,15 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git fetch origin
-          git rebase origin/${{ github.event.pull_request.base.ref }}
+          git rebase origin/${{ github.event.pull_request.base.ref }} || echo "Merge conflicts!!!!"
+      - name: Check for conflicts
+        if: github.event_name == 'pull_request'
+        run: |
+          git status
+          if ! git diff --check; then
+            git diff
+            exit 1
+          fi
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -14,6 +14,13 @@ jobs:
         node-version: [16, 18.17.1]
     steps:
       - uses: actions/checkout@v3
+      - name: Rebase # Rebase with master or release* (branch against which PR is raised)
+        if: github.event_name == 'pull_request'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin
+          git rebase origin/${{ github.event.pull_request.base.ref }}
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}


### PR DESCRIPTION
Currently `frontend-build.yml` workflow only runs either **on the PR** or **on master after the merge/push**.

As per this update now PR will get rebased with the target/base (master or release*), then build and other tests will run on that.