### PR TITLE
Fix object preview

### DIFF
--- a/packages/odf/components/s3-browser/download-and-preview/download-and-preview.ts
+++ b/packages/odf/components/s3-browser/download-and-preview/download-and-preview.ts
@@ -28,7 +28,12 @@ const getObjectURL: GetObjectURL = async (bucketName, object, noobaaS3) => {
     Bucket: bucketName,
     Key: getName(object),
   });
-  const blob = await new Response(responseStream.Body as ReadableStream).blob();
+  let blob = await new Response(responseStream.Body as ReadableStream).blob();
+  blob = blob.slice(
+    0,
+    blob.size,
+    responseStream.ContentType || 'application/octet-stream'
+  );
 
   return window.URL.createObjectURL(blob);
 };


### PR DESCRIPTION
**Before:**
"Preview" of objects was not working correctly, ex: was displaying random text for png image.
<img width="1727" alt="Screenshot 2024-10-17 at 12 31 17 PM" src="https://github.com/user-attachments/assets/7e12467e-e553-4b3e-9466-a3d80d2bc827">

**After:**
It works now and browser will either display the content or auto-download if type is unrecognisable.
<img width="1728" alt="Screenshot 2024-10-17 at 12 31 39 PM" src="https://github.com/user-attachments/assets/95a9ee1b-2056-4f81-b9b1-83ccbff98d8b">
