### PR TITLE
Enable S3 browser for all modes

### DIFF
--- a/packages/odf/components/object-service-nav-item/object-service.tsx
+++ b/packages/odf/components/object-service-nav-item/object-service.tsx
@@ -16,7 +16,6 @@ import Tabs, { TabPage } from '@odf/shared/utils/Tabs';
 import {
   useResolvedExtensions,
   NamespaceBar,
-  useFlag,
 } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Extension,
@@ -29,8 +28,6 @@ import {
   useLocation,
   useNavigate,
 } from 'react-router-dom-v5-compat';
-import { BUCKETS_BASE_ROUTE } from '../../constants';
-import { MCG_STANDALONE } from '../../features';
 
 const OBJECT_SERVICE_CONTEXT = 'odf-object-service';
 const NAMESPACE_BAR_PATHS = [referenceForModel(NooBaaObjectBucketClaimModel)];
@@ -41,8 +38,6 @@ const isObjectServiceTab = (e: Extension) =>
 const ObjectServicePage: React.FC = () => {
   const { t } = useCustomTranslation();
   const title = t('Object Storage');
-
-  const isMCGStandalone = useFlag(MCG_STANDALONE);
 
   const [extensions, isLoaded, error] = useResolvedExtensions<HorizontalNavTab>(
     isObjectServiceTab as ExtensionTypeGuard<HorizontalNavTab>
@@ -65,13 +60,12 @@ const ObjectServicePage: React.FC = () => {
   React.useEffect(() => {
     if (
       (location.pathname.endsWith('/odf/object-storage') ||
-        location.pathname.endsWith('/odf/object-storage/') ||
-        (!isMCGStandalone && location.pathname.includes(BUCKETS_BASE_ROUTE))) &&
+        location.pathname.endsWith('/odf/object-storage/')) &&
       !_.isEmpty(sortedPages)
     ) {
       navigate('/odf/object-storage/' + sortedPages[0].href, { replace: true });
     }
-  }, [location.pathname, navigate, sortedPages, isMCGStandalone]);
+  }, [location.pathname, navigate, sortedPages]);
 
   const showNamespaceBar = NAMESPACE_BAR_PATHS.some((path) =>
     location.pathname.includes(path)

--- a/packages/odf/features.ts
+++ b/packages/odf/features.ts
@@ -17,18 +17,13 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import * as _ from 'lodash-es';
 import { SECOND, RGW_PROVISIONER, NOOBAA_PROVISIONER } from './constants';
-import {
-  isExternalCluster,
-  isClusterIgnored,
-  isMCGStandaloneCluster,
-} from './utils';
+import { isExternalCluster, isClusterIgnored } from './utils';
 
 export const ODF_MODEL_FLAG = 'ODF_MODEL'; // Based on the existence of StorageSystem CRD
 export const RGW_FLAG = 'RGW'; // Based on the existence of StorageClass with RGW provisioner ("openshift-storage.ceph.rook.io/bucket")
 export const MCG_FLAG = 'MCG'; // Based on the existence of NooBaa StorageClass (which only gets created if NooBaaSystem is present)
 export const ODF_ADMIN = 'ODF_ADMIN'; // Set to "true" if user is an "openshift-storage" admin (access to StorageSystems)
 export const PROVIDER_MODE = 'PROVIDER_MODE'; // Set to "true" if user has deployed it in provider mode
-export const MCG_STANDALONE = 'MCG_STANDALONE'; // Set to "true" if user has deployed for MCG standalone mode
 
 // Check the user's access to some resources.
 const ssarChecks = [
@@ -64,7 +59,6 @@ export const setOCSFlags = async (setFlag: SetFeatureFlag) => {
             !isClusterIgnored(sc) && !isExternalCluster(sc)
         );
         setFlag(PROVIDER_MODE, isProviderMode(internalStorageCluster));
-        setFlag(MCG_STANDALONE, isMCGStandaloneCluster(internalStorageCluster));
         clearInterval(ocsIntervalId);
       } else if (setFlagFalse) {
         setFlagFalse = false;

--- a/plugins/odf/console-extensions.json
+++ b/plugins/odf/console-extensions.json
@@ -135,9 +135,6 @@
       "path": ["/odf/object-storage/create-bucket"],
       "exact": true,
       "component": { "$codeRef": "createBucket.default" }
-    },
-    "flags": {
-      "required": ["MCG_STANDALONE"]
     }
   },
   {
@@ -553,9 +550,6 @@
       "component": {
         "$codeRef": "s3BucketList.default"
       }
-    },
-    "flags": {
-      "required": ["MCG_STANDALONE", "ODF_ADMIN"]
     }
   },
   {
@@ -604,23 +598,6 @@
     },
     "flags": {
       "required": ["MCG", "ODF_ADMIN"]
-    }
-  },
-  {
-    "type": "odf.horizontalNav/tab",
-    "properties": {
-      "id": "objectbuckets",
-      "name": "%plugin__odf-console~Object Buckets%",
-      "contextId": "odf-object-service",
-      "after": "namespace-store",
-      "href": "objectbucket.io~v1alpha1~ObjectBucket",
-      "component": {
-        "$codeRef": "ob.ObjectBucketListPage"
-      }
-    },
-    "flags": {
-      "required": ["MCG"],
-      "disallowed": ["MCG_STANDALONE"]
     }
   },
   {
@@ -745,9 +722,6 @@
       "component": {
         "$codeRef": "s3BucketOverview.default"
       }
-    },
-    "flags": {
-      "required": ["MCG_STANDALONE"]
     }
   }
 ]


### PR DESCRIPTION
Enabling S3 browser for all modes: Internal, External, Provider and MCG-Standalone.
Skipping Client mode clusters, S3 browser will still be hidden for that case.