### PR TITLE
Fix i18n translations

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -13,7 +13,7 @@ const LANGUAGES = ['en', 'ja', 'ko', 'zh', 'es', 'fr'];
 const resolveLocale = (dirName: string, ns: string) =>
   LANGUAGES.map((lang) => ({
     from: path.resolve(dirName, `locales/${lang}/plugin__*.json`),
-    to: `locales/${lang}/${ns}.[ext]`,
+    to: `locales/${lang}/${ns}[ext]`,
   }));
 
 const NODE_ENV = (process.env.NODE_ENV ||


### PR DESCRIPTION
Earlier generated file example: `plugin__odf-console..json` (notice double dots in the name).

After the fix generated file example: `plugin__odf-console.json` (single dot). 