### PR TITLE
Run sanity checks on PR base branch change 

### DIFF
--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -1,13 +1,13 @@
-name: Build Test
+name: Sanity Checks
 on:
   push:
     branches: [master]
   pull_request:
     branches: [master, release*]
+    types: [opened, synchronize, reopened, edited]
 
 jobs:
-  build-test:
-    name: resolve-dependencies
+  sanity-checks:
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
The pull_request `edited` event type is the only one that detects a change in the base branch, so we're adding it to the list of event types to prevent the following scenarios:
- When updating the base branch, no sanity-checks are run.
- Successful sanity-checks runs on the previous branch that are kept when base branch is updated: misleading (we don't know if they would have failed against the new base branch).

NOTE: the side effect is when editing the title or PR description, sanity-checks will be re-triggered. Although not ideal, it's better than adding a condition on the job to not run it on title/description changes, as the job is marked as skipped: misleading (we don't know if the previous run was successful or not).