### PR TITLE
Add 'encryptionKMSID' for 'Attach Storage' form

### DIFF
--- a/packages/odf/components/attach-storage-storagesystem/attach-storage-footer.tsx
+++ b/packages/odf/components/attach-storage-storagesystem/attach-storage-footer.tsx
@@ -23,9 +23,17 @@ export const AttachStorageFormFooter = (
     errorMessage,
     storageClassDetails,
   } = state;
-  const { name } = storageClassDetails;
+  const { name, enableStorageClassEncryption, encryptionKMSID } =
+    storageClassDetails;
   const isDisabled =
-    checkRequiredValues(poolName, replicaSize, lsoStorageClassName, name) ||
+    checkRequiredValues(
+      poolName,
+      replicaSize,
+      lsoStorageClassName,
+      name,
+      enableStorageClassEncryption,
+      encryptionKMSID
+    ) ||
     inProgress ||
     !!errorMessage;
 

--- a/packages/odf/components/attach-storage-storagesystem/attach-storage.scss
+++ b/packages/odf/components/attach-storage-storagesystem/attach-storage.scss
@@ -4,6 +4,7 @@
   
 .storagepool-form {
   margin-top: var(--pf-v5-global--spacer--md);
+  margin-left: calc(var(--pf-v5-global--spacer--lg) * -1);
 }
 .attachstorage-form {
   margin-right: var(--pf-v5-global--spacer--xl);

--- a/packages/odf/components/attach-storage-storagesystem/state.ts
+++ b/packages/odf/components/attach-storage-storagesystem/state.ts
@@ -11,6 +11,7 @@ type StorageClassDetails = {
   name: string;
   volumeBindingMode: VolumeBindingMode;
   enableStorageClassEncryption: boolean;
+  encryptionKMSID: string;
 };
 
 type PoolDetails = {
@@ -49,6 +50,7 @@ export const initialAttachStorageState: AttachStorageFormState = {
     name: '',
     volumeBindingMode: VolumeBindingMode.WaitForFirstConsumer,
     enableStorageClassEncryption: false,
+    encryptionKMSID: '',
   },
 };
 
@@ -97,6 +99,7 @@ export enum AttachStorageActionType {
   SET_DEVICESET_ENCRYPTION = 'SET_DEVICESET_ENCRYPTION',
   SET_STORAGECLASS_NAME = 'SET_STORAGECLASS_NAME',
   SET_STORAGECLASS_ENCRYPTION = 'SET_STORAGECLASS_ENCRYPTION',
+  SET_ENCRYPTION_KMS_ID = 'SET_ENCRYPTION_KMS_ID',
   SET_STORAGECLASS_RECLAIM_POLICY = 'SET_STORAGECLASS_RECLAIM_POLICY',
   SET_STORAGECLASS_VOLUME_BINDING_MODE = 'SET_STORAGECLASS_VOLUME_BINDING_MODE',
 }
@@ -126,6 +129,10 @@ export type AttachStorageAction =
   | {
       type: AttachStorageActionType.SET_STORAGECLASS_ENCRYPTION;
       payload: boolean;
+    }
+  | {
+      type: AttachStorageActionType.SET_ENCRYPTION_KMS_ID;
+      payload: string;
     }
   | {
       type: AttachStorageActionType.SET_STORAGECLASS_RECLAIM_POLICY;
@@ -222,6 +229,15 @@ export const attachStorageReducer = (
         storageClassDetails: {
           ...state.storageClassDetails,
           enableStorageClassEncryption: action.payload,
+        },
+      };
+    }
+    case AttachStorageActionType.SET_ENCRYPTION_KMS_ID: {
+      return {
+        ...state,
+        storageClassDetails: {
+          ...state.storageClassDetails,
+          encryptionKMSID: action.payload,
         },
       };
     }

--- a/packages/odf/components/attach-storage-storagesystem/storageclass-form.tsx
+++ b/packages/odf/components/attach-storage-storagesystem/storageclass-form.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { StorageClassEncryptionKMSID } from '@odf/ocs/storage-class/sc-form';
 import { ReclaimPolicy, VolumeBindingMode } from '@odf/shared';
 import {
   Dropdown,
@@ -39,6 +40,16 @@ const StorageClassForm: React.FC<StorageClassFormProps> = ({
       payload: !state.storageClassDetails.enableStorageClassEncryption,
     });
   }, [dispatch, state.storageClassDetails.enableStorageClassEncryption]);
+  const onEncryptionKMSIDChange = (
+    _id: string,
+    paramName: string,
+    _checkbox: boolean
+  ) => {
+    dispatch({
+      type: AttachStorageActionType.SET_ENCRYPTION_KMS_ID,
+      payload: paramName,
+    });
+  };
 
   const reclaimPolicyDropdownItems = React.useMemo(() => {
     return Object.values(ReclaimPolicy).map((policy) => (
@@ -178,12 +189,19 @@ const StorageClassForm: React.FC<StorageClassFormProps> = ({
       </FormGroup>
       <FormGroup>
         <Checkbox
-          id="enable-encryption-device-set"
+          id="enable-encryption-storage-class"
           label={t('Enable encryption on StorageClass')}
           className="pf-v5-u-pt-md"
           isChecked={state.storageClassDetails.enableStorageClassEncryption}
           onChange={onEncryptionChange}
         />
+        {!!state.storageClassDetails.enableStorageClassEncryption && (
+          <StorageClassEncryptionKMSID
+            onParamChange={onEncryptionKMSIDChange}
+            parameterKey=""
+            parameterValue={state.storageClassDetails.encryptionKMSID}
+          />
+        )}
       </FormGroup>
     </div>
   );

--- a/packages/odf/components/attach-storage-storagesystem/utils.ts
+++ b/packages/odf/components/attach-storage-storagesystem/utils.ts
@@ -2,6 +2,12 @@ export const checkRequiredValues = (
   poolName: string,
   replicaSize: string,
   lsoStorageClassName: string,
-  storageClassName: string
+  storageClassName: string,
+  enableStorageClassEncryption: boolean,
+  encryptionKMSID: string
 ): boolean =>
-  !poolName || !replicaSize || !lsoStorageClassName || !storageClassName;
+  !poolName ||
+  !replicaSize ||
+  !lsoStorageClassName ||
+  !storageClassName ||
+  (enableStorageClassEncryption ? !encryptionKMSID : false);


### PR DESCRIPTION
Follow-up of https://github.com/red-hat-storage/odf-console/pull/1662

https://issues.redhat.com/browse/DFBUGS-908

<img width="1719" alt="Screenshot 2024-11-26 at 8 13 32 PM" src="https://github.com/user-attachments/assets/53230c88-5e3c-4f3d-9289-5a8bb893e934">
