### PR TITLE
NO-JIRA: add `co-spin` to `StatusIconAndText`

### DIFF
--- a/packages/shared/src/status/StatusIconAndText.tsx
+++ b/packages/shared/src/status/StatusIconAndText.tsx
@@ -29,7 +29,7 @@ const StatusIconAndText: React.FC<StatusIconAndTextProps> = ({
       {icon &&
         React.cloneElement(icon, {
           className: classNames(
-            spin && 'fa-spin',
+            spin && 'co-spin fa-spin',
             icon.props.className,
             !iconOnly && 'co-icon-and-text__icon co-icon-flex-child'
           ),


### PR DESCRIPTION
A PR in Admin console https://github.com/openshift/console/pull/14603 will remove font-awesome, which will remove the `fa-spin` class and replace it with `co-spin`. This PR adds `co-spin` to `StatusIconAndText` for 4.19.x support