### PR TITLE
Fix pool name check for blockpools

### DIFF
--- a/packages/ocs/storage-pool/body.tsx
+++ b/packages/ocs/storage-pool/body.tsx
@@ -151,7 +151,10 @@ export const StoragePoolBody: React.FC<StoragePoolBodyProps> = ({
         .test(
           'unique-name',
           translationFieldRequirements[3],
-          (value: string) => !existingNames.includes(value)
+          (value: string) =>
+            !existingNames.includes(
+              usePrefix ? `${prefixName}-${value}` : value
+            )
         ),
     });
 
@@ -159,7 +162,7 @@ export const StoragePoolBody: React.FC<StoragePoolBodyProps> = ({
       schema: validationSchema,
       fieldRequirements: translationFieldRequirements,
     };
-  }, [existingNames, t]);
+  }, [prefixName, usePrefix, existingNames, t]);
 
   const resolver = useYupValidationResolver(schema);
   const {


### PR DESCRIPTION
```
oc get cephblockpool -A
NAMESPACE           NAME                                      PHASE   TYPE         FAILUREDOMAIN   AGE
openshift-storage   builtin-mgr                               Ready   Replicated   host            40d
openshift-storage   ocs-storagecluster-cephblockpool          Ready   Replicated   host            40d
openshift-storage   ocs-storagecluster-cephblockpool-pool-3   Ready   Replicated   host            58m
openshift-storage   pool-5                                    Ready   Replicated   host            149m
```
Created the following blockpools above 


Checking with pool-3, it does not allow to continue 
<img width="825" alt="Screenshot 2025-01-22 at 8 25 52 PM" src="https://github.com/user-attachments/assets/6f0694e0-b9b3-41bb-9a23-a38466c5b7d5" />

Checking with pool-5, it allows it normally
<img width="825" alt="Screenshot 2025-01-22 at 8 26 21 PM" src="https://github.com/user-attachments/assets/21f173d3-208f-49cb-9764-2d0eb8233f5b" />
