### PR TITLE
Cancel icon not working ("Create new BackingStore" modal) #1874

### DIFF
--- a/packages/odf/components/create-bs/create-bs-modal.tsx
+++ b/packages/odf/components/create-bs/create-bs-modal.tsx
@@ -16,7 +16,12 @@ const CreateBackingStoreFormModal: React.FC<CreateBackingStoreFormModalProps> =
 
     const Header = <ModalHeader>{t('Create new BackingStore')}</ModalHeader>;
     return (
-      <Modal isOpen={isOpen} variant={ModalVariant.small} header={Header}>
+      <Modal
+        isOpen={isOpen}
+        variant={ModalVariant.small}
+        header={Header}
+        onClose={closeModal}
+      >
         <div className="nb-endpoints__modal">
           <ModalBody>
             <p>


### PR DESCRIPTION
Fixes: https://github.com/red-hat-storage/odf-console/issues/1874
Added "onClose={closeModal}" to the Modal in the file "odf-console/packages/odf/components/create-bs/create-bs-modal.tsx" to make the close icon work, after this change the close icon is working to close create new backing store.
 go to:
"Storage > Object Storage > Bucket Class > Create Bucket Class > Select "BucketClass type" as "Standard", type any "BucketClass name" and select "Next" > On the third "Resources" step, select "Create BackingStore" > try closing the modal via close icon on top-right corner of the modal"
Modal is now getting closed on clicking the cross/cancel icon.

<img width="1728" alt="Screenshot 2025-02-20 at 11 11 15 AM" src="https://github.com/user-attachments/assets/80c5ca64-6906-41a2-aa52-cf15f001620a" />
