### PR TITLE
Add spacing class in body.tsx to insert space between the header and …

### DIFF
--- a/packages/ocs/storage-pool/body.tsx
+++ b/packages/ocs/storage-pool/body.tsx
@@ -261,7 +261,7 @@ export const StoragePoolBody: React.FC<StoragePoolBodyProps> = ({
 
   return isClusterReady || !showPoolStatus ? (
     <>
-      <FormGroup label={t('Volume type')} isRequired>
+      <FormGroup label={t('Volume type')} className="pf-v5-u-pt-xl" isRequired>
         <div className="pf-v5-u-display-flex pf-v5-u-flex-direction-row ceph-pool__radio-flex">
           <Radio
             label={t('Filesystem')}


### PR DESCRIPTION
volume type label

Add padding ("Create storage pool" page) https://github.com/red-hat-storage/odf-console/issues/1873

https://issues.redhat.com/browse/RHSTOR-7022
Go to: "Storage > Data Foundation > Overview > Click on StorageSystem name > Storage pools > Create storage pool".

Add spacing class in odf-console/packages/ocs/storage-pool/body.tsx to insert space between the header and volume type label
<img width="1728" alt="Screenshot 2025-02-25 at 12 35 52 PM" src="https://github.com/user-attachments/assets/888dae13-ecbe-47df-a52b-92e2af47353a" />
