### PR TITLE
Make the create backing store dropdown work

### DIFF
--- a/packages/odf/components/bucket-class/create-bc.tsx
+++ b/packages/odf/components/bucket-class/create-bc.tsx
@@ -40,7 +40,9 @@ export const NS_STORE_MODAL_KEY = 'BC_CREATE_WIZARD_NS_STORE_CREATE_MODAL';
 const NamespaceStoreCreateModal = React.lazy(
   () => import('../namespace-store/namespace-store-modal')
 );
-
+const CreateBackingStoreFormModal = React.lazy(
+  () => import('../create-bs/create-bs-modal')
+);
 const CreateBucketClass: React.FC<{}> = () => {
   const { t } = useCustomTranslation();
 
@@ -56,6 +58,10 @@ const CreateBucketClass: React.FC<{}> = () => {
 
   const launchModal = React.useCallback(
     () => launcher(NamespaceStoreCreateModal, { isOpen: true }),
+    [launcher]
+  );
+  const launchBackingStoreModal = React.useCallback(
+    () => launcher(CreateBackingStoreFormModal, { isOpen: true }),
     [launcher]
   );
 
@@ -77,6 +83,7 @@ const CreateBucketClass: React.FC<{}> = () => {
             dispatch={dispatch}
             namespace={namespace}
             launchModal={launchModal}
+            launchBackingStoreModal={launchBackingStoreModal}
           />
         );
       case NamespacePolicyType.MULTI:

--- a/packages/odf/components/bucket-class/wizard-pages/namespace-store-pages/cache-namespace-store.tsx
+++ b/packages/odf/components/bucket-class/wizard-pages/namespace-store-pages/cache-namespace-store.tsx
@@ -18,7 +18,14 @@ import { TimeDurationDropdown } from '../../time-duration-dropdown';
 
 export const CacheNamespaceStorePage: React.FC<CacheNamespaceStoreProps> =
   React.memo(
-    ({ dispatch, namespace, state, hideCreateNamespaceStore, launchModal }) => {
+    ({
+      dispatch,
+      namespace,
+      state,
+      hideCreateNamespaceStore,
+      launchModal,
+      launchBackingStoreModal,
+    }) => {
       const { t } = useCustomTranslation();
       const [showHelp, setShowHelp] = React.useState(true);
 
@@ -112,6 +119,7 @@ export const CacheNamespaceStorePage: React.FC<CacheNamespaceStoreProps> =
                 selectedKey={getName(state.cacheBackingStore)}
                 namespace={namespace}
                 onChange={handleBSStateChange}
+                launchBackingStoreModal={launchBackingStoreModal}
               />
               <p className="nb-create-bc-step-page-form__element--light-text">
                 {t(
@@ -148,4 +156,5 @@ type CacheNamespaceStoreProps = {
   namespace: string;
   hideCreateNamespaceStore?: boolean;
   launchModal?: () => void;
+  launchBackingStoreModal?: () => void;
 };

--- a/packages/odf/components/s3-browser/create-or-edit-lifecycle-rules/useEditLifecycleRule.ts
+++ b/packages/odf/components/s3-browser/create-or-edit-lifecycle-rules/useEditLifecycleRule.ts
@@ -46,8 +46,8 @@ const convertLifecycleRuleToRuleState = (rule: LifecycleRule): RuleState => {
   const tags: Tag[] = rule.Filter?.Tag
     ? [rule.Filter.Tag]
     : rule.Filter?.And
-    ? rule.Filter.And?.Tags || []
-    : [];
+      ? rule.Filter.And?.Tags || []
+      : [];
 
   if (rule.Filter) {
     if (rule.Filter?.And) {


### PR DESCRIPTION
"Create new Backing Store" option not working ("Create new BucketClass" page) #1875

 Add a usestate react hook in packages/odf/components/create-bs/backing-store-dropdown.tsx  to enable the create backing store modal in odf-console/packages/odf/components/create-bs/create-bs-modal.tsx  popup on clicking in backingstore dropdown

Go to: "Storage > Object Storage > Bucket Class > Create Bucket Class > Select "BucketClass type" as "Namespace", type any "BucketClass name" and select "Next" > Select "Cache NamespaceStore" as policy type and select "Next" > On the third "Resources" step, select "Backing store" dropdown and click on "Create new Backing Store" item"

No modal pops up, whereas on clicking "Create new Backing Store" item from the dropdown should open a modal.

now it is working after the above change
<img width="1728" alt="Screenshot 2025-02-28 at 2 57 34 PM" src="https://github.com/user-attachments/assets/5a22501d-1367-4bf6-ae1a-4463d368bffb" />
<img width="1728" alt="Screenshot 2025-02-28 at 2 57 23 PM" src="https://github.com/user-attachments/assets/91c3dacc-2709-444a-a550-ab75211d8039" />
