### PR TITLE
DFBUGS-1627: Add contrast between text and background

### DIFF
--- a/packages/ocs/dashboards/common/capacity-card/capacity-card.tsx
+++ b/packages/ocs/dashboards/common/capacity-card/capacity-card.tsx
@@ -128,6 +128,11 @@ export const CapacityCard: React.FC<CapacityCardProps> = React.memo((props) => {
                 colorScale={colorScale}
                 padding={{ top: 0, bottom: 0, left: 0, right: 0 }}
                 constrainToVisibleArea
+                titleComponent={
+                  <ChartLabel
+                    style={{ fill: `var(--pf-v5-global--Color--100)` }}
+                  />
+                }
                 subTitleComponent={
                   <ChartLabel
                     dy={5}


### PR DESCRIPTION
[DFBUGS-1627](https://issues.redhat.com//browse/DFBUGS-1627): Add contrast between text and background

https://issues.redhat.com/browse/DFBUGS-1627  
  
  Add a title component with fill: `var(--pf-v5-global--Color--100)` in file packages/ocs/dashboards/common/capacity-card/capacity-card.tsx  to add contrast between text and background

pie graph text has minimal contrast  before- is dark against a dark background

After the above change 
<img width="1728" alt="Screenshot 2025-03-10 at 12 58 58 PM" src="https://github.com/user-attachments/assets/fefd6160-ea2b-4077-8cce-9622dd925a57" />
<img width="1728" alt="Screenshot 2025-03-10 at 12 55 14 PM" src="https://github.com/user-attachments/assets/bbe20648-7a4e-430a-89b1-b3c101b625c5" />

