### PR TITLE
Storage Cluster modals fix: re-render on cluster change

### DIFF
--- a/cypress/tests/add-capacity.spec.ts
+++ b/cypress/tests/add-capacity.spec.ts
@@ -87,9 +87,11 @@ describe('OCS Operator Expansion of Storage Class Test', () => {
           initialState.storageCluster?.spec?.storageDeviceSets?.[0]
             ?.dataPVCTemplate?.spec?.resources?.requests?.storage
         ];
+      const replicas =
+        initialState.storageCluster?.spec?.storageDeviceSets?.[0]?.replica;
       cy.byTestID('requestSize').should('have.value', String(initialCapacity));
       cy.byTestID('provisioned-capacity').contains(
-        `${(initialCapacity * 3).toFixed(0)} TiB`
+        `${(initialCapacity * replicas).toFixed(0)} TiB`
       );
       cy.byTestID('add-cap-sc-dropdown', { timeout: 10000 }).should(
         'be.visible'
@@ -154,15 +156,16 @@ describe('OCS Operator Expansion of Storage Class Test', () => {
 
       cy.log('New OSDs are added correctly to the right nodes', () => {
         const nodes = getIds(osdTree.nodes, 'host');
-        expect(verifyNodeOSDMapping(nodes, newOSDIds, formattedOSDTree)).to.be
-          .true;
+        expect(
+          verifyNodeOSDMapping(nodes, newOSDIds, formattedOSDTree)
+        ).to.equal(true);
       });
     });
     cy.exec('oc get nodes -o json').then((res) => {
       const nodes = JSON.parse(res.stdout);
       const allNodesReady = nodes.items.every(isNodeReady);
       cy.log('No Nodes should go to Not Ready state');
-      expect(allNodesReady).to.be.true;
+      expect(allNodesReady).to.equal(true);
     });
   });
 });

--- a/packages/odf/components/actions/csv-actions.ts
+++ b/packages/odf/components/actions/csv-actions.ts
@@ -1,8 +1,8 @@
 import { useMemo } from 'react';
 import { LSO_OPERATOR } from '@odf/core/constants';
-import AddSSCapacityModal from '@odf/core/modals/add-capacity/add-capacity-modal';
+import AddCapacityModal from '@odf/core/modals/add-capacity/add-capacity-modal';
 import CapacityAutoscalingModal from '@odf/core/modals/capacity-autoscaling/capacity-autoscaling-modal';
-import ConfigureSSPerformanceModal from '@odf/core/modals/configure-performance/configure-performance-modal';
+import ConfigurePerformanceModal from '@odf/core/modals/configure-performance/configure-performance-modal';
 import { isCapacityAutoScalingAllowed } from '@odf/core/utils';
 import {
   DEFAULT_INFRASTRUCTURE,
@@ -68,9 +68,11 @@ export const useCsvActions = ({
       referenceForModel(k8sModel) === referenceForModel(ODFStorageSystem) &&
       isOCSStorageSystem(resource)
     ) {
-      items.push(AddCapacityStorageSystem(resource, launchModal));
+      items.push(AddCapacityStorageSystem(launchModal, storageCluster));
       if (!isProviderMode) {
-        items.push(ConfigurePerformanceStorageSystem(resource, launchModal));
+        items.push(
+          ConfigurePerformanceStorageSystem(launchModal, storageCluster)
+        );
       }
       if (
         isCapacityAutoScalingAllowed(
@@ -114,16 +116,16 @@ const AttachStorageStorageSystem = (resource: StorageSystemKind): Action => {
 };
 
 const AddCapacityStorageSystem = (
-  resource: StorageSystemKind,
-  launchModal: LaunchModal
+  launchModal: LaunchModal,
+  storageCluster: StorageClusterKind
 ): Action => {
   return {
     id: 'add-capacity-storage-system',
     label: 'Add Capacity',
     insertBefore: 'edit-csv',
     cta: () => {
-      launchModal(AddSSCapacityModal as any, {
-        extraProps: { resource },
+      launchModal(AddCapacityModal, {
+        extraProps: { storageCluster },
         isOpen: true,
       });
     },
@@ -131,16 +133,16 @@ const AddCapacityStorageSystem = (
 };
 
 const ConfigurePerformanceStorageSystem = (
-  resource: StorageSystemKind,
-  launchModal: LaunchModal
+  launchModal: LaunchModal,
+  storageCluster: StorageClusterKind
 ): Action => {
   return {
     id: 'configure-performance-storage-system',
     label: 'Configure performance',
     insertAfter: 'add-capacity-storage-system',
     cta: () => {
-      launchModal(ConfigureSSPerformanceModal as any, {
-        extraProps: { resource },
+      launchModal(ConfigurePerformanceModal, {
+        extraProps: { storageCluster },
         isOpen: true,
       });
     },

--- a/packages/odf/components/alerts/alert-action-path.tsx
+++ b/packages/odf/components/alerts/alert-action-path.tsx
@@ -3,7 +3,7 @@ import { DEFAULT_STORAGE_NAMESPACE } from '@odf/shared/constants';
 import { StorageClusterModel } from '@odf/shared/models';
 import { StorageClusterKind } from '@odf/shared/types';
 import { k8sList } from '@openshift-console/dynamic-plugin-sdk';
-import { AddCapacityModal } from '../../modals/add-capacity/add-capacity-modal';
+import AddCapacityModal from '../../modals/add-capacity/add-capacity-modal';
 
 export const getDiskAlertActionPath = () =>
   window.open('https://access.redhat.com/solutions/5194851');
@@ -17,18 +17,19 @@ export const launchClusterExpansionModal = async (_alert, launchModal) => {
       name: alert?.annotations?.target_name,
       ns: alert?.annotations?.target_namespace,
     });
-    launchModal(AddCapacityModal, { isOpen: true, storageCluster });
     */
-    const storageCluster = (await k8sList({
+    const storageClusters = (await k8sList({
       model: StorageClusterModel,
       queryParams: { ns: DEFAULT_STORAGE_NAMESPACE },
     })) as StorageClusterKind[];
     launchModal(AddCapacityModal, {
       isOpen: true,
-      storageCluster: getStorageClusterInNs(
-        storageCluster,
-        DEFAULT_STORAGE_NAMESPACE
-      ),
+      extraProps: {
+        storageCluster: getStorageClusterInNs(
+          storageClusters,
+          DEFAULT_STORAGE_NAMESPACE
+        ),
+      },
     });
   } catch (e) {
     // eslint-disable-next-line no-console

--- a/packages/shared/src/modals/common.ts
+++ b/packages/shared/src/modals/common.ts
@@ -1,3 +1,5 @@
+import { StorageClusterKind } from '@odf/shared/types/storage';
+
 export type CommonModalProps<T = {}> = {
   isOpen: boolean;
   closeModal: () => void;
@@ -5,3 +7,7 @@ export type CommonModalProps<T = {}> = {
     [key: string]: any;
   } & T;
 };
+
+export type StorageClusterActionModalProps = CommonModalProps<{
+  storageCluster: StorageClusterKind;
+}>;


### PR DESCRIPTION
As modals are not children of the component that triggers them, storage cluster resource was not being updated properly.
Changes:
- Watch for changes in StorageCluster via `useK8sWatchResource`.
- Unified props type for StorageCluster action modals.
- Cleanup of redundant wrapper components for `AddCapacity` & `ConfigurePerformance` modals.