### PR TITLE
Fix S3 bucket overview routing

### DIFF
--- a/packages/shared/src/utils/Tabs.tsx
+++ b/packages/shared/src/utils/Tabs.tsx
@@ -105,7 +105,8 @@ const Tabs: React.FC<TabsProps> = ({
       (href) =>
         location.hash === href ||
         currentLocation.endsWith(href) ||
-        currentLocation.endsWith(`${href}/`)
+        currentLocation.endsWith(`${href}/`) ||
+        currentLocation.includes(href)
     );
     const trueActiveTab = hrefToTabMap[firstMatchKey];
     if (trueActiveTab && trueActiveTab !== activeTab) {


### PR DESCRIPTION
Without this fix routing breaks for `basePath/href` tabs' routes (when we have nested tabs).