### PR TITLE
DFBUGS-1634 Fix selection tabs, chart donut, skeletons, and loading placeholders.

### DIFF
--- a/packages/ocs/dashboards/common/capacity-card/capacity-card.scss
+++ b/packages/ocs/dashboards/common/capacity-card/capacity-card.scss
@@ -13,6 +13,7 @@
   &__chart {
     flex-grow: 0.12;
     max-height: 180px;
+    max-width: 180px;
     margin-bottom: 1rem;
     margin-right: 1rem;
   }

--- a/packages/shared/src/utils/tabs.scss
+++ b/packages/shared/src/utils/tabs.scss
@@ -8,8 +8,9 @@
 
   .pf-v5-c-tabs__link {
     margin-right: 2rem;
-    padding: var(--pf-v5-c-tabs__link--PaddingTop) 0
-      var(--pf-v5-c-tabs__link--PaddingBottom) 0;
+    &::cue-region {
+      width: fit-content;  
+    }
   }
 
   .pf-m-current span {


### PR DESCRIPTION
**https://issues.redhat.com/browse/DFBUGS-1634
Fix selection tabs, chart donut, skeletons, and loading placeholders.**
	          Add cue region and remove padding in packages/shared/src/utils/tabs.scss to make the selection tabs fit the content. and add max-width in packages/ocs/dashboards/common/capacity-card/capacity-card.scss to make the chardonut remain in the raw capacity card during zoom in and zoom out. Fix the loading placeholders overlapped with the text in /packages/ocs/dashboards/object-service/status-card/object-service-health.tsx file. Add loading skeletons to details cards in files /packages/ocs/dashboards/object-service/details-card/details-card.scss /packages/ocs/dashboards/object-service/details-card/details-card.tsx and /packages/ocs/dashboards/persistent-internal/details-card.tsx.

**BEFORE CHANGES:**
CHARTDONUT:
<img width="1676" alt="Screenshot 2025-03-28 at 3 17 34 PM" src="https://github.com/user-attachments/assets/6ab39db5-c4ff-4347-ac3b-56e612a4ee0f" />
SELECTION TABS:
<img width="1728" alt="Screenshot 2025-03-28 at 11 02 03 AM" src="https://github.com/user-attachments/assets/3f640bf4-fe2d-489e-a3db-a8802b85c253" />
LOADING PLACEHOLDERS WHILE LOADING AND SKELETON SCREENS:
![image](https://github.com/user-attachments/assets/674b84dd-f518-4e35-b6c1-6776eb30f3b5)
AFTER CHANGES:
CHART DONUT:
<img width="1728" alt="Screenshot 2025-03-28 at 11 00 24 AM" src="https://github.com/user-attachments/assets/83034e24-5d96-4b94-81b9-402cf1820a96" />
<img width="1728" alt="Screenshot 2025-03-28 at 11 00 30 AM" src="https://github.com/user-attachments/assets/d87f86db-cdc2-4d2c-8595-47f607ba5035" />
SELECTION TABS:
<img width="1728" alt="Screenshot 2025-03-28 at 12 01 49 PM" src="https://github.com/user-attachments/assets/5f64cd24-d66b-4d4b-b246-d9671db21776" />
LOADING PLACEHOLDERS WHILE LOADING:
<img width="1290" alt="Screenshot 2025-03-28 at 2 29 07 PM" src="https://github.com/user-attachments/assets/c74d4ca7-02ad-4e1d-b56e-560b31683441" />
SKELETON SCREENS:
<img width="1728" alt="Screenshot 2025-03-28 at 2 30 14 PM" src="https://github.com/user-attachments/assets/8e68035d-316b-4b2e-801e-eaf688731c6a" />
<img width="1728" alt="Screenshot 2025-03-28 at 2 30 36 PM" src="https://github.com/user-attachments/assets/33363275-5327-4e49-b7c2-e6e8442c5f61" />
