### PR TITLE
Capacity Autoscaling modal: show 'Failed' state timestamp & message.

### DIFF
--- a/locales/en/plugin__odf-console.json
+++ b/locales/en/plugin__odf-console.json
@@ -915,6 +915,7 @@
   "How does smart scaling work?": "How does smart scaling work?",
   "Smart scaling adds capacity through OSD expansion by resizing existing OSDs or adding new OSDs to maintain node balance.": "Smart scaling adds capacity through OSD expansion by resizing existing OSDs or adding new OSDs to maintain node balance.",
   "Note:": "Note:",
+  "OSD expansion is limited to a maximum of {{osdMaxSize}}.": "OSD expansion is limited to a maximum of {{osdMaxSize}}.",
   "How does it work?": "How does it work?",
   "This may incur additional costs for the underlying storage.": "This may incur additional costs for the underlying storage.",
   "Cluster expansion limit": "Cluster expansion limit",

--- a/packages/odf/components/create-storage-system/reducer.ts
+++ b/packages/odf/components/create-storage-system/reducer.ts
@@ -9,7 +9,6 @@ import {
   ExternalState,
 } from '@odf/odf-plugin-sdk/extensions';
 import { NetworkAttachmentDefinitionKind, NodeKind } from '@odf/shared/types';
-import { getCapacityAutoScalingDefaultLimit } from '@odf/shared/utils';
 import * as _ from 'lodash-es';
 import {
   DiskSize,
@@ -75,7 +74,7 @@ export const initialState: CreateStorageSystemState = {
     pvCount: 0,
     resourceProfile: ResourceProfile.Balanced,
     capacityAutoScaling: {
-      capacityLimit: getCapacityAutoScalingDefaultLimit(),
+      capacityLimit: null,
       enable: false,
     },
     volumeValidationType: VolumeTypeValidation.NONE,

--- a/packages/odf/constants/common.ts
+++ b/packages/odf/constants/common.ts
@@ -80,11 +80,6 @@ export enum CreateStepsSC {
   REVIEWANDCREATE = 'REVIEWANDCREATE',
 }
 
-export const SIZE_IN_TB = {
-  [StorageSizeUnit.Gi]: 1024,
-  [StorageSizeUnit.Ti]: 1,
-};
-
 export const OSD_CAPACITY_SIZES = {
   [`512${StorageSizeUnit.Gi}`]: 0.5,
   [`2${StorageSizeUnit.Ti}`]: 2,

--- a/packages/odf/modals/add-capacity/add-capacity-modal.tsx
+++ b/packages/odf/modals/add-capacity/add-capacity-modal.tsx
@@ -22,7 +22,11 @@ import {
   DeviceSet,
 } from '@odf/shared/types';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
-import { humanizeBinaryBytes, referenceForModel } from '@odf/shared/utils';
+import {
+  getStorageSizeInTiBWithoutUnit,
+  humanizeBinaryBytes,
+  referenceForModel,
+} from '@odf/shared/utils';
 import {
   useK8sWatchResource,
   WatchK8sResource,
@@ -50,7 +54,6 @@ import {
 import {
   DefaultRequestSize,
   NO_PROVISIONER,
-  SIZE_IN_TB,
   requestedCapacityTooltip,
   storageClassTooltip,
 } from '../../constants';
@@ -210,12 +213,7 @@ const AddCapacityModal: React.FC<StorageClusterActionModalProps> = ({
 
   const deviceSets: DeviceSet[] = storageCluster?.spec?.storageDeviceSets || [];
   const osdSizeWithUnit = getRequestedPVCSize(deviceSets?.[0]?.dataPVCTemplate);
-  // ODF support Gi and Ti for any custome size
-  const [osdSize, unit] = osdSizeWithUnit
-    ? osdSizeWithUnit.split(/(\d+)/).filter(Boolean)
-    : [];
-  const osdSizeWithoutUnit: number =
-    osdSize && unit ? +osdSize / SIZE_IN_TB[unit] : null;
+  const osdSizeWithoutUnit = getStorageSizeInTiBWithoutUnit(osdSizeWithUnit);
   const isNoProvionerSC: boolean = storageClass?.provisioner === NO_PROVISIONER;
   const selectedSCName: string = getName(storageClass);
   const deviceSetIndex: number = getCurrentDeviceSetIndex(

--- a/packages/shared/src/constants/common.ts
+++ b/packages/shared/src/constants/common.ts
@@ -65,6 +65,10 @@ export const STORAGE_SIZE_UNIT_NAME_MAP = Object.freeze({
   [StorageSizeUnit.Gi]: StorageSizeUnitName.GiB,
   [StorageSizeUnit.Ti]: StorageSizeUnitName.TiB,
 });
+export const TIB_CONVERSION_DIVISOR = {
+  [StorageSizeUnit.Gi]: 1024,
+  [StorageSizeUnit.Ti]: 1,
+};
 
 export const BLOCK = 'Block';
 export const FILESYSTEM = 'Filesystem';

--- a/packages/shared/src/dropdown/TypeaheadDropdown.tsx
+++ b/packages/shared/src/dropdown/TypeaheadDropdown.tsx
@@ -281,6 +281,9 @@ export const TypeaheadDropdown: React.FC<TypeaheadDropdownProps> = ({
     </MenuToggle>
   );
 
+  if (selectedValue !== selected) {
+    onOptionSelect(null, selectedValue);
+  }
   return (
     <div className={className}>
       <Select

--- a/packages/shared/src/utils/storage.spec.ts
+++ b/packages/shared/src/utils/storage.spec.ts
@@ -1,0 +1,25 @@
+import { getStorageSizeInTiBWithoutUnit } from './storage';
+
+describe('getStorageSizeInTiBWithoutUnit', () => {
+  it('returns the correct amount in TiB', () => {
+    const conversion: [unknown, number][] = [
+      [null, 0],
+      ['', 0],
+      ['Gi', 0],
+      ['1', 0],
+      [1, 0], // Number primitive not allowed.
+      ['1GiB', 0], // Non-allowed unit.
+      ['0Gi', 0],
+      ['0Ti', 0],
+      ['102.4Gi', 0.1],
+      ['512Gi', 0.5],
+      ['0.5Ti', 0.5],
+      ['1024Gi', 1],
+      ['2Ti', 2],
+    ];
+
+    conversion.forEach(([input, output]) =>
+      expect(getStorageSizeInTiBWithoutUnit(input as string)).toBe(output)
+    );
+  });
+});

--- a/packages/shared/src/utils/storage.ts
+++ b/packages/shared/src/utils/storage.ts
@@ -1,9 +1,9 @@
 import { Model } from '@odf/odf-plugin-sdk/extensions';
 import {
-  CAPACITY_AUTOSCALING_MAX_LIMIT_IN_TIB,
   CEPH_PROVISIONERS,
   DEFAULT_DEVICECLASS,
   ODF_OPERATOR,
+  TIB_CONVERSION_DIVISOR,
   STORAGE_SIZE_UNIT_NAME_MAP,
 } from '@odf/shared/constants';
 import { StorageClusterModel } from '@odf/shared/models';
@@ -11,22 +11,18 @@ import { getName } from '@odf/shared/selectors/k8s';
 import {
   ClusterServiceVersionKind,
   StorageClusterKind,
-  StorageSizeUnit,
   StorageSystemKind,
 } from '@odf/shared/types';
 import { getGVKLabel } from '@odf/shared/utils/common';
 import { K8sResourceKind } from '@openshift-console/dynamic-plugin-sdk';
 import * as _ from 'lodash-es';
 
-export const getCapacityAutoScalingDefaultLimit = () =>
-  `${CAPACITY_AUTOSCALING_MAX_LIMIT_IN_TIB}${StorageSizeUnit.Ti}`;
-
 export const getFormattedCapacity = (capacity: string) => {
   if (!capacity) {
     return '-';
   }
-  return `${capacity.match(/\d+/g)[0]} ${
-    STORAGE_SIZE_UNIT_NAME_MAP[capacity.match(/\D+/g)[0]]
+  return `${capacity.match(/[^a-zA-Z]+/g)[0]} ${
+    STORAGE_SIZE_UNIT_NAME_MAP[capacity.match(/[a-zA-Z]+/g)[0]]
   }`;
 };
 
@@ -35,6 +31,19 @@ export const getODFCsv = (csvList: ClusterServiceVersionKind[] = []) =>
     (csv) =>
       csv?.metadata.name?.substring(0, ODF_OPERATOR.length) === ODF_OPERATOR
   );
+
+export const getStorageSizeInTiBWithoutUnit = (
+  sizeWithUnit: string
+): number => {
+  try {
+    const [size, unit] = sizeWithUnit.split(/([^a-zA-Z]+)/).filter(Boolean);
+    return TIB_CONVERSION_DIVISOR[unit]
+      ? Number(size) / TIB_CONVERSION_DIVISOR[unit]
+      : 0;
+  } catch (_error) {
+    return 0;
+  }
+};
 
 export const getStorageAutoScalerName = (storageCluster: StorageClusterKind) =>
   `${getName(storageCluster)}-${DEFAULT_DEVICECLASS}`;


### PR DESCRIPTION
- Delete preexisting autoscaler CR on storage cluster creation to avoid misconfiguration.
- Minor fixes, improvements & refactoring.
![day2-3-modal-enabled-failed](https://github.com/user-attachments/assets/f9be1de5-07df-4144-8a21-284d629c4269)
