### PR TITLE
Adds facade for StorageSystem resource in UI

### DIFF
--- a/cypress/consts.ts
+++ b/cypress/consts.ts
@@ -3,7 +3,7 @@ export const KUBEADMIN_IDP = 'kube:admin';
 
 export const ODF_OPERATOR_NAME = 'OpenShift Data Foundation';
 export const CLUSTER_NAMESPACE = 'openshift-storage';
-export const STORAGE_SYSTEM_NAME = 'ocs-storagecluster-storagesystem';
+export const STORAGE_SYSTEM_NAME = 'ocs-storagecluster';
 export const STORAGE_CLUSTER_NAME = 'ocs-storagecluster';
 export const CEPH_CLUSTER_NAME = `${STORAGE_CLUSTER_NAME}-cephcluster`;
 

--- a/cypress/support.ts
+++ b/cypress/support.ts
@@ -43,7 +43,7 @@ Cypress.Cookies.debug(true);
 
 Cypress.Commands.add('install', () => {
   cy.exec(
-    `oc get storagesystem ${STORAGE_SYSTEM_NAME} -n ${CLUSTER_NAMESPACE}`,
+    `oc get storagecluster ${STORAGE_SYSTEM_NAME} -n ${CLUSTER_NAMESPACE}`,
     {
       failOnNonZeroExit: false,
     }
@@ -88,15 +88,15 @@ Cypress.Commands.add('install', () => {
       cy.byLegacyTestID('horizontal-link-Storage Systems').click();
       cy.byLegacyTestID('item-filter').type(STORAGE_SYSTEM_NAME);
       cy.get('a').contains(STORAGE_SYSTEM_NAME);
-      cy.get('td[id="status"]', { timeout: 5 * MINUTE }).contains('Available', {
-        timeout: 5 * MINUTE,
+      cy.get('td[id="status"]', { timeout: 5 * MINUTE }).contains('Ready', {
+        timeout: 25 * MINUTE,
       });
       // Verify that the OCS SC is in READY state.
       cy.exec(OCS_SC_STATE, { timeout: 25 * MINUTE });
       cy.visit('/');
     } else {
       cy.log(
-        ' ocs-storagecluster-storagesystem is present, proceeding without installation.'
+        ' ocs-storagecluster is present, proceeding without installation.'
       );
     }
   });

--- a/cypress/tests/add-capacity.spec.ts
+++ b/cypress/tests/add-capacity.spec.ts
@@ -5,7 +5,7 @@ import {
   STORAGE_CLUSTER_NAME,
   CLUSTER_NAMESPACE,
   CEPH_CLUSTER_NAME,
-  ODF_OPERATOR_NAME,
+  MINUTE,
 } from '../consts';
 import {
   createOSDTreeMap,
@@ -71,7 +71,6 @@ describe('OCS Operator Expansion of Storage Class Test', () => {
       const pods = JSON.parse(res.stdout);
       _.set(initialState, 'pods', pods);
 
-      ODFCommon.visitStorageDashboard();
       ODFCommon.visitStorageSystemList();
       listPage.searchInList(STORAGE_SYSTEM_NAME);
       // Todo(bipuladh): Add a proper data-selector once the list page is migrated
@@ -99,19 +98,17 @@ describe('OCS Operator Expansion of Storage Class Test', () => {
       modal.submit();
       modal.shouldBeClosed();
 
-      cy.clickNavLink(['Operators', 'Installed Operators']).first();
-      cy.byLegacyTestID('item-filter').type(ODF_OPERATOR_NAME);
-      cy.byTestOperatorRow(ODF_OPERATOR_NAME).click();
-      cy.byLegacyTestID('horizontal-link-Storage System').click();
-      cy.contains(STORAGE_SYSTEM_NAME).click();
-      cy.contains('Resources').click();
-      cy.byTestOperandLink(STORAGE_CLUSTER_NAME).click();
+      ODFCommon.visitStorageDashboard();
+      ODFCommon.visitStorageSystemList();
       // Wait for the storage cluster to reach Ready
       // Storage Cluster CR flickers so wait for 10 seconds
       // Disablng until ocs-operator fixes above issue
       // eslint-disable-next-line cypress/no-unnecessary-waiting
       cy.wait(10000);
-      cy.byTestID('resource-status').contains('Ready', { timeout: 900000 });
+      // eslint-disable-next-line cypress/require-data-selectors
+      cy.get('td[id="status"]', { timeout: 5 * MINUTE }).contains('Ready', {
+        timeout: 900000,
+      });
     });
     cy.exec(
       `oc get storagecluster ${STORAGE_CLUSTER_NAME} -n ${CLUSTER_NAMESPACE} -o json`

--- a/cypress/tests/object-service-dashboards.spec.ts
+++ b/cypress/tests/object-service-dashboards.spec.ts
@@ -5,7 +5,7 @@ describe('Tests Buckets, Status, Object Storage Efficiency, and Resource Provide
   beforeEach(() => {
     ODFCommon.visitStorageDashboard();
     cy.byLegacyTestID('horizontal-link-Storage Systems').first().click();
-    cy.byLegacyTestID('item-filter').type('ocs-storagecluster-storagesystem');
+    cy.byLegacyTestID('item-filter').type('ocs-storagecluster');
     cy.byTestRows('resource-row')
       .get('td a', {
         timeout: 5 * SECOND,

--- a/cypress/views/multiple-storageclass.ts
+++ b/cypress/views/multiple-storageclass.ts
@@ -26,7 +26,7 @@ export const fetchWorkerNodesJson = () =>
 
 export const addCapacity = (scName: string) => {
   cy.byLegacyTestID('item-filter').clear();
-  cy.byLegacyTestID('item-filter').type('ocs-storagecluster-storagesystem');
+  cy.byLegacyTestID('item-filter').type('ocs-storagecluster');
   cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
   cy.byTestID('kebab-button').click();
   cy.contains('Add Capacity').click();

--- a/packages/ocs/storage-class/sc-form.tsx
+++ b/packages/ocs/storage-class/sc-form.tsx
@@ -43,6 +43,7 @@ import {
   InfrastructureModel,
   StorageClassModel,
   SecretModel,
+  StorageClusterModel,
   ODFStorageSystem,
 } from '@odf/shared/models';
 import { getName, getNamespace } from '@odf/shared/selectors';
@@ -100,8 +101,8 @@ import {
 
 type OnParamChange = (id: string, paramName: string, checkbox: boolean) => void;
 
-const storageSystemResource: WatchK8sResource = {
-  kind: referenceForModel(ODFStorageSystem),
+const storageClusterResource: WatchK8sResource = {
+  kind: referenceForModel(StorageClusterModel),
   isList: true,
 };
 
@@ -209,7 +210,7 @@ const StorageSystemDropdown: React.FC<{
         filterResource={filterOCSStorageSystems}
         id="system-name"
         data-test="storage-system-dropdown"
-        resource={storageSystemResource}
+        resource={storageClusterResource}
         resourceModel={ODFStorageSystem}
       />
       <span className="help-block">

--- a/packages/odf/components/create-storage-system/create-storage-system-steps/create-local-volume-set-step/body.tsx
+++ b/packages/odf/components/create-storage-system/create-storage-system-steps/create-local-volume-set-step/body.tsx
@@ -19,7 +19,7 @@ import { useK8sList } from '@odf/shared/hooks/useK8sList';
 import { TextInputWithFieldRequirements } from '@odf/shared/input-with-requirements';
 import { StorageClassModel } from '@odf/shared/models';
 import { getName } from '@odf/shared/selectors';
-import { StorageSystemKind } from '@odf/shared/types';
+import { StorageClassResourceKind } from '@odf/shared/types';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import validationRegEx from '@odf/shared/utils/validation';
 import { useYupValidationResolver } from '@odf/shared/yup-validation-resolver';
@@ -224,7 +224,7 @@ export const LocalVolumeSetBody: React.FC<LocalVolumeSetBodyProps> = ({
   };
 
   const [data, loaded, loadError] =
-    useK8sList<StorageSystemKind>(StorageClassModel);
+    useK8sList<StorageClassResourceKind>(StorageClassModel);
 
   const { schema, fieldRequirements } = React.useMemo(() => {
     const existingNames =

--- a/packages/odf/components/create-storage-system/footer.tsx
+++ b/packages/odf/components/create-storage-system/footer.tsx
@@ -10,7 +10,6 @@ import {
   NO_PROVISIONER,
   Steps,
   StepsName,
-  STORAGE_CLUSTER_SYSTEM_KIND,
 } from '@odf/core/constants';
 import { useODFNamespaceSelector } from '@odf/core/redux';
 import {
@@ -30,11 +29,7 @@ import {
 } from '@odf/shared/models';
 import { getName, getNamespace } from '@odf/shared/selectors';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
-import {
-  getGVKLabel,
-  getStorageAutoScalerName,
-  isNotFoundError,
-} from '@odf/shared/utils';
+import { getStorageAutoScalerName, isNotFoundError } from '@odf/shared/utils';
 import {
   k8sDelete,
   K8sResourceCommon,
@@ -60,7 +55,6 @@ import {
   createNoobaaExternalPostgresResources,
   setCephRBDAsDefault,
   createStorageCluster,
-  createStorageSystem,
   labelNodes,
   taintNodes,
   createOCSNamespace,
@@ -322,11 +316,6 @@ const handleReviewAndCreateNext = async (
     ) {
       await labelNodes(nodes, systemNamespace);
       await createAdditionalFeatureResources();
-      await createStorageSystem(
-        OCS_INTERNAL_CR_NAME,
-        STORAGE_CLUSTER_SYSTEM_KIND,
-        systemNamespace
-      );
       storageCluster = await createStorageCluster(
         state,
         systemNamespace,
@@ -343,7 +332,6 @@ const handleReviewAndCreateNext = async (
 
       const subSystemName = isRhcs ? OCS_EXTERNAL_CR_NAME : externalSystemName;
       const subSystemState = isRhcs ? connectionDetails : createStorageClass;
-      const subSystemKind = getGVKLabel(model);
 
       const shouldSetCephRBDAsDefault = setCephRBDAsDefault(
         isRBDStorageClassDefault,
@@ -359,7 +347,6 @@ const handleReviewAndCreateNext = async (
         shouldSetCephRBDAsDefault: shouldSetCephRBDAsDefault,
       });
 
-      await createStorageSystem(subSystemName, subSystemKind, systemNamespace);
       // create internal mode cluster along with Non-RHCS StorageSystem (if any Ceph cluster already does not exists)
       if (!hasOCS && !isRhcs) {
         await labelNodes(nodes, systemNamespace);

--- a/packages/odf/components/create-storage-system/payloads.ts
+++ b/packages/odf/components/create-storage-system/payloads.ts
@@ -18,17 +18,12 @@ import {
 import { DEFAULT_STORAGE_NAMESPACE } from '@odf/shared/constants';
 import {
   StorageClusterModel,
-  ODFStorageSystem,
   NodeModel,
   NamespaceModel,
   StorageAutoScalerModel,
 } from '@odf/shared/models';
-import { Patch, StorageSystemKind } from '@odf/shared/types';
-import {
-  getAPIVersionForModel,
-  getStorageAutoScalerName,
-  k8sPatchByName,
-} from '@odf/shared/utils';
+import { Patch } from '@odf/shared/types';
+import { getStorageAutoScalerName, k8sPatchByName } from '@odf/shared/utils';
 import {
   K8sResourceKind,
   k8sCreate,
@@ -42,27 +37,6 @@ import {
   cephStorageLabel,
 } from '../../constants';
 import { WizardNodeState, WizardState } from './reducer';
-
-export const createStorageSystem = async (
-  subSystemName: string,
-  subSystemKind: string,
-  systemNamespace: string
-) => {
-  const payload: StorageSystemKind = {
-    apiVersion: getAPIVersionForModel(ODFStorageSystem),
-    kind: ODFStorageSystem.kind,
-    metadata: {
-      name: `${subSystemName}-storagesystem`,
-      namespace: systemNamespace,
-    },
-    spec: {
-      name: subSystemName,
-      kind: subSystemKind,
-      namespace: systemNamespace,
-    },
-  };
-  return k8sCreate({ model: ODFStorageSystem, data: payload });
-};
 
 export const createSecretPayload = (
   name: string,

--- a/packages/odf/components/odf-dashboard/performance-card/performance-card.tsx
+++ b/packages/odf/components/odf-dashboard/performance-card/performance-card.tsx
@@ -8,18 +8,12 @@ import {
   usePrometheusBasePath,
 } from '@odf/shared/hooks/custom-prometheus-poll';
 import useRefWidth from '@odf/shared/hooks/ref-width';
+import { useWatchStorageSystems } from '@odf/shared/hooks/useWatchStorageSystems';
 import { ODFStorageSystem } from '@odf/shared/models';
 import ResourceLink from '@odf/shared/resource-link/resource-link';
 import Table, { Column } from '@odf/shared/table/table';
-import { StorageSystemKind } from '@odf/shared/types';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
-import {
-  getDashboardLink,
-  getGVK,
-  referenceFor,
-  referenceForModel,
-} from '@odf/shared/utils';
-import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import { getDashboardLink, getGVK, referenceFor } from '@odf/shared/utils';
 import {
   UtilizationDurationDropdown,
   useUtilizationDuration,
@@ -96,11 +90,6 @@ const getRow: GetRow = ({
   ];
 };
 
-const storageSystemResource = {
-  kind: referenceForModel(ODFStorageSystem),
-  isList: true,
-};
-
 const nameSort = (a: RowProps, b: RowProps, c: SortByDirection) => {
   const negation = c !== SortByDirection.asc;
   const sortVal = a.systemName.localeCompare(b.systemName);
@@ -150,9 +139,7 @@ const PerformanceCard: React.FC = () => {
     [t]
   );
 
-  const [systems, systemLoaded, systemLoadError] = useK8sWatchResource<
-    StorageSystemKind[]
-  >(storageSystemResource);
+  const [systems, systemLoaded, systemLoadError] = useWatchStorageSystems();
   const { duration } = useUtilizationDuration();
   const [latency, latencyError, latencyLoading] = useCustomPrometheusPoll({
     query: UTILIZATION_QUERY[StorageDashboard.LATENCY],

--- a/packages/odf/components/odf-dashboard/status-card/status-card.tsx
+++ b/packages/odf/components/odf-dashboard/status-card/status-card.tsx
@@ -11,12 +11,10 @@ import {
   useCustomPrometheusPoll,
   usePrometheusBasePath,
 } from '@odf/shared/hooks/custom-prometheus-poll';
-import { StorageClusterModel, ODFStorageSystem } from '@odf/shared/models';
+import { useWatchStorageSystems } from '@odf/shared/hooks/useWatchStorageSystems';
+import { StorageClusterModel } from '@odf/shared/models';
 import { getName, getNamespace } from '@odf/shared/selectors';
-import {
-  ClusterServiceVersionKind,
-  StorageSystemKind,
-} from '@odf/shared/types';
+import { ClusterServiceVersionKind } from '@odf/shared/types';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import {
   getGVK,
@@ -52,19 +50,11 @@ const operatorResource: K8sResourceObj = (ns) => ({
   isList: true,
 });
 
-const storageSystemResource = {
-  kind: referenceForModel(ODFStorageSystem),
-  isList: true,
-};
-
 export const StatusCard: React.FC = () => {
   const { t } = useCustomTranslation();
   const [csvData, csvLoaded, csvLoadError] =
     useSafeK8sWatchResource<ClusterServiceVersionKind[]>(operatorResource);
-  const [systems, systemsLoaded, systemsLoadError] = useK8sWatchResource<
-    StorageSystemKind[]
-  >(storageSystemResource);
-
+  const [systems, systemsLoaded, systemsLoadError] = useWatchStorageSystems();
   const [healthData, healthError, healthLoading] = useCustomPrometheusPoll({
     query: STATUS_QUERIES[StorageDashboard.HEALTH],
     endpoint: 'api/v1/query' as any,

--- a/packages/odf/components/odf-dashboard/system-capacity-card/capacity-card.tsx
+++ b/packages/odf/components/odf-dashboard/system-capacity-card/capacity-card.tsx
@@ -7,28 +7,16 @@ import {
   useCustomPrometheusPoll,
   usePrometheusBasePath,
 } from '@odf/shared/hooks/custom-prometheus-poll';
+import { useWatchStorageSystems } from '@odf/shared/hooks/useWatchStorageSystems';
 import { ODFStorageSystem } from '@odf/shared/models';
 import { StorageSystemKind } from '@odf/shared/types';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
-import {
-  getGVK,
-  humanizeBinaryBytes,
-  referenceFor,
-  referenceForModel,
-} from '@odf/shared/utils';
-import {
-  PrometheusResponse,
-  useK8sWatchResource,
-} from '@openshift-console/dynamic-plugin-sdk';
+import { getGVK, humanizeBinaryBytes, referenceFor } from '@odf/shared/utils';
+import { PrometheusResponse } from '@openshift-console/dynamic-plugin-sdk';
 import * as _ from 'lodash-es';
 import { Card, CardBody, CardHeader, CardTitle } from '@patternfly/react-core';
 import { storageCapacityTooltip } from '../../../constants';
 import { StorageDashboard, CAPACITY_QUERIES } from '../queries';
-
-const storageSystemResource = {
-  kind: referenceForModel(ODFStorageSystem),
-  isList: true,
-};
 
 const getMetricForSystem = (
   metric: PrometheusResponse,
@@ -43,10 +31,7 @@ const getMetricForSystem = (
 
 const SystemCapacityCard: React.FC = () => {
   const { t } = useCustomTranslation();
-  const [systems, systemsLoaded, systemsLoadError] = useK8sWatchResource<
-    StorageSystemKind[]
-  >(storageSystemResource);
-
+  const [systems, systemsLoaded, systemsLoadError] = useWatchStorageSystems();
   const [usedCapacity, errorUsedCapacity, loadingUsedCapacity] =
     useCustomPrometheusPoll({
       query: CAPACITY_QUERIES[StorageDashboard.USED_CAPACITY_FILE_BLOCK],

--- a/packages/odf/components/system-list/odf-system-list.tsx
+++ b/packages/odf/components/system-list/odf-system-list.tsx
@@ -13,13 +13,14 @@ import {
   useCustomPrometheusPoll,
   usePrometheusBasePath,
 } from '@odf/shared/hooks/custom-prometheus-poll';
+import { useWatchStorageSystems } from '@odf/shared/hooks/useWatchStorageSystems';
 import { CustomKebabItem, Kebab } from '@odf/shared/kebab/kebab';
 import {
   ClusterServiceVersionModel,
   InfrastructureModel,
+  ODFStorageSystem,
   StorageClusterModel,
 } from '@odf/shared/models';
-import { ODFStorageSystem } from '@odf/shared/models';
 import { getName, getNamespace } from '@odf/shared/selectors';
 import { Status } from '@odf/shared/status/Status';
 import {
@@ -366,10 +367,11 @@ const StorageSystemRow: React.FC<RowProps<StorageSystemKind, CustomData>> = ({
         <Kebab
           extraProps={{
             resource: obj,
-            resourceModel: ODFStorageSystem,
+            resourceModel: StorageClusterModel,
             storageCluster,
           }}
           customKebabItems={customKebabItems}
+          customLabel={ODFStorageSystem.label}
         />
       </TableData>
     </>
@@ -393,14 +395,7 @@ export const StorageSystemListPage: React.FC<StorageSystemListPageProps> = ({
   const { odfNamespace, isODFNsLoaded, odfNsLoadError } =
     useODFNamespaceSelector();
 
-  const [storageSystems, loaded, loadError] = useK8sWatchResource<
-    StorageSystemKind[]
-  >({
-    kind: referenceForModel(ODFStorageSystem),
-    isList: true,
-    selector,
-  });
-
+  const [storageSystems, loaded, loadError] = useWatchStorageSystems();
   const [data, filteredData, onFilterChange] =
     useListPageFilter(storageSystems);
 

--- a/packages/odf/features.ts
+++ b/packages/odf/features.ts
@@ -1,8 +1,4 @@
-import {
-  ODFStorageSystem,
-  StorageClassModel,
-  StorageClusterModel,
-} from '@odf/shared/models';
+import { StorageClassModel, StorageClusterModel } from '@odf/shared/models';
 import { SelfSubjectAccessReviewModel } from '@odf/shared/models';
 import {
   StorageClassResourceKind,
@@ -30,8 +26,8 @@ const ssarChecks = [
   {
     flag: ODF_ADMIN,
     resourceAttributes: {
-      group: ODFStorageSystem.apiGroup,
-      resource: ODFStorageSystem.plural,
+      group: StorageClusterModel.apiGroup,
+      resource: StorageClusterModel.plural,
       verb: 'list',
     },
   },

--- a/packages/odf/redux/provider-hooks/useODFSystemFlags.ts
+++ b/packages/odf/redux/provider-hooks/useODFSystemFlags.ts
@@ -7,16 +7,8 @@ import {
 } from '@odf/core/utils';
 import { CephObjectStoreModel, NooBaaSystemModel } from '@odf/shared';
 import { useDeepCompareMemoize } from '@odf/shared/hooks/deep-compare-memoize';
-import {
-  CephClusterModel,
-  StorageClusterModel,
-  ODFStorageSystem,
-} from '@odf/shared/models';
-import {
-  getName,
-  getNamespace,
-  getOwnerReferences,
-} from '@odf/shared/selectors';
+import { CephClusterModel, StorageClusterModel } from '@odf/shared/models';
+import { getName, getNamespace } from '@odf/shared/selectors';
 import {
   StorageClusterKind,
   CephClusterKind,
@@ -81,9 +73,8 @@ const useODFSystemFlagsPayload = ({
             );
 
             const odfSystemFlags = {
-              odfSystemName: getOwnerReferences(sc)?.find(
-                (o) => o.kind === ODFStorageSystem.kind
-              )?.name,
+              // After deprecation of StorageSystem; system and cluster name are the same
+              odfSystemName: getName(sc),
               ocsClusterName: getName(sc),
               // Set to "true" if it is internal mode StorageCluster
               isInternalMode: !isExternalCluster(sc),

--- a/packages/shared/src/hooks/useWatchStorageSystems.ts
+++ b/packages/shared/src/hooks/useWatchStorageSystems.ts
@@ -1,0 +1,118 @@
+import {
+  K8sModel,
+  K8sResourceKind,
+  useK8sWatchResources,
+} from '@openshift-console/dynamic-plugin-sdk';
+import { WatchK8sResources } from '@openshift-console/dynamic-plugin-sdk-internal/lib/extensions/console-types';
+import { ODFStorageSystem, StorageClusterModel } from '../models';
+import {
+  getAnnotations,
+  getLabels,
+  getName,
+  getNamespace,
+  getUID,
+} from '../selectors';
+import { StorageClusterKind, StorageSystemKind } from '../types';
+import { useDeepCompareMemoize } from './deep-compare-memoize';
+
+type ResourceObjects = {
+  storageClusters: StorageClusterKind[];
+  flashSystemClusters: K8sResourceKind[];
+};
+
+// To be used only in this one place and not to be exported
+const IBMFlashSystemModel: K8sModel = {
+  label: 'IBM Flash System',
+  labelPlural: 'IBM Flash Systems',
+  apiVersion: 'v1alpha1',
+  apiGroup: 'odf.ibm.com',
+  plural: 'flashsystemclusters',
+  abbr: 'FS',
+  namespaced: true,
+  kind: 'FlashSystemCluster',
+  crd: true,
+};
+
+const resources: WatchK8sResources<ResourceObjects> = {
+  storageClusters: {
+    groupVersionKind: {
+      group: StorageClusterModel.apiGroup,
+      version: StorageClusterModel.apiVersion,
+      kind: StorageClusterModel.kind,
+    },
+    isList: true,
+  },
+  flashSystemClusters: {
+    groupVersionKind: {
+      group: IBMFlashSystemModel.apiGroup,
+      version: IBMFlashSystemModel.apiVersion,
+      kind: IBMFlashSystemModel.kind,
+    },
+    isList: true,
+  },
+};
+
+const mapStorageClusterToStorageSystem = (
+  storageCluster: StorageClusterKind
+): StorageSystemKind => ({
+  apiVersion: ODFStorageSystem.apiVersion,
+  kind: ODFStorageSystem.kind,
+  metadata: {
+    name: getName(storageCluster),
+    namespace: getNamespace(storageCluster),
+    uid: getUID(storageCluster),
+    creationTimestamp: storageCluster.metadata.creationTimestamp,
+    resourceVersion: storageCluster.metadata.resourceVersion,
+    annotations: getAnnotations(storageCluster),
+    labels: getLabels(storageCluster),
+  },
+  spec: {
+    kind: `${storageCluster.kind}.${storageCluster.apiVersion}`,
+    name: getName(storageCluster),
+    namespace: getNamespace(storageCluster),
+  },
+  status: {
+    phase: storageCluster?.status?.phase,
+  },
+});
+
+/**
+ * A facade layer to poll StorageCluster and IBMFlashSystem resources.
+ * It should be used where watching of StorageSystem resource is required.
+ * StorageSystem resource is a deprecated resource so polling it will not give us any information.
+ *
+ * @returns [StorageSystemKind[], boolean, any]
+ */
+export const useWatchStorageSystems = (): [
+  StorageSystemKind[],
+  boolean,
+  any,
+] => {
+  const { storageClusters: odfClusters, flashSystemClusters } =
+    useK8sWatchResources<ResourceObjects>(resources);
+
+  const loaded = odfClusters.loaded && flashSystemClusters.loaded;
+  // Flashsystem loaderror can occur when IBM flashsystem operator is not installed hence ignore it
+  const loadError = odfClusters.loadError;
+  const storageClusters: StorageClusterKind[] = odfClusters.data;
+  const storageSystems: StorageSystemKind[] =
+    odfClusters?.loaded && !odfClusters.loadError
+      ? storageClusters?.map(mapStorageClusterToStorageSystem)
+      : [];
+  const flashSystems = flashSystemClusters.data;
+  const flashSystemClustersList: StorageSystemKind[] =
+    flashSystemClusters?.loaded && !flashSystemClusters.loadError
+      ? flashSystems?.map(mapStorageClusterToStorageSystem)
+      : [];
+
+  const aggregatedStorageSystems = [
+    ...storageSystems,
+    ...flashSystemClustersList,
+  ];
+  const memoizedStorageSystems = useDeepCompareMemoize(
+    aggregatedStorageSystems,
+    true
+  );
+
+  return [memoizedStorageSystems, loaded, loadError];
+};

--- a/packages/shared/src/kebab/kebab.tsx
+++ b/packages/shared/src/kebab/kebab.tsx
@@ -83,6 +83,7 @@ type KebabProps = {
   };
   terminatingTooltip?: React.ReactNode;
   hideItems?: ModalKeys[];
+  customLabel?: string;
 };
 
 type KebabStaticProperties = {
@@ -135,6 +136,7 @@ export const Kebab: React.FC<KebabProps> & KebabStaticProperties = ({
   isDisabled,
   terminatingTooltip,
   hideItems,
+  customLabel,
 }) => {
   const { t } = useCustomTranslation();
   const launchModal = useModal();
@@ -150,7 +152,7 @@ export const Kebab: React.FC<KebabProps> & KebabStaticProperties = ({
   useClickOutside(dropdownRef, dropdownToggleRef, closeDropdown);
 
   const { resourceModel, resource } = extraProps;
-  const resourceLabel = resourceModel.label;
+  const resourceLabel = customLabel ?? resourceModel.label;
   const navigate = useNavigate();
 
   const [canCreate, createLoading] = useAccessReview({


### PR DESCRIPTION
### Changes Introduced
 - Removes StorageSystem creation code in install path
 - Adds a facade for StorageSystem so code dependent on SS can remain intact.
 - Replaces calls to StorageSystem resource to `useWatchStorageSystem` hook.
 - Update Cypress tests for Install flow.

### Screenshots
![Screenshot 2025-04-02 at 2 50 53 PM](https://github.com/user-attachments/assets/903a5b30-3bb6-4979-8864-e0af2a27276c)
![Screenshot 2025-04-02 at 2 50 59 PM](https://github.com/user-attachments/assets/49c66a82-7651-4c7e-8846-cc02118e4ce3)
![Screenshot 2025-04-02 at 2 51 07 PM](https://github.com/user-attachments/assets/d89cdfbb-258d-4490-b7f5-a222dc046522)
![Screenshot 2025-04-02 at 2 51 54 PM](https://github.com/user-attachments/assets/e4af04ef-10db-4c2a-9f57-a96a92be9bca)
