### PR TITLE
Fix for ManagedClusterAction mca-64x44 violates policy 299

### DIFF
--- a/packages/mco/types/acm.ts
+++ b/packages/mco/types/acm.ts
@@ -185,15 +185,7 @@ export enum ManagedClusterActionType {
 
 export type ACMManagedClusterActionKind = K8sResourceCommon & {
   spec?: {
-    cluster?: {
-      name: string;
-    };
-    type?: 'Action';
     actionType?: ManagedClusterActionType;
-    scope?: {
-      resourceType: string;
-      namespace: string;
-    };
     kube?: {
       resource?: string;
       name?: string;

--- a/packages/mco/utils/managed-cluster-action.ts
+++ b/packages/mco/utils/managed-cluster-action.ts
@@ -52,9 +52,6 @@ export const fireManagedClusterAction = async (
       kind: ACMManagedClusterActionModel.kind,
       metadata: { generateName: 'mca-', namespace: clusterName },
       spec: {
-        cluster: { name: clusterName },
-        type: 'Action',
-        scope: { resourceType, namespace: resourceNamespace },
         actionType,
         kube: {
           resource: resourceType,


### PR DESCRIPTION
The ManagedClusterAction CRD does not include these spec fields, which leads to a policy violation warning being triggered in the console.