### PR TITLE
[WIP] Capacity Autoscaling: set storagecluster uid in autoscaler CR

### DIFF
--- a/packages/odf/components/create-storage-system/footer.tsx
+++ b/packages/odf/components/create-storage-system/footer.tsx
@@ -23,17 +23,10 @@ import {
 } from '@odf/core/utils';
 import { StorageClassWizardStepExtensionProps as ExternalStorage } from '@odf/odf-plugin-sdk/extensions';
 import { StorageClusterKind } from '@odf/shared';
-import {
-  StorageAutoScalerModel,
-  StorageClusterModel,
-} from '@odf/shared/models';
-import { getName, getNamespace } from '@odf/shared/selectors';
+import { StorageClusterModel } from '@odf/shared/models';
+import { getName } from '@odf/shared/selectors';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
-import { getStorageAutoScalerName, isNotFoundError } from '@odf/shared/utils';
-import {
-  k8sDelete,
-  K8sResourceCommon,
-} from '@openshift-console/dynamic-plugin-sdk';
+import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import {
   WizardFooter,
   WizardContext,
@@ -362,41 +355,19 @@ const handleReviewAndCreateNext = async (
       if (!isRhcs && !!waitToCreate) await waitToCreate(model);
       await createExternalSubSystem(subSystemPayloads);
     }
-    if (storageCluster) {
+    if (storageCluster && state.capacityAndNodes.capacityAutoScaling.enable) {
+      // Don't stop the workflow on autoscaler creation error.
       try {
-        // Delete preexisting ui-created autoscaler to avoid a misconfiguration.
-        await k8sDelete({
-          model: StorageAutoScalerModel,
-          resource: {
-            metadata: {
-              name: getStorageAutoScalerName(storageCluster),
-              namespace: getNamespace(storageCluster),
-            },
-          },
-        });
+        await createStorageAutoScaler(
+          state.capacityAndNodes.capacityAutoScaling.capacityLimit,
+          storageCluster
+        );
       } catch (error) {
-        // It's OK if it didn't exist.
-        if (!isNotFoundError(error)) {
-          // eslint-disable-next-line no-console
-          console.error(
-            `Error while deleting preexisting capacity autoscaling: ${error.message}`
-          );
-        }
-      }
-      if (state.capacityAndNodes.capacityAutoScaling.enable) {
-        // Don't stop the workflow on autoscaler creation error.
-        try {
-          await createStorageAutoScaler(
-            state.capacityAndNodes.capacityAutoScaling.capacityLimit,
-            storageCluster
-          );
-        } catch (error) {
-          // TODO: raise a notification once the notification system is implemented.
-          // eslint-disable-next-line no-console
-          console.error(
-            `Error while enabling capacity autoscaling: ${error.message}`
-          );
-        }
+        // TODO: raise a notification once the notification system is implemented.
+        // eslint-disable-next-line no-console
+        console.error(
+          `Error while enabling capacity autoscaling: ${error.message}`
+        );
       }
     }
     navigate('/odf/systems');

--- a/packages/odf/components/create-storage-system/payloads.ts
+++ b/packages/odf/components/create-storage-system/payloads.ts
@@ -10,6 +10,7 @@ import {
   getAPIVersion,
   getName,
   getNamespace,
+  getUID,
 } from '@odf/shared';
 import {
   NOOBAA_EXTERNAL_PG_TLS_SECRET_NAME,
@@ -223,6 +224,8 @@ export const createStorageAutoScaler = (
       storageCapacityLimit: capacityLimit,
       storageCluster: {
         name: getName(storageCluster),
+        namespace: getNamespace(storageCluster),
+        uid: getUID(storageCluster),
       },
     },
   };

--- a/packages/odf/modals/capacity-autoscaling/capacity-autoscaling-modal.tsx
+++ b/packages/odf/modals/capacity-autoscaling/capacity-autoscaling-modal.tsx
@@ -15,6 +15,7 @@ import {
   DEFAULT_DEVICECLASS,
   getName,
   getNamespace,
+  getUID,
   GrayUnknownIcon,
   GreenCheckCircleIcon,
   RedExclamationCircleIcon,
@@ -168,7 +169,7 @@ const CapacityAutoscalingModal: React.FC<StorageClusterActionModalProps> = ({
 
   const clusterStorageAutoScalers = storageAutoScalers?.filter(
     (autoScaler) =>
-      autoScaler.spec.storageCluster.name === getName(storageCluster) &&
+      autoScaler.spec.storageCluster.uid === getUID(storageCluster) &&
       (_.isEmpty(autoScaler.spec.deviceClass) ||
         autoScaler.spec.deviceClass.toLowerCase() === DEFAULT_DEVICECLASS)
   );

--- a/packages/shared/src/types/storage.ts
+++ b/packages/shared/src/types/storage.ts
@@ -236,6 +236,8 @@ export type StorageAutoScalerKind = K8sResourceCommon & {
     storageCapacityLimit: string;
     storageCluster: {
       name: string;
+      namespace: string;
+      uid: string;
     };
   };
   status?: {

--- a/packages/shared/src/utils/storage.ts
+++ b/packages/shared/src/utils/storage.ts
@@ -7,7 +7,7 @@ import {
   STORAGE_SIZE_UNIT_NAME_MAP,
 } from '@odf/shared/constants';
 import { StorageClusterModel } from '@odf/shared/models';
-import { getName } from '@odf/shared/selectors/k8s';
+import { getName, getUID } from '@odf/shared/selectors/k8s';
 import {
   ClusterServiceVersionKind,
   StorageClusterKind,
@@ -46,7 +46,7 @@ export const getStorageSizeInTiBWithoutUnit = (
 };
 
 export const getStorageAutoScalerName = (storageCluster: StorageClusterKind) =>
-  `${getName(storageCluster)}-${DEFAULT_DEVICECLASS}`;
+  `${getName(storageCluster)}-${DEFAULT_DEVICECLASS}-${getUID(storageCluster)}`;
 
 export const isOCSStorageSystem = (
   resource: K8sResourceKind


### PR DESCRIPTION
Merge after https://github.com/red-hat-storage/ocs-operator/pull/3126
Fixes: https://issues.redhat.com/browse/DFBUGS-2079
Also adding cluster `uid` in the autoscaler CR name to avoid name conflicts, hence no need for deleting preexisting CR on cluster creation (Day-1).