### PR TITLE
DFBUGS-2147: [release-4.18-compatibility] fix: update serialize-javascript to >=6.0.2 to address XSS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,17 +184,18 @@
   "resolutions": {
     "cache-loader/loader-utils": "^1.4.2",
     "cache-loader/loader-utils/json5": "^1.0.2",
-    "cross-spawn": "^7.0.6",
     "eslint-plugin-import/tsconfig-paths/json5": "^1.0.2",
-    "http-proxy-middleware": "^2.0.7",
     "loader-utils": "^2.0.4",
     "minimist": "^1.2.8",
-    "nanoid": "^3.3.8",
-    "postcss": "^8.4.49",
-    "tough-cookie": "^4.1.3",
     "webpack": "^5.96.1",
     "webpack-bundle-analyzer/ws": "^7.5.10",
-    "webpack-dev-server/express": "^4.21.0"
+    "webpack-dev-server/express": "^4.21.0",
+    "http-proxy-middleware": "^2.0.7",
+    "tough-cookie": "^4.1.3",
+    "cross-spawn": "^7.0.6",
+    "postcss": "^8.4.49",
+    "nanoid": "^3.3.8",
+    "serialize-javascript": "^6.0.2"
   },
   "engines": {
     "node": ">=20.x"


### PR DESCRIPTION
https://issues.redhat.com/browse/DFBUGS-2152 
https://issues.redhat.com/browse/DFBUGS-2147 
https://issues.redhat.com/browse/DFBUGS-2157 
