### PR TITLE
DFBUGS-2148: [release-4.14] fix: update serialize-javascript to >=6.0.2 to address XSS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,7 +178,8 @@
     "webpack-dev-middleware": "^5.3.4",
     "webpack-bundle-analyzer/ws": "^7.5.10",
     "webpack-dev-server/express": "^4.21.0",
-    "ws": "^8.18.0"
+    "ws": "^8.18.0",
+    "serialize-javascript": "^6.0.2"
   },
   "engines": {
     "node": ">=14.17.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9705,14 +9705,7 @@ send@0.19.0:
     range-parser "~1.2.1"
     statuses "2.0.1"
 
-serialize-javascript@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-5.0.1.tgz#7886ec848049a462467a97d3d918ebb2aaf934f4"
-  integrity sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==
-  dependencies:
-    randombytes "^2.1.0"
-
-serialize-javascript@^6.0.1:
+serialize-javascript@^5.0.1, serialize-javascript@^6.0.1, serialize-javascript@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
   integrity sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==


### PR DESCRIPTION
https://issues.redhat.com/browse/DFBUGS-2153
https://issues.redhat.com/browse/DFBUGS-2148
https://issues.redhat.com/browse/DFBUGS-2143 