### PR TITLE
Fix for DRPolicy creation issue for MDR

### DIFF
--- a/packages/mco/components/create-dr-policy/utils/cluster-list-utils.ts
+++ b/packages/mco/components/create-dr-policy/utils/cluster-list-utils.ts
@@ -106,6 +106,8 @@ const getODFInfo = (
       requiredODFVersion
     );
 
+    const deploymentType = odfInfo?.deploymentType;
+
     return [
       {
         odfVersion,
@@ -114,6 +116,7 @@ const getODFInfo = (
         storageClusterInfo: {
           storageClusterNamespacedName,
           cephFSID,
+          deploymentType,
         },
       },
       odfInfo?.clients || [],
@@ -130,6 +133,7 @@ const getODFInfo = (
         storageClusterInfo: {
           storageClusterNamespacedName: '',
           cephFSID: '',
+          deploymentType: '',
         },
       },
       [],

--- a/packages/mco/components/create-dr-policy/utils/reducer.ts
+++ b/packages/mco/components/create-dr-policy/utils/reducer.ts
@@ -10,6 +10,8 @@ export type StorageClusterInfoType = {
   // ToDo: Use list type after ODF starts supporting
   // multiple clients per managed cluster
   clientInfo?: ConnectedClient;
+  // Deployment type of ODF cluster internal/external
+  deploymentType: string;
 };
 
 export type ODFConfigInfoType = {


### PR DESCRIPTION
When both selected clusters have deploymentType set to external, storage class validation is not required. An early return in the useStorageClassValidation hook was added to skip the validation logic entirely if both clusters are external.

For the external cluster, `ramendr.openshift.io/storageid` was added by the MCO operator after the DRPolicy & MirrorPeer creation. so it is not possible to do the storage class validation. 

Issue: https://issues.redhat.com/browse/DFBUGS-2229