### PR TITLE
Failover Blocked in UI Due to DRType Misidentification in RDR Setup

### DIFF
--- a/locales/en/plugin__odf-console.json
+++ b/locales/en/plugin__odf-console.json
@@ -1748,6 +1748,7 @@
   "Only lowercase letters, numbers, non-consecutive periods, or hyphens": "Only lowercase letters, numbers, non-consecutive periods, or hyphens",
   "Cannot be used before": "Cannot be used before",
   "Cannot be used before within the same namespace": "Cannot be used before within the same namespace",
+  "Cannot be empty": "Cannot be empty",
   "Not enough usage data": "Not enough usage data",
   "Total requests: ": "Total requests: ",
   "used": "used",
@@ -1796,6 +1797,9 @@
   "No resources available": "No resources available",
   "Select {{resourceLabel}}": "Select {{resourceLabel}}",
   "Error Loading": "Error Loading",
+  "no results": "no results",
+  "No results found for {{ filterValue }}": "No results found for {{ filterValue }}",
+  "Clear selected value": "Clear selected value",
   "Loading empty page": "Loading empty page",
   "You are not authorized to complete this action. See your cluster administrator for role-based access control information.": "You are not authorized to complete this action. See your cluster administrator for role-based access control information.",
   "Not Authorized": "Not Authorized",
@@ -1859,6 +1863,7 @@
   "Infrastructures": "Infrastructures",
   "Subscriptions": "Subscriptions",
   "Project": "Project",
+  "Suspended": "Suspended",
   "Composable table": "Composable table",
   "Selectable table": "Selectable table",
   "Select all": "Select all",
@@ -1913,10 +1918,5 @@
   "Cannot change resource name (original: \"{{name}}\", updated: \"{{newName}}\").": "Cannot change resource name (original: \"{{name}}\", updated: \"{{newName}}\").",
   "Cannot change resource namespace (original: \"{{namespace}}\", updated: \"{{newNamespace}}\").": "Cannot change resource namespace (original: \"{{namespace}}\", updated: \"{{newNamespace}}\").",
   "Cannot change resource kind (original: \"{{original}}\", updated: \"{{updated}}\").": "Cannot change resource kind (original: \"{{original}}\", updated: \"{{updated}}\").",
-  "Cannot change API group (original: \"{{apiGroup}}\", updated: \"{{newAPIGroup}}\").": "Cannot change API group (original: \"{{apiGroup}}\", updated: \"{{newAPIGroup}}\").",
-  "Cannot be empty": "Cannot be empty",
-  "no results": "no results",
-  "No results found for {{ filterValue }}": "No results found for {{ filterValue }}",
-  "Clear selected value": "Clear selected value",
-  "Suspended": "Suspended"
+  "Cannot change API group (original: \"{{apiGroup}}\", updated: \"{{newAPIGroup}}\").": "Cannot change API group (original: \"{{apiGroup}}\", updated: \"{{newAPIGroup}}\")."
 }

--- a/packages/mco/components/create-dr-policy/selected-cluster-validator.tsx
+++ b/packages/mco/components/create-dr-policy/selected-cluster-validator.tsx
@@ -50,9 +50,8 @@ const checkSyncPolicyExists = (
   drPolicies: DRPolicyKind[]
 ): boolean =>
   drPolicies.some((drPolicy) => {
-    const { drClusters, schedulingInterval } = drPolicy.spec;
-    const isSyncPolicy =
-      getReplicationType(schedulingInterval) === ReplicationType.SYNC;
+    const { drClusters } = drPolicy.spec;
+    const isSyncPolicy = getReplicationType(drPolicy) === ReplicationType.SYNC;
     return (
       isSyncPolicy && drClusters.every((cluster) => clusters.includes(cluster))
     );

--- a/packages/mco/components/dr-status-popover/parsers/applicationset-parser.tsx
+++ b/packages/mco/components/dr-status-popover/parsers/applicationset-parser.tsx
@@ -60,7 +60,7 @@ const ApplicationSetParser: React.FC<ApplicationSetParserProps> = ({
       const healthStatus = getReplicationHealth(
         dataLastSyncedOn || '',
         schedulingInterval,
-        getReplicationType(schedulingInterval)
+        getReplicationType(drPolicy)
       );
 
       return {

--- a/packages/mco/components/dr-status-popover/parsers/discovered-parser.tsx
+++ b/packages/mco/components/dr-status-popover/parsers/discovered-parser.tsx
@@ -49,15 +49,14 @@ export const DiscoveredParser: React.FC<DiscoveredParserProps> = ({
     const volumeReplicationHealth = getReplicationHealth(
       volumeLastGroupSyncTime,
       schedulingInterval,
-      getReplicationType(schedulingInterval)
+      getReplicationType(drPolicy)
     );
 
     const kubeObjectSchedulingInterval =
       drPlacementControl?.spec?.kubeObjectProtection?.captureInterval;
     const kubeObjectReplicationHealth = getReplicationHealth(
       lastKubeObjectProtectionTime,
-      kubeObjectSchedulingInterval,
-      getReplicationType(kubeObjectSchedulingInterval)
+      kubeObjectSchedulingInterval
     );
 
     return {

--- a/packages/mco/components/dr-status-popover/parsers/subscription-parser.tsx
+++ b/packages/mco/components/dr-status-popover/parsers/subscription-parser.tsx
@@ -51,7 +51,7 @@ const parseDRStatusForGroup = (
   const targetCluster = findCluster(drClusters, primaryClusterName);
 
   const lastGroupSyncTime: string = drpc?.status?.lastGroupSyncTime;
-  const replicationType = getReplicationType(schedulingInterval);
+  const replicationType = getReplicationType(group.drInfo?.drPolicy);
 
   const volumeReplicationHealth = getReplicationHealth(
     lastGroupSyncTime,

--- a/packages/mco/components/drpolicy-list-page/drpolicy-list-page.tsx
+++ b/packages/mco/components/drpolicy-list-page/drpolicy-list-page.tsx
@@ -46,7 +46,7 @@ const DRPolicyRow: React.FC<RowProps<DRPolicyKind, RowData>> = ({
   ));
   const appCount = policyToAppCount?.[getName(obj)] || 0;
   const syncInterval = obj?.spec?.schedulingInterval;
-  const replicationType = getReplicationType(syncInterval);
+  const replicationType = getReplicationType(obj);
 
   return (
     <>

--- a/packages/mco/components/mco-dashboard/disaster-recovery/parsers/applicationset-parser.tsx
+++ b/packages/mco/components/mco-dashboard/disaster-recovery/parsers/applicationset-parser.tsx
@@ -21,10 +21,10 @@ import {
   DRClusterKind,
 } from '@odf/mco/types';
 import {
-  findDRType,
   findDeploymentClusters,
   getProtectedPVCsFromDRPC,
   getRemoteNamespaceFromAppSet,
+  getReplicationType,
 } from '@odf/mco/utils';
 import { getName, getNamespace } from '@odf/shared/selectors';
 import * as _ from 'lodash-es';
@@ -112,12 +112,8 @@ export const useApplicationSetParser: UseApplicationSetParser = (
       // DRCluster to its ApplicationSets (total and protected) mapping
       formattedArgoAppSetResources.forEach((argoApplicationSetResource) => {
         const { application } = argoApplicationSetResource || {};
-        const {
-          drClusters: currentDRClusters,
-          drPlacementControl,
-          drPolicy,
-          placementDecision,
-        } = argoApplicationSetResource.placements?.[0] || {};
+        const { drPlacementControl, drPolicy, placementDecision } =
+          argoApplicationSetResource.placements?.[0] || {};
         const deploymentClusters = findDeploymentClusters(
           placementDecision,
           drPlacementControl
@@ -139,7 +135,7 @@ export const useApplicationSetParser: UseApplicationSetParser = (
                     drpcName: getName(drPlacementControl),
                     drpcNamespace: getNamespace(drPlacementControl),
                     protectedPVCs: getProtectedPVCsFromDRPC(drPlacementControl),
-                    replicationType: findDRType(currentDRClusters),
+                    replicationType: getReplicationType(drPolicy),
                     volumeSyncInterval: drPolicy?.spec?.schedulingInterval,
                     workloadNamespaces: [
                       getRemoteNamespaceFromAppSet(application),

--- a/packages/mco/components/mco-dashboard/disaster-recovery/parsers/discovered-parser.tsx
+++ b/packages/mco/components/mco-dashboard/disaster-recovery/parsers/discovered-parser.tsx
@@ -17,9 +17,8 @@ import {
   DRPolicyKind,
 } from '@odf/mco/types';
 import {
-  filerDRClustersUsingDRPolicy,
   findDRPolicyUsingDRPC,
-  findDRType,
+  getReplicationType,
   getLastAppDeploymentClusterName,
   getProtectedPVCsFromDRPC,
 } from '@odf/mco/utils';
@@ -87,10 +86,6 @@ export const useDiscoveredParser: UseDiscoveredParser = (
       // DRCluster to its ApplicationSets (total and protected) mapping
       drPlacementControls.forEach((drPlacementControl) => {
         const drPolicy = findDRPolicyUsingDRPC(drPlacementControl, drPolicies);
-        const currentDRClusters = filerDRClustersUsingDRPolicy(
-          drPolicy,
-          drClusters
-        );
         const decisionCluster =
           getLastAppDeploymentClusterName(drPlacementControl);
         if (drClusterAppsMap.hasOwnProperty(decisionCluster)) {
@@ -109,7 +104,7 @@ export const useDiscoveredParser: UseDiscoveredParser = (
                   drpcName: getName(drPlacementControl),
                   drpcNamespace: getNamespace(drPlacementControl),
                   protectedPVCs: getProtectedPVCsFromDRPC(drPlacementControl),
-                  replicationType: findDRType(currentDRClusters),
+                  replicationType: getReplicationType(drPolicy),
                   volumeSyncInterval: drPolicy?.spec?.schedulingInterval,
                   workloadNamespaces:
                     drPlacementControl.spec?.protectedNamespaces || [],

--- a/packages/mco/components/mco-dashboard/disaster-recovery/parsers/subscription-parser.tsx
+++ b/packages/mco/components/mco-dashboard/disaster-recovery/parsers/subscription-parser.tsx
@@ -14,9 +14,9 @@ import {
   ProtectedAppsMap,
 } from '@odf/mco/types';
 import {
-  findDRType,
   getProtectedPVCsFromDRPC,
   findDeploymentClusters,
+  getReplicationType,
 } from '@odf/mco/utils';
 import { ACMPlacementModel } from '@odf/shared';
 import { ApplicationKind } from '@odf/shared';
@@ -33,18 +33,13 @@ const createPlacementControlInfoList = (
   subscriptionGroupsList.forEach((subscriptionGroup) => {
     const { drInfo } = subscriptionGroup;
     if (!_.isEmpty(drInfo)) {
-      const {
-        drPlacementControl,
-        drPolicy,
-        drClusters: currentDRClusters,
-      } = drInfo;
-
+      const { drPlacementControl, drPolicy } = drInfo;
       const placementControlInfo: PlacementControlInfo = {
         deploymentClusterName: clusterName,
         drpcName: getName(drPlacementControl),
         drpcNamespace: getNamespace(drPlacementControl),
         protectedPVCs: getProtectedPVCsFromDRPC(drPlacementControl),
-        replicationType: findDRType(currentDRClusters),
+        replicationType: getReplicationType(drPolicy),
         volumeSyncInterval: drPolicy?.spec?.schedulingInterval,
         workloadNamespaces: [applicationNamespace],
         failoverCluster: drPlacementControl?.spec?.failoverCluster,

--- a/packages/mco/components/modals/app-failover-relocate/parser/argo-application-set-parser.tsx
+++ b/packages/mco/components/modals/app-failover-relocate/parser/argo-application-set-parser.tsx
@@ -25,9 +25,9 @@ import {
   findCluster,
   findDeploymentClusters,
   checkDRActionReadiness,
-  findDRType,
   isDRClusterFenced,
   findPlacementNameFromAppSet,
+  getReplicationType,
 } from '../../../../utils';
 import { FailoverRelocateModal } from '../failover-relocate-modal';
 import { PlacementControlProps } from '../failover-relocate-modal-body';
@@ -155,7 +155,7 @@ export const ArogoApplicationSetParser = (
             isPrimaryClusterAvailable: !!primaryClusterCondition,
             isDRActionReady: checkDRActionReadiness(drPlacementControl, action),
             snapshotTakenTime: drPlacementControl?.status?.lastGroupSyncTime,
-            replicationType: findDRType(drClusters),
+            replicationType: getReplicationType(drPolicy),
             isTargetClusterFenced: isDRClusterFenced(targetDRCluster),
             isPrimaryClusterFenced: isDRClusterFenced(primaryDRCluster),
             areSiblingApplicationsFound: !!siblingApplications?.length,

--- a/packages/mco/components/modals/app-failover-relocate/parser/discovered-application-parser.tsx
+++ b/packages/mco/components/modals/app-failover-relocate/parser/discovered-application-parser.tsx
@@ -14,8 +14,8 @@ import {
   checkDRActionReadiness,
   filterManagedClusterUsingDRClusters,
   findCluster,
-  findDRType,
   getLastAppDeploymentClusterName,
+  getReplicationType,
   isDRClusterFenced,
 } from '@odf/mco/utils';
 import { DRPlacementControlModel } from '@odf/shared';
@@ -158,7 +158,7 @@ export const DiscoveredApplicationParser: React.FC<
           drPlacementControlName: getName(drPlacementControl),
           isDRActionReady: checkDRActionReadiness(drPlacementControl, action),
           snapshotTakenTime: drPlacementControl?.status?.lastGroupSyncTime,
-          replicationType: findDRType(drClusters),
+          replicationType: getReplicationType(drPolicy),
           schedulingInterval: drPolicy?.spec?.schedulingInterval,
         },
       ];

--- a/packages/mco/components/modals/app-failover-relocate/subscriptions/dr-policy-selector.tsx
+++ b/packages/mco/components/modals/app-failover-relocate/subscriptions/dr-policy-selector.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { getReplicationType } from '@odf/mco/utils';
 import { useDeepCompareMemoize } from '@odf/shared/hooks/deep-compare-memoize';
 import { getName, getUID } from '@odf/shared/selectors';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
@@ -90,6 +91,7 @@ export const DRPolicySelector: React.FC<DRPolicySelectorProps> = ({
       policyName: getName(drPolicy),
       drClusters: drPolicy?.spec?.drClusters,
       schedulingInterval: drPolicy?.spec?.schedulingInterval,
+      replicationType: getReplicationType(drPolicy),
     });
     setOpen(false);
   };

--- a/packages/mco/components/modals/app-failover-relocate/subscriptions/peer-cluster-status.tsx
+++ b/packages/mco/components/modals/app-failover-relocate/subscriptions/peer-cluster-status.tsx
@@ -10,11 +10,14 @@ import {
 import { TFunction } from 'react-i18next';
 import { Flex, FlexItem } from '@patternfly/react-core';
 import { UnknownIcon } from '@patternfly/react-icons';
-import { DRActionType, VolumeReplicationHealth } from '../../../../constants';
+import {
+  DRActionType,
+  ReplicationType,
+  VolumeReplicationHealth,
+} from '../../../../constants';
 import {
   checkDRActionReadiness,
   getReplicationHealth,
-  getReplicationType,
 } from '../../../../utils';
 import { DateTimeFormat } from '../failover-relocate-modal-body';
 import { ErrorMessageType } from './error-messages';
@@ -81,7 +84,8 @@ const getPeerStatusSummary = (
   subsGroups: string[],
   actionType: DRActionType,
   schedulingInterval: string,
-  t: TFunction
+  t: TFunction,
+  replicationType: ReplicationType
 ) =>
   drpcStateList?.reduce((acc, drpcState) => {
     const drPlacementControl = drpcState?.drPlacementControl;
@@ -91,7 +95,8 @@ const getPeerStatusSummary = (
       const higherSeverityHealth = getHigherSeverityHealth(
         acc.replicationHealth,
         lastGroupSyncTime,
-        schedulingInterval
+        schedulingInterval,
+        replicationType
       );
 
       return {
@@ -112,9 +117,9 @@ const getPeerStatusSummary = (
 const getHigherSeverityHealth = (
   previousHealth: VolumeReplicationHealth,
   lastGroupSyncTime: string,
-  schedulingInterval: string
+  schedulingInterval: string,
+  replicationType: ReplicationType
 ): VolumeReplicationHealth => {
-  const replicationType = getReplicationType(schedulingInterval);
   const currentHealth = getReplicationHealth(
     lastGroupSyncTime,
     schedulingInterval,
@@ -190,7 +195,8 @@ export const PeerClusterStatus: React.FC<PeerClusterStatusProps> = ({
         selectedSubsGroups,
         actionType,
         selectedDRPolicy.schedulingInterval,
-        t
+        t,
+        selectedDRPolicy.replicationType
       );
       if (
         peerCurrentStatus.peerReadiness.text ===
@@ -232,6 +238,7 @@ export const PeerClusterStatus: React.FC<PeerClusterStatusProps> = ({
   }, [
     selectedSubsGroups,
     selectedDRPolicy.schedulingInterval,
+    selectedDRPolicy.replicationType,
     drPolicyControlState,
     actionType,
     t,

--- a/packages/mco/components/modals/app-failover-relocate/subscriptions/reducer.ts
+++ b/packages/mco/components/modals/app-failover-relocate/subscriptions/reducer.ts
@@ -1,4 +1,4 @@
-import { DRActionType } from '../../../../constants';
+import { DRActionType, ReplicationType } from '../../../../constants';
 import { ApplicationDRInfo } from '../../../../utils';
 import { MessageKind } from './error-messages';
 
@@ -20,6 +20,7 @@ export type DRPolicyType = Partial<{
   policyName: string;
   drClusters: string[];
   schedulingInterval: string;
+  replicationType: ReplicationType;
 }>;
 
 export type TargetClusterType = Partial<{

--- a/packages/mco/components/modals/app-failover-relocate/subscriptions/target-cluster-selector.tsx
+++ b/packages/mco/components/modals/app-failover-relocate/subscriptions/target-cluster-selector.tsx
@@ -50,16 +50,6 @@ const getAvailableCondition = (managedCluster: ACMManagedClusterKind) =>
       condition.status === 'True'
   );
 
-export const getReplicationTypeUsingDRClusters = (
-  targetClusters: DRClusterKind[]
-) =>
-  targetClusters?.every(
-    (drClusterInfo) =>
-      drClusterInfo?.spec?.region === targetClusters?.[0]?.spec?.region
-  )
-    ? ReplicationType.SYNC
-    : ReplicationType.ASYNC;
-
 const TargetClusterStatus: React.FC<TargetClusterStatusProps> = ({
   isClusterAvailable,
 }) => {
@@ -197,8 +187,8 @@ export const TargetClusterSelector: React.FC<TargetClusterSelectorProps> = ({
       const originCluster = drClusterList.find(
         (drCluster) => getName(drCluster) !== getName(managedCluster)
       );
-      const replicationType = getReplicationTypeUsingDRClusters(drClusterList);
-      if (replicationType === ReplicationType.SYNC) {
+
+      if (selectedDRPolicy.replicationType === ReplicationType.SYNC) {
         if (state.actionType === DRActionType.RELOCATE) {
           // Ensure origin and target both clusters are unfenced
           const isClustersUnfenced = drClusterList.every(

--- a/packages/mco/components/modals/app-manage-policies/helper/consistency-groups.tsx
+++ b/packages/mco/components/modals/app-manage-policies/helper/consistency-groups.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {
   CONSISTENCY_GROUP_LABEL,
+  ReplicationType,
   VolumeReplicationHealth,
 } from '@odf/mco/constants';
 import {
@@ -8,7 +9,7 @@ import {
   DRPlacementControlKind,
   DRVolumeReplicationGroupKind,
 } from '@odf/mco/types';
-import { getReplicationHealth, getReplicationType } from '@odf/mco/utils';
+import { getReplicationHealth } from '@odf/mco/utils';
 import {
   ACMManagedClusterViewModel,
   getName,
@@ -323,7 +324,7 @@ export const extractConsistencyGroups = (
       const healthStatus = getReplicationHealth(
         dataLastSyncedOn || '',
         schedulingInterval,
-        getReplicationType(schedulingInterval)
+        ReplicationType.ASYNC
       );
       const isSynced =
         healthStatus === VolumeReplicationHealth.HEALTHY ? true : false;

--- a/packages/mco/components/modals/app-manage-policies/utils/parser-utils.ts
+++ b/packages/mco/components/modals/app-manage-policies/utils/parser-utils.ts
@@ -48,7 +48,7 @@ const getDRPolicyInfo = (drPolicy: DRPolicyKind, assignedOn?: string) =>
         metadata: drPolicy.metadata,
         isValidated: isDRPolicyValidated(drPolicy),
         schedulingInterval: drPolicy.spec.schedulingInterval,
-        replicationType: getReplicationType(drPolicy.spec.schedulingInterval),
+        replicationType: getReplicationType(drPolicy),
         drClusters: drPolicy.spec.drClusters,
         ...(!!assignedOn ? { assignedOn } : {}),
       }


### PR DESCRIPTION
#### Changes Made:
- **Refactored** the logic of `getReplicationType` to prioritize `drPolicy.status.async` and `drPolicy.status.sync` values.
- **Fallback logic** now uses `drPolicy.spec.schedulingInterval !== '0m'` **only if** both `async` and `sync` statuses are undefined.

https://issues.redhat.com/browse/DFBUGS-2271
