### PR TITLE
Convert dl, dd, dt to PF DescriptionList + Remove DetailsBody component

### DIFF
--- a/packages/client/src/components/dashboards/cards/details-card.tsx
+++ b/packages/client/src/components/dashboards/cards/details-card.tsx
@@ -3,8 +3,13 @@ import { useFetchCsv } from '@odf/shared/hooks/use-fetch-csv';
 import { OverviewDetailItem as DetailItem } from '@odf/shared/overview-page';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { getOprVersionFromCSV } from '@odf/shared/utils';
-import { DetailsBody } from '@openshift-console/dynamic-plugin-sdk-internal';
-import { Card, CardHeader, CardTitle, CardBody } from '@patternfly/react-core';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardBody,
+  DescriptionList,
+} from '@patternfly/react-core';
 import { CLIENT_OPERATOR } from '../../../constants';
 
 export const DetailsCard: React.FC = () => {
@@ -24,7 +29,7 @@ export const DetailsCard: React.FC = () => {
         <CardTitle>{t('Details')}</CardTitle>
       </CardHeader>
       <CardBody>
-        <DetailsBody>
+        <DescriptionList>
           <DetailItem key="service_name" title={t('Service name')}>
             {serviceName}
           </DetailItem>
@@ -40,7 +45,7 @@ export const DetailsCard: React.FC = () => {
           >
             {subscriptionVersion}
           </DetailItem>
-        </DetailsBody>
+        </DescriptionList>
       </CardBody>
     </Card>
   );

--- a/packages/ocs/dashboards/block-pool/compression-details-card.tsx
+++ b/packages/ocs/dashboards/block-pool/compression-details-card.tsx
@@ -13,9 +13,14 @@ import {
   humanizePercentage,
   getGaugeValue,
 } from '@odf/shared/utils';
-import { DetailsBody } from '@openshift-console/dynamic-plugin-sdk-internal';
 import { useParams } from 'react-router-dom-v5-compat';
-import { Card, CardBody, CardHeader, CardTitle } from '@patternfly/react-core';
+import {
+  Card,
+  CardBody,
+  CardHeader,
+  CardTitle,
+  DescriptionList,
+} from '@patternfly/react-core';
 import { getPoolQuery, StorageDashboardQuery } from '../../queries';
 import { ODFSystemParams } from '../../types';
 import { getPerPoolMetrics, PoolMetrics } from '../../utils';
@@ -130,23 +135,23 @@ export const CompressionDetailsCard: React.FC = () => {
         <CardTitle>{t('Compression')}</CardTitle>
       </CardHeader>
       <CardBody>
-        <DetailsBody>
+        <DescriptionList>
           <DetailItem isLoading={!obj} title={t('Compression status')}>
             {!compressionEnabled ? t('Disabled') : t('Enabled')}
           </DetailItem>
-        </DetailsBody>
+        </DescriptionList>
         {compressionEnabled && (
-          <DetailsBody>
+          <DescriptionList>
             <div>
-              <DetailsBody>
+              <DescriptionList>
                 <DetailItem isLoading={loading} title={t('Storage efficiency')}>
                   <EfficiencyItemBody {...compressionEligibilityProps} />
                   <EfficiencyItemBody {...compressionRatioProps} />
                   <EfficiencyItemBody {...compressionSavingsProps} />
                 </DetailItem>
-              </DetailsBody>
+              </DescriptionList>
             </div>
-          </DetailsBody>
+          </DescriptionList>
         )}
       </CardBody>
     </Card>

--- a/packages/ocs/dashboards/block-pool/details-card.tsx
+++ b/packages/ocs/dashboards/block-pool/details-card.tsx
@@ -2,8 +2,13 @@ import * as React from 'react';
 import { PoolType } from '@odf/ocs/constants';
 import { OverviewDetailItem as DetailItem } from '@odf/shared/overview-page';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
-import { DetailsBody } from '@openshift-console/dynamic-plugin-sdk-internal';
-import { Card, CardBody, CardHeader, CardTitle } from '@patternfly/react-core';
+import {
+  Card,
+  CardBody,
+  CardHeader,
+  CardTitle,
+  DescriptionList,
+} from '@patternfly/react-core';
 import { BlockPoolDashboardContext } from './block-pool-dashboard-context';
 
 export const DetailsCard: React.FC = () => {
@@ -18,7 +23,7 @@ export const DetailsCard: React.FC = () => {
         <CardTitle>{t('Details')}</CardTitle>
       </CardHeader>
       <CardBody>
-        <DetailsBody>
+        <DescriptionList>
           <DetailItem isLoading={!obj} title={t('Pool name')}>
             {obj.metadata?.name}
           </DetailItem>
@@ -31,7 +36,7 @@ export const DetailsCard: React.FC = () => {
           <DetailItem isLoading={!obj} title={t('Replicas')}>
             {obj.spec?.replicated?.size}
           </DetailItem>
-        </DetailsBody>
+        </DescriptionList>
       </CardBody>
     </Card>
   );

--- a/packages/ocs/dashboards/block-pool/mirroring-card-body.tsx
+++ b/packages/ocs/dashboards/block-pool/mirroring-card-body.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
+import { DescriptionList } from '@patternfly/react-core';
 import './mirroring-card.scss';
 
 export const MirroringCardBody: React.FC<MirroringCardBodyProps> = ({
   children,
-}) => <dl className="odf-block-pool__mirroring-card-body">{children}</dl>;
+}) => <DescriptionList>{children}</DescriptionList>;
 
 type MirroringCardBodyProps = {
   children: React.ReactNode;

--- a/packages/ocs/dashboards/block-pool/mirroring-card-item.tsx
+++ b/packages/ocs/dashboards/block-pool/mirroring-card-item.tsx
@@ -1,7 +1,15 @@
 import * as React from 'react';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
-import classNames from 'classnames';
+import {
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+} from '@patternfly/react-core';
 
+/**
+ * A wrapper around PatternFly's description group. This component's parent must
+ * be a PatternFly DescriptionList.
+ */
 export const MirroringCardItem: React.FC<MirroringCardItemProps> = React.memo(
   ({
     title,
@@ -27,25 +35,19 @@ export const MirroringCardItem: React.FC<MirroringCardItemProps> = React.memo(
       status = children;
     }
     return (
-      <>
+      <DescriptionListGroup>
         {title && (
-          <dt
-            className="odf-block-pool__mirroring-card-item-dt"
-            data-test="mirroring-card-item-title"
-          >
+          <DescriptionListTerm data-test="mirroring-card-item-title">
             {title}
-          </dt>
+          </DescriptionListTerm>
         )}
-        <dd
-          className={classNames(
-            'odf-block-pool__mirroring-card-item-dd',
-            valueClassName
-          )}
+        <DescriptionListDescription
+          className={valueClassName}
           data-test="mirroring-card-item-value"
         >
           {status}
-        </dd>
-      </>
+        </DescriptionListDescription>
+      </DescriptionListGroup>
     );
   }
 );

--- a/packages/ocs/dashboards/block-pool/mirroring-card.scss
+++ b/packages/ocs/dashboards/block-pool/mirroring-card.scss
@@ -1,8 +1,3 @@
-.odf-block-pool__mirroring-card-body {
-  display: flex;
-  flex-wrap: wrap;
-}
-
 .odf-block-pool__mirroring-card-item-dt {
   flex-basis: 100%;
 }

--- a/packages/ocs/dashboards/block-pool/status-card.tsx
+++ b/packages/ocs/dashboards/block-pool/status-card.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import Status from '@openshift-console/dynamic-plugin-sdk/lib/app/components/status/Status';
-import { DetailsBody } from '@openshift-console/dynamic-plugin-sdk-internal';
 import { Card, CardBody, CardHeader, CardTitle } from '@patternfly/react-core';
 import { BlockPoolDashboardContext } from './block-pool-dashboard-context';
 
@@ -15,9 +14,7 @@ export const StatusCard: React.FC = () => {
         <CardTitle>{t('Status')}</CardTitle>
       </CardHeader>
       <CardBody>
-        <DetailsBody>
-          <Status status={obj.status?.phase} />
-        </DetailsBody>
+        <Status status={obj.status?.phase} />
       </CardBody>
     </Card>
   );

--- a/packages/ocs/dashboards/object-service/details-card/details-card.tsx
+++ b/packages/ocs/dashboards/object-service/details-card/details-card.tsx
@@ -31,9 +31,14 @@ import {
   useFlag,
   useK8sWatchResource,
 } from '@openshift-console/dynamic-plugin-sdk';
-import { DetailsBody } from '@openshift-console/dynamic-plugin-sdk-internal';
 import { Link, useParams } from 'react-router-dom-v5-compat';
-import { Card, CardBody, CardHeader, CardTitle } from '@patternfly/react-core';
+import {
+  Card,
+  CardBody,
+  CardHeader,
+  CardTitle,
+  DescriptionList,
+} from '@patternfly/react-core';
 import { ODFSystemParams } from '../../../types';
 import './details-card.scss';
 import EncryptionPopover from '../../common/details-card/encryption-popover';
@@ -107,7 +112,7 @@ export const ObjectServiceDetailsCard: React.FC<{}> = () => {
         <CardTitle>{t('Details')}</CardTitle>
       </CardHeader>
       <CardBody>
-        <DetailsBody>
+        <DescriptionList>
           <DetailItem key="service_name" title={t('Service name')}>
             {isNsSafe && csvLoaded && !csvLoadError ? (
               <Link to={servicePath}>{serviceName}</Link>
@@ -167,7 +172,7 @@ export const ObjectServiceDetailsCard: React.FC<{}> = () => {
               isObjectDashboard={true}
             />
           </DetailItem>
-        </DetailsBody>
+        </DescriptionList>
       </CardBody>
     </Card>
   );

--- a/packages/ocs/dashboards/persistent-external/details-card.tsx
+++ b/packages/ocs/dashboards/persistent-external/details-card.tsx
@@ -21,10 +21,15 @@ import {
   useFlag,
   useK8sWatchResources,
 } from '@openshift-console/dynamic-plugin-sdk';
-import { DetailsBody } from '@openshift-console/dynamic-plugin-sdk-internal';
 import { Base64 } from 'js-base64';
 import { useParams } from 'react-router-dom-v5-compat';
-import { Card, CardBody, CardHeader, CardTitle } from '@patternfly/react-core';
+import {
+  Card,
+  CardBody,
+  CardHeader,
+  CardTitle,
+  DescriptionList,
+} from '@patternfly/react-core';
 import { ODFSystemParams } from '../../types';
 import EncryptionPopover from '../common/details-card/encryption-popover';
 
@@ -89,7 +94,7 @@ export const DetailsCard: React.FC = () => {
         <CardTitle>{t('Details')}</CardTitle>
       </CardHeader>
       <CardBody>
-        <DetailsBody>
+        <DescriptionList>
           <DetailItem title={t('Service name')}>{serviceName}</DetailItem>
           <DetailItem
             title={t('Cluster name')}
@@ -129,7 +134,7 @@ export const DetailsCard: React.FC = () => {
           >
             <EncryptionPopover cluster={ocsCluster} isObjectDashboard={false} />
           </DetailItem>
-        </DetailsBody>
+        </DescriptionList>
       </CardBody>
     </Card>
   );

--- a/packages/ocs/dashboards/persistent-internal/details-card.tsx
+++ b/packages/ocs/dashboards/persistent-internal/details-card.tsx
@@ -23,9 +23,14 @@ import {
   useK8sWatchResource,
   useFlag,
 } from '@openshift-console/dynamic-plugin-sdk';
-import { DetailsBody } from '@openshift-console/dynamic-plugin-sdk-internal';
 import { Link, useParams } from 'react-router-dom-v5-compat';
-import { Card, CardBody, CardHeader, CardTitle } from '@patternfly/react-core';
+import {
+  Card,
+  CardBody,
+  CardHeader,
+  CardTitle,
+  DescriptionList,
+} from '@patternfly/react-core';
 import { PROVIDER_MODE } from '../../../odf/features';
 import { ODFSystemParams } from '../../types';
 import EncryptionPopover from '../common/details-card/encryption-popover';
@@ -77,7 +82,7 @@ const DetailsCard: React.FC = () => {
         <CardTitle>{t('Details')}</CardTitle>
       </CardHeader>
       <CardBody>
-        <DetailsBody>
+        <DescriptionList>
           <DetailItem key="service_name" title={t('Service name')}>
             {isNsSafe && csvLoaded && !csvError ? (
               <Link data-test="ocs-link" to={servicePath}>
@@ -125,7 +130,7 @@ const DetailsCard: React.FC = () => {
               isObjectDashboard={false}
             />
           </DetailItem>
-        </DetailsBody>
+        </DescriptionList>
       </CardBody>
     </Card>
   );

--- a/packages/odf/components/bucket-class/wizard-pages/review-page.tsx
+++ b/packages/odf/components/bucket-class/wizard-pages/review-page.tsx
@@ -19,6 +19,10 @@ import {
   TextVariants,
   Text,
   TextContent,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
 } from '@patternfly/react-core';
 import { NamespacePolicyType } from '../../../constants';
 import { convertTime, getTimeUnitString } from '../../../utils';
@@ -43,13 +47,13 @@ const REVIEW_ICON_MAP = {
  * @deprecated
  */
 const ReviewListTitle: React.FC<{ text: string }> = ({ text }) => (
-  <dt>
+  <DescriptionListTerm>
     <TextContent className="ocs-install-wizard__text-content">
       <Text component={TextVariants.h3} className="ocs-install-wizard__h3 ">
         {text}
       </Text>
     </TextContent>
-  </dt>
+  </DescriptionListTerm>
 );
 
 /**
@@ -79,23 +83,25 @@ const ReviewListBody: React.FC<ReviewListBodyProps> = ({
     : REVIEW_ICON_MAP[alert?.variant || AlertVariant.success];
 
   return (
-    <dd className="ocs-install-wizard__dd">
-      {alert?.variant || !hideIcon ? (
-        <Split>
-          <SplitItem>
-            <Icon className="ocs-install-wizard__icon" />
-          </SplitItem>
-          <SplitItem isFilled>
-            {children}
-            {alert?.variant ? (
-              <ValidationMessage validation={validation} />
-            ) : null}
-          </SplitItem>
-        </Split>
-      ) : (
-        children
-      )}
-    </dd>
+    <DescriptionListGroup>
+      <DescriptionListDescription className="ocs-install-wizard__dd">
+        {alert?.variant || !hideIcon ? (
+          <Split>
+            <SplitItem>
+              <Icon className="ocs-install-wizard__icon" />
+            </SplitItem>
+            <SplitItem isFilled>
+              {children}
+              {alert?.variant ? (
+                <ValidationMessage validation={validation} />
+              ) : null}
+            </SplitItem>
+          </Split>
+        ) : (
+          children
+        )}
+      </DescriptionListDescription>
+    </DescriptionListGroup>
   );
 };
 
@@ -208,7 +214,7 @@ const ReviewPage: React.FC<ReviewPageProps> = ({ state }) => {
       <Title size="xl" headingLevel="h2">
         {t('Review BucketClass')}
       </Title>
-      <dl>
+      <DescriptionList>
         <ReviewListTitle text={t('General')} />
         <br />
         <div className="nb-create-bc-list--indent">
@@ -234,7 +240,7 @@ const ReviewPage: React.FC<ReviewPageProps> = ({ state }) => {
             ? getReviewForNamespaceStore()
             : getReviewForBackingStore()}
         </div>
-      </dl>
+      </DescriptionList>
       {isLoading && <LoadingInline />}
       {!!error && (
         <Alert variant="danger" title="Error" isInline>

--- a/packages/odf/components/mcg/ObjectBucket.tsx
+++ b/packages/odf/components/mcg/ObjectBucket.tsx
@@ -28,6 +28,12 @@ import Status from '@openshift-console/dynamic-plugin-sdk/lib/app/components/sta
 import classNames from 'classnames';
 import * as _ from 'lodash-es';
 import { useParams } from 'react-router-dom-v5-compat';
+import {
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+} from '@patternfly/react-core';
 import { sortable } from '@patternfly/react-table';
 import { NooBaaObjectBucketModel } from '../../../shared/src/models/ocs';
 import { getPhase, obStatusFilter } from '../../utils';
@@ -234,31 +240,41 @@ export const OBDetails: React.FC<OBDetailsProps> = ({ obj, ownerLabel }) => {
           />
         </div>
         <div className="col-sm-6">
-          <dl>
-            <dt>{t('Status')}</dt>
-            <dd>
-              <OBStatus ob={obj} />
-            </dd>
-            <dt>{t('StorageClass')}</dt>
-            <dd>
-              {storageClassName ? (
+          <DescriptionList>
+            <DescriptionListGroup>
+              <DescriptionListTerm>{t('Status')}</DescriptionListTerm>
+              <DescriptionListDescription>
+                <OBStatus ob={obj} />
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+
+            <DescriptionListGroup>
+              <DescriptionListTerm>{t('StorageClass')}</DescriptionListTerm>
+              <DescriptionListDescription>
+                {storageClassName ? (
+                  <ResourceLinkWithKind
+                    kind="StorageClass"
+                    name={storageClassName}
+                  />
+                ) : (
+                  '-'
+                )}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+
+            <DescriptionListGroup>
+              <DescriptionListTerm>
+                {t('Object Bucket Claim')}
+              </DescriptionListTerm>
+              <DescriptionListDescription>
                 <ResourceLinkWithKind
-                  kind="StorageClass"
-                  name={storageClassName}
+                  kind={referenceForModel(NooBaaObjectBucketClaimModel)}
+                  name={OBCName}
+                  namespace={OBCNamespace}
                 />
-              ) : (
-                '-'
-              )}
-            </dd>
-            <dt>{t('Object Bucket Claim')}</dt>
-            <dd>
-              <ResourceLinkWithKind
-                kind={referenceForModel(NooBaaObjectBucketClaimModel)}
-                name={OBCName}
-                namespace={OBCNamespace}
-              />
-            </dd>
-          </dl>
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+          </DescriptionList>
         </div>
       </div>
     </div>

--- a/packages/odf/components/mcg/ObjectBucketClaim.tsx
+++ b/packages/odf/components/mcg/ObjectBucketClaim.tsx
@@ -32,6 +32,12 @@ import {
 import classNames from 'classnames';
 import * as _ from 'lodash-es';
 import { useParams } from 'react-router-dom-v5-compat';
+import {
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+} from '@patternfly/react-core';
 import { sortable } from '@patternfly/react-table';
 import { ATTACH_DEPLOYMENT } from '../../constants';
 import { MCG_FLAG, RGW_FLAG } from '../../features';
@@ -318,45 +324,56 @@ export const OBCDetails: React.FC<OBCDetailsProps> = ({ obj }) => {
             />
           </div>
           <div className="col-sm-6">
-            {isBound(obj) && (
-              <>
-                <dt>{t('Secret')}</dt>
-                <dd>
-                  <ResourceLinkWithKind
-                    kind="Secret"
-                    name={obj.metadata.name}
-                    namespace={obj.metadata.namespace}
-                  />
-                </dd>
-              </>
-            )}
-            <dt>{t('Status')}</dt>
-            <dd>
-              <OBCStatus obc={obj} />
-            </dd>
-            <dt>{t('StorageClass')}</dt>
-            <dd>
-              {storageClassName ? (
-                <ResourceLinkWithKind
-                  kind="StorageClass"
-                  name={storageClassName}
-                />
-              ) : (
-                '-'
+            <DescriptionList>
+              {isBound(obj) && (
+                <DescriptionListGroup>
+                  <DescriptionListTerm>{t('Secret')}</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    <ResourceLinkWithKind
+                      kind="Secret"
+                      name={obj.metadata.name}
+                      namespace={obj.metadata.namespace}
+                    />
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
               )}
-            </dd>
-            {isBound(obj) && (
-              <>
-                <dt>{t('Object Bucket')}</dt>
-                <dd>
-                  <ResourceLinkWithKind
-                    dataTest="ob-link"
-                    kind={referenceForModel(NooBaaObjectBucketModel)}
-                    name={obj.spec.objectBucketName}
-                  />
-                </dd>
-              </>
-            )}
+
+              <DescriptionListGroup>
+                <DescriptionListTerm>{t('Status')}</DescriptionListTerm>
+                <DescriptionListDescription>
+                  <OBCStatus obc={obj} />
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+
+              <DescriptionListGroup>
+                <DescriptionListTerm>{t('StorageClass')}</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {storageClassName ? (
+                    <ResourceLinkWithKind
+                      kind="StorageClass"
+                      name={storageClassName}
+                    />
+                  ) : (
+                    '-'
+                  )}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+
+              {isBound(obj) && (
+                <DescriptionListGroup>
+                  <DescriptionListTerm>
+                    {t('Object Bucket')}
+                  </DescriptionListTerm>
+                  <DescriptionListDescription>
+                    <ResourceLinkWithKind
+                      dataTest="ob-link"
+                      kind={referenceForModel(NooBaaObjectBucketModel)}
+                      name={obj.spec.objectBucketName}
+                    />
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+              )}
+            </DescriptionList>
           </div>
         </div>
       </div>

--- a/packages/odf/components/mcg/secret.tsx
+++ b/packages/odf/components/mcg/secret.tsx
@@ -8,7 +8,13 @@ import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { SecretValue } from '@odf/shared/utils/SecretValue';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { Base64 } from 'js-base64';
-import { Button } from '@patternfly/react-core';
+import {
+  Button,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+} from '@patternfly/react-core';
 import { EyeSlashIcon, EyeIcon } from '@patternfly/react-icons';
 import '../../style.scss';
 
@@ -69,15 +75,16 @@ export const GetSecret: React.FC<GetSecretProps> = ({ obj }) => {
     ? secretValues.reduce((acc, datum) => {
         const { field, value } = datum;
         acc.push(
-          <dt key={`${field}-k`} data-test="secret-data">
-            {field}
-          </dt>
+          <DescriptionListGroup>
+            <DescriptionListTerm key={`${field}-k`} data-test="secret-data">
+              {field}
+            </DescriptionListTerm>
+            <DescriptionListDescription key={`${field}-v`}>
+              <SecretValue value={value} reveal={reveal} encoded={false} />
+            </DescriptionListDescription>
+          </DescriptionListGroup>
         );
-        acc.push(
-          <dd key={`${field}-v`}>
-            <SecretValue value={value} reveal={reveal} encoded={false} />
-          </dd>
-        );
+
         return acc;
       }, [])
     : [];
@@ -107,7 +114,7 @@ export const GetSecret: React.FC<GetSecretProps> = ({ obj }) => {
         ) : null}
       </SectionHeading>
       {dl.length ? (
-        <dl className="secret-data">{dl}</dl>
+        <DescriptionList className="secret-data">{dl}</DescriptionList>
       ) : (
         <EmptyBox label={t('Data')} />
       )}

--- a/packages/odf/components/s3-browser/bucket-details/BucketDetails.tsx
+++ b/packages/odf/components/s3-browser/bucket-details/BucketDetails.tsx
@@ -42,6 +42,10 @@ import {
   TextContent,
   Text,
   TextVariants,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
 } from '@patternfly/react-core';
 import { LockIcon, TagIcon } from '@patternfly/react-icons';
 
@@ -140,27 +144,41 @@ const S3BucketDetailsOverview: React.FC<{}> = ({}) => {
       <SectionHeading text={t('Bucket overview')} />
       <div className="row">
         <div className="col-sm-6">
-          <dl>
-            <dt>{t('Name')}</dt>
-            <dd>{bucketName}</dd>
-            <dt>{t('Tags')}</dt>
-            <dd>
-              <LabelGroup>{tags || DASH}</LabelGroup>
-            </dd>
-            <dt>{t('Owner')}</dt>
-            <dd>{aclData?.Owner?.DisplayName || DASH}</dd>
-          </dl>
+          <DescriptionList>
+            <DescriptionListGroup>
+              <DescriptionListTerm>{t('Name')}</DescriptionListTerm>
+              <DescriptionListDescription>
+                {bucketName}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+
+            <DescriptionListGroup>
+              <DescriptionListTerm>{t('Tags')}</DescriptionListTerm>
+              <DescriptionListDescription>
+                <LabelGroup>{tags || DASH}</LabelGroup>
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+
+            <DescriptionListGroup>
+              <DescriptionListTerm>{t('Owner')}</DescriptionListTerm>
+              <DescriptionListDescription>
+                {aclData?.Owner?.DisplayName || DASH}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+          </DescriptionList>
         </div>
         <div className="col-sm-6">
-          <dl>
-            <dt>{t('Encryption')}</dt>
-            <dd>
-              <LockIcon /> {t('Enabled')}
-              <div className="pf-v5-u-disabled-color-100">
-                {encryptionDescription}
-              </div>
-            </dd>
-          </dl>
+          <DescriptionList>
+            <DescriptionListGroup>
+              <DescriptionListTerm>{t('Encryption')}</DescriptionListTerm>
+              <DescriptionListDescription>
+                <LockIcon /> {t('Enabled')}
+                <div className="pf-v5-u-disabled-color-100">
+                  {encryptionDescription}
+                </div>
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+          </DescriptionList>
         </div>
       </div>
     </div>

--- a/packages/odf/components/topology/sidebar/storage-cluster/StorageClusterDetails.tsx
+++ b/packages/odf/components/topology/sidebar/storage-cluster/StorageClusterDetails.tsx
@@ -42,6 +42,12 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk-internal';
 import * as _ from 'lodash-es';
 import { Link } from 'react-router-dom-v5-compat';
+import {
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+} from '@patternfly/react-core';
 
 const resiliencyProgressQuery = (managedByOCS: string) =>
   DATA_RESILIENCY_QUERY(managedByOCS)[
@@ -107,59 +113,92 @@ export const StorageClusterDetails: React.FC<StorageClusterDetailsProps> = ({
       <SectionHeading text={t('Cluster details')} />
       <div className="row">
         <div className="col-md-5 col-xs-12">
-          <dl>
-            <dt>{t('Name')}</dt>
-            <dd>{ocsName || DASH}</dd>
-            <dt>{t('Data resiliency')}</dt>
-            <dd>
-              {' '}
-              <HealthItem
-                title=""
-                state={dataResiliencyState.state}
-                details={dataResiliencyState.message}
-              />
-            </dd>
-            <dt>{t('Provider')}</dt>
-            <dd>{infrastructurePlatform}</dd>
-            <dt>{t('Mode')}</dt>
-            <dd>{mode}</dd>
-            <dt>{t('Version')}</dt>
-            <dd>{serviceVersion}</dd>
-            <dt>{t('Inventory')}</dt>
-            <dd>
-              <ResourceInventoryItem
-                dataTest="inventory-nodes"
-                isLoading={!nodesLoaded}
-                error={!!nodesLoadError}
-                kind={NodeModel as any}
-                resources={getCephNodes(nodesData, odfNamespace)}
-                mapper={getNodeStatusGroups}
-                basePath={ocsNodesHref}
-              />
-            </dd>
-          </dl>
+          <DescriptionList>
+            <DescriptionListGroup>
+              <DescriptionListTerm>{t('Name')}</DescriptionListTerm>
+              <DescriptionListDescription>
+                {ocsName || DASH}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+
+            <DescriptionListGroup>
+              <DescriptionListTerm>{t('Data resiliency')}</DescriptionListTerm>
+              <DescriptionListDescription>
+                {' '}
+                <HealthItem
+                  title=""
+                  state={dataResiliencyState.state}
+                  details={dataResiliencyState.message}
+                />
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+
+            <DescriptionListGroup>
+              <DescriptionListTerm>{t('Provider')}</DescriptionListTerm>
+              <DescriptionListDescription>
+                {infrastructurePlatform}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+
+            <DescriptionListGroup>
+              <DescriptionListTerm>{t('Mode')}</DescriptionListTerm>
+              <DescriptionListDescription>{mode}</DescriptionListDescription>
+            </DescriptionListGroup>
+
+            <DescriptionListGroup>
+              <DescriptionListTerm>{t('Version')}</DescriptionListTerm>
+              <DescriptionListDescription>
+                {serviceVersion}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+
+            <DescriptionListGroup>
+              <DescriptionListTerm>{t('Inventory')}</DescriptionListTerm>
+              <DescriptionListDescription>
+                <ResourceInventoryItem
+                  dataTest="inventory-nodes"
+                  isLoading={!nodesLoaded}
+                  error={!!nodesLoadError}
+                  kind={NodeModel as any}
+                  resources={getCephNodes(nodesData, odfNamespace)}
+                  mapper={getNodeStatusGroups}
+                  basePath={ocsNodesHref}
+                />
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+          </DescriptionList>
         </div>
         <div className="col-md-7 col-xs-12">
-          <dl>
-            <dt>{t('Status')}</dt>
-            <dd>
-              <Status status={resourceStatus(storageCluster)} />
-            </dd>
-            <dt>{t('Service name')}</dt>
-            <dd className="text-capitalize">
-              {isNsSafe && csvLoaded && !csvError ? (
-                <Link data-test="ocs-link" to={servicePath}>
-                  {serviceName}
-                </Link>
-              ) : (
-                serviceName
-              )}
-            </dd>
-            <dt>{t('Storage efficiency')}</dt>
-            <dd>
-              <StorageEfficiencyContent />
-            </dd>
-          </dl>
+          <DescriptionList>
+            <DescriptionListGroup>
+              <DescriptionListTerm>{t('Status')}</DescriptionListTerm>
+              <DescriptionListDescription>
+                <Status status={resourceStatus(storageCluster)} />
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+
+            <DescriptionListGroup>
+              <DescriptionListTerm>{t('Service name')}</DescriptionListTerm>
+              <DescriptionListDescription className="text-capitalize">
+                {isNsSafe && csvLoaded && !csvError ? (
+                  <Link data-test="ocs-link" to={servicePath}>
+                    {serviceName}
+                  </Link>
+                ) : (
+                  serviceName
+                )}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+
+            <DescriptionListGroup>
+              <DescriptionListTerm>
+                {t('Storage efficiency')}
+              </DescriptionListTerm>
+              <DescriptionListDescription>
+                <StorageEfficiencyContent />
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+          </DescriptionList>
         </div>
       </div>
     </div>

--- a/packages/shared/src/details-page/DetailsPage.tsx
+++ b/packages/shared/src/details-page/DetailsPage.tsx
@@ -18,6 +18,10 @@ import {
   Popover,
   Split,
   SplitItem,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
 } from '@patternfly/react-core';
 import { PencilAltIcon } from '@patternfly/react-icons';
 import { LoadingBox } from '../generic/status-box';
@@ -219,8 +223,8 @@ export const DetailsItem: React.FC<DetailsItemProps> = ({
   const value: React.ReactNode = children || _.get(obj, path, defaultValue);
   const editable = onEdit && canEdit;
   return hide ? null : (
-    <>
-      <dt
+    <DescriptionListGroup>
+      <DescriptionListTerm
         className={classnames('details-item__label', labelClassName)}
         data-test-selector={`details-item-label__${label}`}
       >
@@ -243,13 +247,9 @@ export const DetailsItem: React.FC<DetailsItemProps> = ({
                 })}
                 maxWidth="30rem"
               >
-                <Button
-                  data-test={label}
-                  variant="plain"
-                  className="details-item__popover-button"
-                >
+                <DescriptionListTerm className="description-list-term">
                   {label}
-                </Button>
+                </DescriptionListTerm>
               </Popover>
             ) : (
               label
@@ -258,7 +258,7 @@ export const DetailsItem: React.FC<DetailsItemProps> = ({
           {editable && editAsGroup && (
             <>
               <SplitItem isFilled />
-              <SplitItem>
+              <SplitItem className="pf-v5-u-ml-sm">
                 <EditButton testId={label} onClick={onEdit}>
                   {t('Edit')}
                 </EditButton>
@@ -266,8 +266,8 @@ export const DetailsItem: React.FC<DetailsItemProps> = ({
             </>
           )}
         </Split>
-      </dt>
-      <dd
+      </DescriptionListTerm>
+      <DescriptionListDescription
         className={classnames('details-item__value', valueClassName, {
           'details-item__value--group': editable && editAsGroup,
         })}
@@ -280,8 +280,8 @@ export const DetailsItem: React.FC<DetailsItemProps> = ({
         ) : (
           value
         )}
-      </dd>
-    </>
+      </DescriptionListDescription>
+    </DescriptionListGroup>
   );
 };
 
@@ -310,7 +310,7 @@ export const ResourceSummary: React.FC<ResourceSummaryProps> = ({
   const launchModal = useModal();
 
   return (
-    <dl data-test-id="resource-summary" className="odf-m-pane__details">
+    <DescriptionList data-test-id="resource-summary">
       <DetailsItem
         label={t('Name')}
         obj={resource}
@@ -395,6 +395,6 @@ export const ResourceSummary: React.FC<ResourceSummaryProps> = ({
       >
         <OwnerReferences resource={resource} />
       </DetailsItem>
-    </dl>
+    </DescriptionList>
   );
 };

--- a/packages/shared/src/details-page/details.scss
+++ b/packages/shared/src/details-page/details.scss
@@ -15,3 +15,7 @@
   display: flex;
   flex-direction: column;
 }
+
+.description-list-term:hover {
+  cursor: pointer;
+}

--- a/packages/shared/src/overview-page/OverviewDetailItem.scss
+++ b/packages/shared/src/overview-page/OverviewDetailItem.scss
@@ -1,16 +1,5 @@
 @import '@odf/shared/styles/skeleton';
 
-.odf-overview-details-card__item-title {
-  flex-basis: 100%;
-}
-
-.odf-overview-details-card__item-value {
-  flex-basis: 100%;
-  margin-bottom: 8px;
-  overflow: hidden;
-  overflow-wrap: break-word;
-}
-
 .odf-overview-details-card__skeleton-text {
   animation: $skeleton-animation;
   background: $skeleton-color;

--- a/packages/shared/src/overview-page/OverviewDetailItem.tsx
+++ b/packages/shared/src/overview-page/OverviewDetailItem.tsx
@@ -1,5 +1,9 @@
 import * as React from 'react';
-import classNames from 'classnames';
+import {
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+} from '@patternfly/react-core';
 
 import './OverviewDetailItem.scss';
 
@@ -11,10 +15,14 @@ export type OverviewDetailItemProps = {
   isLoading?: boolean;
   /** Value for a className */
   valueClassName?: string;
-
+  /** Error message to display */
   error?: string;
 };
 
+/**
+ * A wrapper around PatternFly's description group. This component's parent must
+ * be a PatternFly DescriptionList.
+ */
 export const OverviewDetailItem: React.FC<OverviewDetailItemProps> = ({
   title,
   isLoading = false,
@@ -34,22 +42,16 @@ export const OverviewDetailItem: React.FC<OverviewDetailItemProps> = ({
     status = children;
   }
   return (
-    <>
-      <dt
-        className="odf-overview-details-card__item-title"
-        data-test="detail-item-title"
-      >
+    <DescriptionListGroup>
+      <DescriptionListTerm data-test="detail-item-title">
         {title}
-      </dt>
-      <dd
-        className={classNames(
-          'odf-overview-details-card__item-value',
-          valueClassName
-        )}
+      </DescriptionListTerm>
+      <DescriptionListDescription
+        className={valueClassName}
         data-test="detail-item-value"
       >
         {status}
-      </dd>
-    </>
+      </DescriptionListDescription>
+    </DescriptionListGroup>
   );
 };

--- a/packages/shared/src/styles/_common.scss
+++ b/packages/shared/src/styles/_common.scss
@@ -154,15 +154,6 @@
   padding: 0 0 30px;
 }
 
-.odf-m-pane__details {
-  line-height: 1.66;
-  min-width: 0;
-  white-space: normal;
-  dd {
-    @include odf-break-word;
-  }
-}
-
 .text-muted {
   color: var(--pf-v5-global--Color--200);
 }

--- a/packages/shared/src/topology/sidebar/node/NodeDetails.tsx
+++ b/packages/shared/src/topology/sidebar/node/NodeDetails.tsx
@@ -18,6 +18,12 @@ import {
 } from '@odf/shared/utils';
 import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
 import * as _ from 'lodash-es';
+import {
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+} from '@patternfly/react-core';
 import NodeIPList from './NodeIPList';
 
 export type NodeDetailsProps = {
@@ -36,86 +42,150 @@ export const NodeDetails: React.FC<NodeDetailsProps> = ({ resource: node }) => {
       <SectionHeading text={t('Node details')} />
       <div className="row">
         <div className="col-md-6 col-xs-12">
-          <dl>
-            <dt>{t('Name')}</dt>
-            <dd>{node.metadata.name || '-'}</dd>
-            <dt>{t('Role')}</dt>
-            <dd>{roles.join(', ')}</dd>
-            <dt>{t('Instance type')}</dt>
-            <dd>{getNodeInstanceType(node)}</dd>
+          <DescriptionList>
+            <DescriptionListGroup>
+              <DescriptionListTerm>{t('Name')}</DescriptionListTerm>
+              <DescriptionListDescription>
+                {node.metadata.name || '-'}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+
+            <DescriptionListGroup>
+              <DescriptionListTerm>{t('Role')}</DescriptionListTerm>
+              <DescriptionListDescription>
+                {roles.join(', ')}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+
+            <DescriptionListGroup>
+              <DescriptionListTerm>{t('Instance type')}</DescriptionListTerm>
+              <DescriptionListDescription>
+                {getNodeInstanceType(node)}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+
             {availableZone && (
-              <>
-                <dt>{t('Zone')}</dt>
-                <dd>{availableZone}</dd>
-              </>
+              <DescriptionListGroup>
+                <DescriptionListTerm>{t('Zone')}</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {availableZone}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
             )}
+
             {availableRack && (
-              <>
-                <dt>{t('Rack')}</dt>
-                <dd>{availableRack}</dd>
-              </>
+              <DescriptionListGroup>
+                <DescriptionListTerm>{t('Rack')}</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {availableRack}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
             )}
-            <dt>{t('External ID')}</dt>
-            <dd>{_.get(node, 'spec.externalID', '-')}</dd>
-            <dt>{t('Node addresses')}</dt>
-            <dd>
-              <NodeIPList ips={getNodeAddresses(node)} expand />
-            </dd>
-            <dt>{t('Annotations')}</dt>
-            <dd>
-              {t('{{count}} annotation', {
-                count: _.size(node.metadata.annotations),
-              })}
-            </dd>
+
+            <DescriptionListGroup>
+              <DescriptionListTerm>{t('External ID')}</DescriptionListTerm>
+              <DescriptionListDescription>
+                {_.get(node, 'spec.externalID', '-')}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+
+            <DescriptionListGroup>
+              <DescriptionListTerm>{t('Node addresses')}</DescriptionListTerm>
+              <DescriptionListDescription>
+                <NodeIPList ips={getNodeAddresses(node)} expand />
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+
+            <DescriptionListGroup>
+              <DescriptionListTerm>{t('Annotations')}</DescriptionListTerm>
+              <DescriptionListDescription>
+                {t('{{count}} annotation', {
+                  count: _.size(node.metadata.annotations),
+                })}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+
             {machine.name && (
-              <>
-                <dt>{t('Machine')}</dt>
-                <dd>
+              <DescriptionListGroup>
+                <DescriptionListTerm>{t('Machine')}</DescriptionListTerm>
+                <DescriptionListDescription>
                   <ResourceLink
                     kind={referenceForModel(MachineModel)}
                     name={machine.name}
                     namespace={machine.namespace}
                   />
-                </dd>
-              </>
+                </DescriptionListDescription>
+              </DescriptionListGroup>
             )}
+
             {_.has(node, 'spec.unschedulable') && (
-              <>
-                <dt>{t('Unschedulable')}</dt>
-                <dd className="text-capitalize">
+              <DescriptionListGroup>
+                <DescriptionListTerm>{t('Unschedulable')}</DescriptionListTerm>
+                <DescriptionListDescription className="text-capitalize">
                   {_.get(node, 'spec.unschedulable', '-').toString()}
-                </dd>
-              </>
+                </DescriptionListDescription>
+              </DescriptionListGroup>
             )}
-          </dl>
+          </DescriptionList>
         </div>
         <div className="col-md-6 col-xs-12">
-          <dl>
-            <dt>{t('Status')}</dt>
-            <dd>
-              <Status status={nodeStatus(node)} />
-            </dd>
-            <dt>{t('Operating system')}</dt>
-            <dd className="text-capitalize">
-              {_.get(node, 'status.nodeInfo.operatingSystem', '-')}
-            </dd>
-            <dt>{t('Kernel version')}</dt>
-            <dd>{_.get(node, 'status.nodeInfo.kernelVersion', '-')}</dd>
-            <dt>{t('OS image')}</dt>
-            <dd>{_.get(node, 'status.nodeInfo.osImage', '-')}</dd>
-            <dt>{t('Architecture')}</dt>
-            <dd className="text-uppercase">
-              {_.get(node, 'status.nodeInfo.architecture', '-')}
-            </dd>
-            <dt>{t('Kubelet version')}</dt>
-            <dd>{_.get(node, 'status.nodeInfo.kubeletVersion', '-')}</dd>
-            <dt>{t('Provider ID')}</dt>
-            <dd>{getProviderID(node)}</dd>
-            <dt>{t('Created')}</dt>
-            <dd>
-              <Timestamp timestamp={node.metadata.creationTimestamp} />
-            </dd>
-          </dl>
+          <DescriptionList>
+            <DescriptionListGroup>
+              <DescriptionListTerm>{t('Status')}</DescriptionListTerm>
+              <DescriptionListDescription>
+                <Status status={nodeStatus(node)} />
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+
+            <DescriptionListGroup>
+              <DescriptionListTerm>{t('Operating system')}</DescriptionListTerm>
+              <DescriptionListDescription className="text-capitalize">
+                {_.get(node, 'status.nodeInfo.operatingSystem', '-')}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+
+            <DescriptionListGroup>
+              <DescriptionListTerm>{t('Kernel version')}</DescriptionListTerm>
+              <DescriptionListDescription>
+                {_.get(node, 'status.nodeInfo.kernelVersion', '-')}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+
+            <DescriptionListGroup>
+              <DescriptionListTerm>{t('OS image')}</DescriptionListTerm>
+              <DescriptionListDescription>
+                {_.get(node, 'status.nodeInfo.osImage', '-')}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+
+            <DescriptionListGroup>
+              <DescriptionListTerm>{t('Architecture')}</DescriptionListTerm>
+              <DescriptionListDescription className="text-uppercase">
+                {_.get(node, 'status.nodeInfo.architecture', '-')}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+
+            <DescriptionListGroup>
+              <DescriptionListTerm>{t('Kubelet version')}</DescriptionListTerm>
+              <DescriptionListDescription>
+                {_.get(node, 'status.nodeInfo.kubeletVersion', '-')}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+
+            <DescriptionListGroup>
+              <DescriptionListTerm>{t('Provider ID')}</DescriptionListTerm>
+              <DescriptionListDescription>
+                {getProviderID(node)}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+
+            <DescriptionListGroup>
+              <DescriptionListTerm>{t('Created')}</DescriptionListTerm>
+              <DescriptionListDescription>
+                <Timestamp timestamp={node.metadata.creationTimestamp} />
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+          </DescriptionList>
         </div>
       </div>
     </div>

--- a/packages/shared/src/utils/SecretValue.tsx
+++ b/packages/shared/src/utils/SecretValue.tsx
@@ -2,7 +2,13 @@ import * as React from 'react';
 import { CopyToClipboard } from '@odf/shared/utils/copy-to-clipboard';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { Base64 } from 'js-base64';
-import { Button } from '@patternfly/react-core';
+import {
+  Button,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+} from '@patternfly/react-core';
 import { EyeSlashIcon, EyeIcon } from '@patternfly/react-icons';
 import { EmptyBox } from '../generic/status-box';
 import { SectionHeading } from '../heading/page-heading';
@@ -100,15 +106,16 @@ export const GetSecret: React.FC<GetSecretProps> = ({ obj }) => {
     ? secretValues.reduce((acc, datum) => {
         const { field, value } = datum;
         acc.push(
-          <dt key={`${field}-k`} data-test="secret-data">
-            {field}
-          </dt>
+          <DescriptionListGroup>
+            <DescriptionListTerm key={`${field}-k`} data-test="secret-data">
+              {field}
+            </DescriptionListTerm>
+            <DescriptionListDescription key={`${field}-v`}>
+              <SecretValue value={value} reveal={reveal} encoded={false} />
+            </DescriptionListDescription>
+          </DescriptionListGroup>
         );
-        acc.push(
-          <dd key={`${field}-v`}>
-            <SecretValue value={value} reveal={reveal} encoded={false} />
-          </dd>
-        );
+
         return acc;
       }, [])
     : [];
@@ -138,7 +145,7 @@ export const GetSecret: React.FC<GetSecretProps> = ({ obj }) => {
         ) : null}
       </SectionHeading>
       {dl.length ? (
-        <dl className="secret-data">{dl}</dl>
+        <DescriptionList className="secret-data">{dl}</DescriptionList>
       ) : (
         <EmptyBox label={t('Data')} />
       )}


### PR DESCRIPTION
https://issues.redhat.com/browse/DFBUGS-2327

Console removed `DetailsBody` component from the internal SDK.
Console removed the styling for `dl, dd, dt` HTML elements.
Ref: https://github.com/openshift/console/pull/14947 for more details.

**Before:**
<img width="1726" alt="Screenshot 2025-04-23 at 1 50 48 PM" src="https://github.com/user-attachments/assets/7d478f30-e3fd-4910-8c05-1cec6f48cf77" />

**After:**
<img width="1718" alt="Screenshot 2025-04-23 at 2 01 51 PM" src="https://github.com/user-attachments/assets/c15fe778-8a7e-4eb2-ad21-b9c9a4eab4e7" />
