### PR TITLE
[MDR] Bug fix in MDR DRPolicy creation

### DIFF
--- a/locales/en/plugin__odf-console.json
+++ b/locales/en/plugin__odf-console.json
@@ -54,7 +54,7 @@
   "Replication interval": "Replication interval",
   "Replication policy": "Replication policy",
   "Unsupported peering configuration.": "Unsupported peering configuration.",
-  "The clusters you're trying to peer aren't compatible. It could be due to mismatched types (one with a client, the other without) or both using the same Data Foundation provider. Select clusters that are either the same type or have separate providers to continue.": "The clusters you're trying to peer aren't compatible. It could be due to mismatched types (one with a client, the other without) or both using the same Data Foundation provider. Select clusters that are either the same type or have separate providers to continue.",
+  "The selected clusters cannot be peered due to a mismatch in types. Ensure both clusters are of the same type to continue.": "The selected clusters cannot be peered due to a mismatch in types. Ensure both clusters are of the same type to continue.",
   "Selected clusters cannot be used to create a DRPolicy.": "Selected clusters cannot be used to create a DRPolicy.",
   "A mirror peer configuration already exists for one or more of the selected clusters, either from an existing or deleted DR policy. To create a new DR policy with these clusters, delete any existing mirror peer configurations associated with them and try again.": "A mirror peer configuration already exists for one or more of the selected clusters, either from an existing or deleted DR policy. To create a new DR policy with these clusters, delete any existing mirror peer configurations associated with them and try again.",
   "Cannot proceed with policy creation.": "Cannot proceed with policy creation.",

--- a/packages/mco/components/create-dr-policy/select-cluster-list.tsx
+++ b/packages/mco/components/create-dr-policy/select-cluster-list.tsx
@@ -197,6 +197,8 @@ export const SelectClusterList: React.FC<SelectClusterListProps> = ({
 
   const clusters: ManagedClusterInfoType[] = React.useMemo(() => {
     if (!!requiredODFVersion && allLoaded && !anyError)
+      // TODO: Switch from using the MCV-based odf-info ConfigMap to using
+      // the odf-client-info ConfigMap from the openshift-operators namespace
       return getManagedClusterInfoTypes(
         managedClusters,
         mcvs,

--- a/packages/mco/constants/acm.ts
+++ b/packages/mco/constants/acm.ts
@@ -36,10 +36,11 @@ export const APPLICATION_TYPE_DISPLAY_TEXT = (
   [DRApplication.DISCOVERED]: t('Discovered'),
 });
 
-// Managed cluster status conditions
+// Condition types
 export const MANAGED_CLUSTER_CONDITION_AVAILABLE =
   'ManagedClusterConditionAvailable';
 export const MANAGED_CLUSTER_JOINED = 'ManagedClusterJoined';
+export const MANAGED_CLUSTER_VIEW_PROCESSING = 'Processing';
 
 // Search result labels
 export const LABEL = 'label';

--- a/packages/mco/utils/disaster-recovery.tsx
+++ b/packages/mco/utils/disaster-recovery.tsx
@@ -28,6 +28,7 @@ import {
   Operator,
   MatchExpression,
 } from '@openshift-console/dynamic-plugin-sdk/lib/api/common-types';
+import * as _ from 'lodash-es';
 import { TFunction } from 'react-i18next';
 import { InProgressIcon, UnknownIcon } from '@patternfly/react-icons';
 import { DRPlacementControlType } from '../components/modals/app-manage-policies/utils/types';
@@ -252,9 +253,9 @@ export const getReplicationType = (drPolicy: DRPolicyKind): ReplicationType => {
 
   // Primary logic: Use replication type based on status if available
   // RDR
-  if (status?.['async']) return ReplicationType.ASYNC;
+  if (!_.isEmpty(status?.['async'])) return ReplicationType.ASYNC;
   // MDR
-  if (status?.['sync']) return ReplicationType.SYNC;
+  if (!_.isEmpty(status?.['sync'])) return ReplicationType.SYNC;
 
   // Fallback logic: Use schedulingInterval to determine type
   const isAsync = drPolicy?.spec?.schedulingInterval !== '0m';

--- a/packages/shared/src/selectors/k8s.ts
+++ b/packages/shared/src/selectors/k8s.ts
@@ -56,13 +56,11 @@ export const getOwnerReferences = <
     'metadata.ownerReferences'
   ) as K8sResourceCommon['metadata']['ownerReferences'];
 
-type KnownResourceConditions = 'Available' | 'Degraded' | 'Progressing';
-
 export const getResourceCondition = <
   A extends K8sResourceKind = K8sResourceKind,
 >(
   resource: A,
-  condition: KnownResourceConditions
+  condition: string
 ): K8sResourceCondition => {
   return resource?.status?.conditions?.find(
     (current: K8sResourceCondition) => current.type === condition


### PR DESCRIPTION
**Bug Fixes:**
- Resolved an issue where the *Create DRPolicy* page was incorrectly blocking policy creation for clients under the same provider (MDR scenario).
- Updated the peer validation message to accurately reflect support for client-to-client peering under the same provider.
- Fixed a bug in parsing the `odf-info` ConfigMap by ensuring it is now fetched only from valid `MultiClusterViews (MCVs)`.
- Corrected a display issue on the *DRPolicy List* page where Sync policies were mistakenly shown as Async.

TODO: Switch to MulticlusterView(MCV) based `odf-info` ConfigMap reading logic to `odf-client-info` ConfigMap, which is present in `openshift-operator` namespace. MCO is already resolved, provider to client mapping, and it will simplify the UI logic. 

Issue: https://issues.redhat.com/browse/DFBUGS-2337 
