### PR TITLE
Auto distribute storage resources to StorageConsumers during creation

### DIFF
--- a/packages/odf/components/create-storage-system/footer.tsx
+++ b/packages/odf/components/create-storage-system/footer.tsx
@@ -8,6 +8,7 @@ import {
 import {
   MINIMUM_NODES,
   NO_PROVISIONER,
+  OCS_INTERNAL_CR_NAME,
   Steps,
   StepsName,
 } from '@odf/core/constants';
@@ -62,7 +63,6 @@ import {
 } from './payloads';
 import { WizardCommonProps, WizardState } from './reducer';
 
-const OCS_INTERNAL_CR_NAME = 'ocs-storagecluster';
 const OCS_EXTERNAL_CR_NAME = 'ocs-external-storagecluster';
 
 const validateBackingStorageStep = (

--- a/packages/odf/components/storage-consumers/CreateStorageConsumer.tsx
+++ b/packages/odf/components/storage-consumers/CreateStorageConsumer.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DiskSize } from '@odf/core/constants';
+import { DiskSize, OCS_INTERNAL_CR_NAME } from '@odf/core/constants';
 import { useODFNamespaceSelector } from '@odf/core/redux';
 import { StorageQuota } from '@odf/core/types';
 import {
@@ -126,6 +126,14 @@ const CreateStorageConsumer: React.FC = () => {
         },
         spec: {
           storageQuotaInGiB: quotaInGib,
+          storageClasses: [
+            { name: `${OCS_INTERNAL_CR_NAME}-ceph-rbd` },
+            { name: `${OCS_INTERNAL_CR_NAME}-cephfs` },
+          ],
+          volumeSnapshotClasses: [
+            { name: `${OCS_INTERNAL_CR_NAME}-rbdplugin-snapclass` },
+            { name: `${OCS_INTERNAL_CR_NAME}-cephfsplugin-snapclass` },
+          ],
         },
       },
     })

--- a/packages/odf/constants/common.ts
+++ b/packages/odf/constants/common.ts
@@ -6,6 +6,7 @@ import { DEFAULT_STORAGE_NAMESPACE } from '@odf/shared/constants';
 import { Toleration, Taint } from '@odf/shared/types';
 import { TFunction } from 'react-i18next';
 
+export const OCS_INTERNAL_CR_NAME = 'ocs-storagecluster';
 export const CEPH_BRAND_NAME = 'Red Hat Ceph Storage';
 export const NO_PROVISIONER = 'kubernetes.io/no-provisioner';
 export const STORAGE_CLUSTER_SYSTEM_KIND = 'storagecluster.ocs.openshift.io/v1';

--- a/plugins/odf/console-extensions.json
+++ b/plugins/odf/console-extensions.json
@@ -793,6 +793,9 @@
       "provider": {
         "$codeRef": "storageClientAttacherAction.useStorageClientAttacherAction"
       }
+    },
+    "flags": {
+      "required": ["PROVIDER_MODE"]
     }
   },
   {
@@ -806,6 +809,9 @@
       "provider": {
         "$codeRef": "storageClientAttacherAction.useStorageClientAttacherAction"
       }
+    },
+    "flags": {
+      "required": ["PROVIDER_MODE"]
     }
   },
   {


### PR DESCRIPTION
Distributes default StorageClasses to new StorageConsumer 
Distributes default VolumeSnapshotClasses to new StorageConsumer 
Updates UI code to add default storage resources to creation payload 
Allows resource distribution only for Provider mode

Fixes https://issues.redhat.com/browse/DFBUGS-2310