### PR TITLE
Sets hostNetwork to false for cephObjectStores

### DIFF
--- a/packages/odf/components/utils/common.ts
+++ b/packages/odf/components/utils/common.ts
@@ -515,6 +515,7 @@ export const getOCSRequestData = ({
     networkConfiguration.networkType === NetworkType.NIC
   ) {
     requestData.spec.hostNetwork = true;
+    requestData.spec.managedResources.cephObjectStores.hostNetwork = false;
   }
 
   if (encryption) {


### PR DESCRIPTION
Changes to managedResources when Host networking is used

Fixes https://issues.redhat.com/browse/DFBUGS-2324