### PR TITLE
pre-commit: autoadd i18n changes

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,3 @@
 npx lint-staged
+yarn i18n -s
+git add locales

--- a/locales/en/plugin__odf-console.json
+++ b/locales/en/plugin__odf-console.json
@@ -1747,6 +1747,7 @@
   "Only lowercase letters, numbers, non-consecutive periods, or hyphens": "Only lowercase letters, numbers, non-consecutive periods, or hyphens",
   "Cannot be used before": "Cannot be used before",
   "Cannot be used before within the same namespace": "Cannot be used before within the same namespace",
+  "Cannot be empty": "Cannot be empty",
   "Not enough usage data": "Not enough usage data",
   "Total requests: ": "Total requests: ",
   "used": "used",
@@ -1795,6 +1796,9 @@
   "No resources available": "No resources available",
   "Select {{resourceLabel}}": "Select {{resourceLabel}}",
   "Error Loading": "Error Loading",
+  "no results": "no results",
+  "No results found for {{ filterValue }}": "No results found for {{ filterValue }}",
+  "Clear selected value": "Clear selected value",
   "Loading empty page": "Loading empty page",
   "You are not authorized to complete this action. See your cluster administrator for role-based access control information.": "You are not authorized to complete this action. See your cluster administrator for role-based access control information.",
   "Not Authorized": "Not Authorized",
@@ -1858,6 +1862,7 @@
   "Infrastructures": "Infrastructures",
   "Subscriptions": "Subscriptions",
   "Project": "Project",
+  "Suspended": "Suspended",
   "Composable table": "Composable table",
   "Selectable table": "Selectable table",
   "Select all": "Select all",
@@ -1912,10 +1917,5 @@
   "Cannot change resource name (original: \"{{name}}\", updated: \"{{newName}}\").": "Cannot change resource name (original: \"{{name}}\", updated: \"{{newName}}\").",
   "Cannot change resource namespace (original: \"{{namespace}}\", updated: \"{{newNamespace}}\").": "Cannot change resource namespace (original: \"{{namespace}}\", updated: \"{{newNamespace}}\").",
   "Cannot change resource kind (original: \"{{original}}\", updated: \"{{updated}}\").": "Cannot change resource kind (original: \"{{original}}\", updated: \"{{updated}}\").",
-  "Cannot change API group (original: \"{{apiGroup}}\", updated: \"{{newAPIGroup}}\").": "Cannot change API group (original: \"{{apiGroup}}\", updated: \"{{newAPIGroup}}\").",
-  "Cannot be empty": "Cannot be empty",
-  "no results": "no results",
-  "No results found for {{ filterValue }}": "No results found for {{ filterValue }}",
-  "Clear selected value": "Clear selected value",
-  "Suspended": "Suspended"
+  "Cannot change API group (original: \"{{apiGroup}}\", updated: \"{{newAPIGroup}}\").": "Cannot change API group (original: \"{{apiGroup}}\", updated: \"{{newAPIGroup}}\")."
 }


### PR DESCRIPTION
This is meant to avoid running GH actions that we know they'll fail (when the translations updates are missing) so we save time and resources wasted on E2E tests for a failed PR.