### PR TITLE
Fix S3 upload issue

### DIFF
--- a/locales/en/plugin__odf-console.json
+++ b/locales/en/plugin__odf-console.json
@@ -1774,6 +1774,7 @@
   "Only lowercase letters, numbers, non-consecutive periods, or hyphens": "Only lowercase letters, numbers, non-consecutive periods, or hyphens",
   "Cannot be used before": "Cannot be used before",
   "Cannot be used before within the same namespace": "Cannot be used before within the same namespace",
+  "Cannot be empty": "Cannot be empty",
   "Not enough usage data": "Not enough usage data",
   "Total requests: ": "Total requests: ",
   "used": "used",
@@ -1822,6 +1823,9 @@
   "No resources available": "No resources available",
   "Select {{resourceLabel}}": "Select {{resourceLabel}}",
   "Error Loading": "Error Loading",
+  "no results": "no results",
+  "No results found for {{ filterValue }}": "No results found for {{ filterValue }}",
+  "Clear selected value": "Clear selected value",
   "Loading empty page": "Loading empty page",
   "You are not authorized to complete this action. See your cluster administrator for role-based access control information.": "You are not authorized to complete this action. See your cluster administrator for role-based access control information.",
   "Not Authorized": "Not Authorized",
@@ -1885,6 +1889,7 @@
   "Infrastructures": "Infrastructures",
   "Subscriptions": "Subscriptions",
   "Project": "Project",
+  "Suspended": "Suspended",
   "Composable table": "Composable table",
   "Selectable table": "Selectable table",
   "Select all": "Select all",
@@ -1939,10 +1944,5 @@
   "Cannot change resource name (original: \"{{name}}\", updated: \"{{newName}}\").": "Cannot change resource name (original: \"{{name}}\", updated: \"{{newName}}\").",
   "Cannot change resource namespace (original: \"{{namespace}}\", updated: \"{{newNamespace}}\").": "Cannot change resource namespace (original: \"{{namespace}}\", updated: \"{{newNamespace}}\").",
   "Cannot change resource kind (original: \"{{original}}\", updated: \"{{updated}}\").": "Cannot change resource kind (original: \"{{original}}\", updated: \"{{updated}}\").",
-  "Cannot change API group (original: \"{{apiGroup}}\", updated: \"{{newAPIGroup}}\").": "Cannot change API group (original: \"{{apiGroup}}\", updated: \"{{newAPIGroup}}\").",
-  "Cannot be empty": "Cannot be empty",
-  "no results": "no results",
-  "No results found for {{ filterValue }}": "No results found for {{ filterValue }}",
-  "Clear selected value": "Clear selected value",
-  "Suspended": "Suspended"
+  "Cannot change API group (original: \"{{apiGroup}}\", updated: \"{{newAPIGroup}}\").": "Cannot change API group (original: \"{{apiGroup}}\", updated: \"{{newAPIGroup}}\")."
 }

--- a/packages/odf/components/s3-browser/upload-objects/upload-component/FileUploadComponent.tsx
+++ b/packages/odf/components/s3-browser/upload-objects/upload-component/FileUploadComponent.tsx
@@ -79,7 +79,7 @@ export const FileUploadComponent: React.FC<FileUploadComponentProps> = observer(
           );
           uploadStore.addFile(convertFileToUploadProgress(file, key), key);
         });
-        if (uploadStatus !== UploadStatus.UPLOAD_COMPLETE) {
+        if (!!acceptedFiles.length) {
           setUploadStatus(UploadStatus.UPLOAD_START);
           const batches = _.chunk(acceptedFiles, 6);
           let completionTime: number;
@@ -92,14 +92,7 @@ export const FileUploadComponent: React.FC<FileUploadComponentProps> = observer(
         setUploadStatus(UploadStatus.UPLOAD_COMPLETE);
         triggerRefresh();
       },
-      [
-        closeAlert,
-        foldersPath,
-        processFiles,
-        setCompletionTime,
-        triggerRefresh,
-        uploadStatus,
-      ]
+      [closeAlert, foldersPath, processFiles, setCompletionTime, triggerRefresh]
     );
 
     const { getRootProps, getInputProps } = useDropzone({


### PR DESCRIPTION
After a successful file upload, `uploadStatus` is set to `UPLOAD_COMPLETE`. On subsequent uploads, this value remains unchanged (unless "Dismiss" is explicitly clicked or page is reloaded) when calling the onDrop callback, causing the condition `if (uploadStatus !== UPLOAD_COMPLETE)` to be evaluated as `false` and preventing the further uploads (cause `if` block is not executed).