### PR TITLE
RHSTOR-7461Upgrade Yup to version 1.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "webpack": "^5.97.1",
     "webpack-bundle-analyzer": "^4.10.2",
     "webpack-cli": "^6.0.1",
-    "yup": "^0.32.11"
+    "yup": "^1.6.1"
   },
   "devDependencies": {
     "@cypress/webpack-preprocessor": "^6.0.4",

--- a/packages/odf/components/mcg/useObcFormSchema.ts
+++ b/packages/odf/components/mcg/useObcFormSchema.ts
@@ -69,7 +69,11 @@ const useObcFormSchema = (
       }),
     }).concat(obcNameSchema);
 
-    return { obcFormSchema, fieldRequirements };
+    return {
+      obcFormSchema:
+        obcFormSchema as unknown as UseObcBaseSchema['obcFormSchema'],
+      fieldRequirements,
+    };
   }, [data, loadError, loaded, state.scProvisioner, t]);
 };
 

--- a/packages/odf/components/s3-browser/create-bucket/useS3BucketFormValidation.ts
+++ b/packages/odf/components/s3-browser/create-bucket/useS3BucketFormValidation.ts
@@ -43,7 +43,10 @@ const useS3BucketFormValidation = (): S3BucketFormValidation => {
         .transform((value: string) => (!!value ? value : '')),
     });
 
-    return { bucketFormSchema, fieldRequirements };
+    return {
+      bucketFormSchema: bucketFormSchema as unknown as S3BucketFormSchema,
+      fieldRequirements,
+    };
   }, [t]);
 };
 

--- a/packages/odf/constants/providerSchema.ts
+++ b/packages/odf/constants/providerSchema.ts
@@ -44,7 +44,7 @@ export const providerSchema = (shouldValidateSecret: boolean) =>
     }),
     'pvc-name': Yup.object().when('provider-name', {
       is: StoreProviders.FILESYSTEM,
-      then: (schema: Yup.SchemaOf<PersistentVolumeClaimKind>) =>
+      then: (schema: Yup.ObjectSchema<PersistentVolumeClaimKind>) =>
         schema.required(),
     }),
     'folder-name': Yup.string().when('provider-name', {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -45,7 +45,7 @@
     "sass": "^1.89.0",
     "typescript": "^5.8.3",
     "victory-core": "^37.3.6",
-    "yup": "^0.32.11"
+    "yup": "^1.6.1"
   },
   "peerDependencies": {
     "@openshift-console/dynamic-plugin-sdk": "1.8.0",

--- a/packages/shared/src/yup-validation-resolver/useYupValidationResolver.spec.ts
+++ b/packages/shared/src/yup-validation-resolver/useYupValidationResolver.spec.ts
@@ -49,10 +49,10 @@ describe('useYupValidationResolver tests', () => {
           messages: {
             ['Required']: {
               field: 'name',
-              type: 'required',
+              type: 'optionality',
             },
           },
-          type: 'required',
+          type: 'optionality',
         },
       },
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2217,7 +2217,7 @@
     sass "^1.89.0"
     typescript "^5.8.3"
     victory-core "^37.3.6"
-    yup "^0.32.11"
+    yup "^1.6.1"
 
 "@openshift-console/dynamic-plugin-sdk-internal@1.0.0":
   version "1.0.0"
@@ -11373,6 +11373,11 @@ property-expr@^2.0.4:
   resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.5.tgz#278bdb15308ae16af3e3b9640024524f4dc02cb4"
   integrity sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA==
 
+property-expr@^2.0.5:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.6.tgz#f77bc00d5928a6c748414ad12882e83f24aec1e8"
+  integrity sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==
+
 proxy-addr@~2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
@@ -13248,6 +13253,11 @@ time-span@^5.1.0:
   dependencies:
     convert-hrtime "^5.0.0"
 
+tiny-case@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-case/-/tiny-case-1.0.3.tgz#d980d66bc72b5d5a9ca86fb7c9ffdb9c898ddd03"
+  integrity sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==
+
 tiny-invariant@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
@@ -13482,6 +13492,11 @@ type-fest@^0.8.0:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+
+type-fest@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
+  integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
 
 type-is@~1.6.18:
   version "1.6.18"
@@ -14606,3 +14621,13 @@ yup@^0.32.11:
     nanoclone "^0.2.1"
     property-expr "^2.0.4"
     toposort "^2.0.2"
+
+yup@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-1.6.1.tgz#8defcff9daaf9feac178029c0e13b616563ada4b"
+  integrity sha512-JED8pB50qbA4FOkDol0bYF/p60qSEDQqBD0/qeIrUCG1KbPBIQ776fCUNb9ldbPcSTxA69g/47XTo4TqWiuXOA==
+  dependencies:
+    property-expr "^2.0.5"
+    tiny-case "^1.0.3"
+    toposort "^2.0.2"
+    type-fest "^2.19.0"


### PR DESCRIPTION
https://issues.redhat.com/browse/RHSTOR-7461

Upgrade yup to version 1.6.1 in both package.json files

Upgradation of yup is leading to errors as in the attached file yup_errors.txt
[yup_errors.txt](https://github.com/user-attachments/files/20998884/yup_errors.txt)
Yarn test is leading to the errors as in the attached file yarn_test_yup_errors.txt
[yarn_test_yup_erros.txt](https://github.com/user-attachments/files/20998898/yarn_test_yup_erros.txt)

hence updated the file packages/shared/src/yup-validation-resolver/useYupValidationResolver.spec.ts to resove the errors on yarn test

and modified the files packages/odf/components/mcg/useObcFormSchema.ts
                                      packages/odf/components/s3-browser/create-bucket/useS3BucketFormValidation.ts
                                      packages/odf/constants/providerSchema.ts
to resolve type errors