### PR TITLE
StoragePool creation changes for new 2 Nodes + 1 Arbiter cluster

### DIFF
--- a/packages/ocs/storage-pool/body.tsx
+++ b/packages/ocs/storage-pool/body.tsx
@@ -2,14 +2,17 @@ import * as React from 'react';
 import { AttachStorageAction } from '@odf/core/components/attach-storage-storagesystem/state';
 import { checkArbiterCluster } from '@odf/core/utils';
 import {
+  DEFAULT_INFRASTRUCTURE,
   fieldRequirementsTranslations,
   formSettings,
 } from '@odf/shared/constants';
 import { useK8sGet } from '@odf/shared/hooks';
 import { TextInputWithFieldRequirements } from '@odf/shared/input-with-requirements';
-import { StorageClusterModel } from '@odf/shared/models';
+import { InfrastructureModel, StorageClusterModel } from '@odf/shared/models';
 import { getNamespace } from '@odf/shared/selectors';
 import {
+  InfraTopologyMode,
+  InfrastructureKind,
   ListKind,
   StorageClusterKind,
   CephClusterKind,
@@ -83,6 +86,13 @@ export const StoragePoolStatus: React.FC<StoragePoolStatusProps> = ({
   );
 };
 
+export const isInfrastructureInTwoNodeOneArbiterTopology = (
+  infrastructure: InfrastructureKind
+): boolean =>
+  (infrastructure?.status?.controlPlaneTopology ??
+    InfraTopologyMode.HighlyAvailable) ===
+  InfraTopologyMode.HighlyAvailableArbiter;
+
 export type StoragePoolStatusProps = {
   status: string;
   name?: string;
@@ -124,6 +134,9 @@ export const StoragePoolBody: React.FC<StoragePoolBodyProps> = ({
 
   const [storageCluster, storageClusterLoaded, storageClusterLoadError] =
     useK8sGet<ListKind<StorageClusterKind>>(StorageClusterModel, null, poolNs);
+
+  const [infrastructure, infrastructureLoaded, infrastructureError] =
+    useK8sGet<InfrastructureKind>(InfrastructureModel, DEFAULT_INFRASTRUCTURE);
 
   const [isReplicaOpen, setReplicaOpen] = React.useState(false);
 
@@ -188,6 +201,15 @@ export const StoragePoolBody: React.FC<StoragePoolBodyProps> = ({
     });
   }, [poolName, dispatch, errors?.newPoolName, prefixName, usePrefix]);
 
+  // TwoNodeOneArbiterCluster detection
+  React.useEffect(() => {
+    if (infrastructureLoaded && !infrastructureError)
+      dispatch({
+        type: StoragePoolActionType.SET_POOL_TWO_NODE_ONE_ARBITER,
+        payload: isInfrastructureInTwoNodeOneArbiterTopology(infrastructure),
+      });
+  }, [infrastructure, infrastructureLoaded, infrastructureError, dispatch]);
+
   // Failure Domain
   React.useEffect(() => {
     if (storageClusterLoaded && !storageClusterLoadError)
@@ -224,10 +246,21 @@ export const StoragePoolBody: React.FC<StoragePoolBodyProps> = ({
     dispatch,
   ]);
 
+  // const arbiterCluster = false;
+  // const replicaList: string[] = arbiterCluster
+  // ? ['2'] // Arbiter => only 2-way replication
+  // : _.keys(OCS_DEVICE_REPLICA).filter((replica: string) => replica !== '4');
+
   const replicaList: string[] = _.keys(OCS_DEVICE_REPLICA).filter(
-    (replica: string) =>
-      (state.isArbiterCluster && replica === '4') ||
-      (!state.isArbiterCluster && replica !== '4')
+    (replica: string) => {
+      if (state.isTwoNodeOneArbiterCluster) {
+        return replica === '2';
+      } else if (state.isArbiterCluster) {
+        return replica === '4';
+      } else {
+        return replica !== '4';
+      }
+    }
   );
 
   const replicaDropdownItems = replicaList.map((replica) => {

--- a/packages/ocs/storage-pool/reducer.ts
+++ b/packages/ocs/storage-pool/reducer.ts
@@ -4,6 +4,7 @@ export type StoragePoolState = {
   replicaSize: string;
   isCompressed: boolean;
   isArbiterCluster: boolean;
+  isTwoNodeOneArbiterCluster: boolean;
   failureDomain: string;
   inProgress: boolean;
   errorMessage: string;
@@ -15,6 +16,7 @@ export enum StoragePoolActionType {
   SET_POOL_REPLICA_SIZE = 'SET_POOL_REPLICA_SIZE',
   SET_POOL_COMPRESSED = 'SET_POOL_COMPRESSED',
   SET_POOL_ARBITER = 'SET_POOL_ARBITER',
+  SET_POOL_TWO_NODE_ONE_ARBITER = 'SET_POOL_TWO_NODE_ONE_ARBITER',
   SET_FAILURE_DOMAIN = 'SET_FAILURE_DOMAIN',
   SET_INPROGRESS = 'SET_INPROGRESS',
   SET_ERROR_MESSAGE = 'SET_ERROR_MESSAGE',
@@ -26,6 +28,7 @@ export const blockPoolInitialState: StoragePoolState = {
   replicaSize: '',
   isCompressed: false,
   isArbiterCluster: false,
+  isTwoNodeOneArbiterCluster: false,
   failureDomain: '',
   inProgress: false,
   errorMessage: '',
@@ -37,6 +40,10 @@ export type StoragePoolAction =
   | { type: StoragePoolActionType.SET_POOL_REPLICA_SIZE; payload: string }
   | { type: StoragePoolActionType.SET_POOL_COMPRESSED; payload: boolean }
   | { type: StoragePoolActionType.SET_POOL_ARBITER; payload: boolean }
+  | {
+      type: StoragePoolActionType.SET_POOL_TWO_NODE_ONE_ARBITER;
+      payload: boolean;
+    }
   | { type: StoragePoolActionType.SET_FAILURE_DOMAIN; payload: string }
   | { type: StoragePoolActionType.SET_INPROGRESS; payload: boolean }
   | { type: StoragePoolActionType.SET_ERROR_MESSAGE; payload: string };
@@ -74,6 +81,12 @@ export const storagePoolReducer = (
       return {
         ...state,
         isArbiterCluster: action.payload,
+      };
+    }
+    case StoragePoolActionType.SET_POOL_TWO_NODE_ONE_ARBITER: {
+      return {
+        ...state,
+        isTwoNodeOneArbiterCluster: action.payload,
       };
     }
     case StoragePoolActionType.SET_FAILURE_DOMAIN: {

--- a/packages/shared/src/types/common.ts
+++ b/packages/shared/src/types/common.ts
@@ -24,6 +24,15 @@ export enum InfraProviders {
   VSphere = 'VSphere',
 }
 
+// reference: https://github.com/openshift/api/blob/674ad74beffcbdf6aa7a577bf23a269c24f92fe8/config/v1/types_infrastructure.go#L142-#L162
+export enum InfraTopologyMode {
+  HighlyAvailable = 'HighlyAvailable',
+  SingleReplica = 'SingleReplica',
+  External = 'External',
+  DualReplica = 'DualReplica',
+  HighlyAvailableArbiter = 'HighlyAvailableArbiter',
+}
+
 export type InfrastructureKind = K8sResourceCommon & {
   apiVersion: 'config.openshift.io/v1';
   kind: 'Infrastructure';
@@ -33,6 +42,7 @@ export type InfrastructureKind = K8sResourceCommon & {
     };
   };
   status?: {
+    controlPlaneTopology: InfraTopologyMode;
     platform: InfraProviders;
   };
 };


### PR DESCRIPTION
When we detect a 2 Nodes + 1 Arbiter cluster, we should only show, '2-way Replication' in 'Data protection policy' list

How is '2 Nodes + 1 Arbiter' cluster detected?
There is an entry in 'Infrastructure' CR's `controlPlaneTopology` status, value should be `HighlyAvailableArbiter`.