### PR TITLE
ExternalSystemsCard: filter ignored ceph clusters & add unit tests

### DIFF
--- a/packages/odf/components/overview/Overview.spec.tsx
+++ b/packages/odf/components/overview/Overview.spec.tsx
@@ -1,0 +1,90 @@
+import * as React from 'react';
+import {
+  PrometheusData,
+  PrometheusResponse,
+  PrometheusResult,
+  useFlag,
+} from '@openshift-console/dynamic-plugin-sdk';
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom-v5-compat';
+import Overview from './Overview';
+
+const odfNamespace = 'test-ns';
+jest.mock('@odf/core/redux/selectors', () => ({
+  useODFNamespaceSelector: () => ({
+    odfNamespace,
+    isODFNsLoaded: true,
+    odfNsLoadError: null,
+    isNsSafe: true,
+    isFallbackSafe: true,
+  }),
+}));
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  ...jest.requireActual('@openshift-console/dynamic-plugin-sdk'),
+  useK8sWatchResource: jest.fn(() => {
+    return [null, true, undefined];
+  }),
+  useK8sWatchResources: jest.fn(() => ({
+    storageClusters: { data: [], loaded: true, loadError: null },
+    flashSystemClusters: { data: [], loaded: true, loadError: null },
+  })),
+  useActivePerspective: jest.fn(() => ''),
+}));
+
+const promResponse: PrometheusResponse = {
+  status: 'success',
+  data: {
+    result: [
+      {
+        metric: {},
+        value: [1712304917.483, '0'],
+      } as PrometheusResult,
+    ],
+    resultType: 'vector',
+  } as PrometheusData,
+};
+jest.mock('@odf/shared/hooks/custom-prometheus-poll', () => ({
+  useCustomPrometheusPoll: jest.fn(() => [promResponse, null, false]),
+  usePrometheusBasePath: jest.fn(() => ''),
+}));
+
+jest.mock('@openshift-console/dynamic-plugin-sdk-internal', () => ({
+  ...jest.requireActual('@openshift-console/dynamic-plugin-sdk-internal'),
+  useUtilizationDuration: jest.fn(() => ({ duration: 0 })),
+}));
+
+jest.mock('@openshift-console/dynamic-plugin-sdk/lib/utils/flags', () => ({
+  ...jest.requireActual(
+    '@openshift-console/dynamic-plugin-sdk/lib/utils/flags'
+  ),
+  useFlag: jest.fn(),
+}));
+
+describe('General Overview', () => {
+  it('only renders common cards', () => {
+    (useFlag as jest.Mock).mockReturnValue(false);
+    render(
+      <BrowserRouter>
+        <Overview />
+      </BrowserRouter>
+    );
+    expect(screen.getByText('Overview')).toBeInTheDocument();
+    expect(screen.getByText('Object storage')).toBeInTheDocument();
+    expect(screen.getByText('Activity')).toBeInTheDocument();
+    expect(screen.queryByText('External systems')).not.toBeInTheDocument();
+  });
+
+  it('also renders External Systems card', () => {
+    (useFlag as jest.Mock).mockReturnValue(true);
+    render(
+      <BrowserRouter>
+        <Overview />
+      </BrowserRouter>
+    );
+    expect(screen.getByText('Overview')).toBeInTheDocument();
+    expect(screen.getByText('Object storage')).toBeInTheDocument();
+    expect(screen.getByText('Activity')).toBeInTheDocument();
+    expect(screen.getByText('External systems')).toBeInTheDocument();
+  });
+});

--- a/packages/odf/components/overview/external-systems-card/ExternalSystemsCard.tsx
+++ b/packages/odf/components/overview/external-systems-card/ExternalSystemsCard.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { isExternalCluster } from '@odf/core/utils/odf';
+import { isClusterIgnored, isExternalCluster } from '@odf/core/utils/odf';
 import { DASH } from '@odf/shared/constants';
 import { useWatchStorageClusters } from '@odf/shared/hooks/useWatchStorageClusters';
 import { resourceStatus } from '@odf/shared/status/Resource';
@@ -84,8 +84,9 @@ export const ExternalSystemsCard: React.FC<CardProps> = ({ className }) => {
   const cephClustersStatuses =
     storageClusters.loaded && !storageClusters.loadError
       ? getClustersStatuses(
-          storageClusters?.data?.filter((cluster) =>
-            isExternalCluster(cluster)
+          storageClusters?.data?.filter(
+            (cluster) =>
+              !isClusterIgnored(cluster) && isExternalCluster(cluster)
           ),
           t
         )


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/RHSTOR-7430
- Unit tests to ensure that `ExternalSystemsCard` is only shown on FDF.