### PR TITLE
fix: override follow-redirects to >=1.14.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "**/package.json": "npx --yes sort-package-json@3.0.0"
   },
   "resolutions": {
+    "follow-redirects": "^1.15.11",
     "webpack": "^5.99.9"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7627,10 +7627,10 @@ focus-trap@7.6.2:
   dependencies:
     tabbable "^6.2.0"
 
-follow-redirects@^1.0.0:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.1.tgz#d9114ded0a1cfdd334e164e6662ad02bfd91ff43"
-  integrity sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==
+follow-redirects@^1.0.0, follow-redirects@^1.15.11:
+  version "1.15.11"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
+  integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
 
 for-each@^0.3.3:
   version "0.3.3"


### PR DESCRIPTION
https://issues.redhat.com/browse/DFBUGS-3741
https://issues.redhat.com/browse/DFBUGS-3899

The transitive dependency `follow-redirects@1.14.1` (via http-proxy@1.18.1) is vulnerable to CVE-2022-0155 and CVE-2022-0536.

Applied an override to enforce follow-redirects >=1.14.4 which includes security fixes.

Verified with `npm ls follow-redirects` after install.