### PR TITLE
Adjust card placement in dashboard

### DIFF
--- a/packages/ocs/dashboards/ocs-system-dashboard.tsx
+++ b/packages/ocs/dashboards/ocs-system-dashboard.tsx
@@ -82,9 +82,9 @@ const PersistentInternalDashboard: React.FC = () => {
   const mainCards: React.ComponentType[] = [
     StatusCard,
     RawCapacityCard,
-    PoolUtilizationCard,
     CapacityTrendCard,
     BreakdownCard,
+    PoolUtilizationCard,
     UtilizationCard,
   ];
   const leftCards: React.ComponentType[] = [


### PR DESCRIPTION
https://issues.redhat.com/browse/DFBUGS-3859

Move Consumption trend and Requested capacity cards above Storage Utilization card.

Change the order of cards placement in the file "_**packages/ocs/dashboards/ocs-system-dashboard.tsx**_"

**BEFORE ADJUSTMENT:**
<img width="2096" height="864" alt="image-2025-08-21-11-08-05-474" src="https://github.com/user-attachments/assets/446821ce-bf86-4ba7-9a09-0cacf0928128" />

**AFTER ADJUSTMENT:**
<img width="1728" height="1117" alt="Screenshot 2025-08-25 at 1 34 23 PM" src="https://github.com/user-attachments/assets/b2eacab2-7b88-40f7-bb7f-bd528486b61d" />

