### PR TITLE
Remove link in resource providers card

### DIFF
--- a/packages/ocs/dashboards/object-service/resource-providers-card/resource-providers-card-item.tsx
+++ b/packages/ocs/dashboards/object-service/resource-providers-card/resource-providers-card-item.tsx
@@ -4,37 +4,27 @@ import * as _ from 'lodash-es';
 
 const ResourceProvidersItemStatus: React.FC<ResourceProvidersRowStatusProps> =
   // eslint-disable-next-line react/display-name
-  React.memo(({ status, link }) => (
+  React.memo(({ status }) => (
     <div className="nb-resource-providers-card__row-status">
       <div className="nb-resource-providers-card__row-status-item">
-        <a
-          href={link}
-          style={{ textDecoration: 'none' }}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <RedExclamationCircleIcon className="co-dashboard-icon nb-resource-providers-card__status-icon" />
-          <span className="nb-resource-providers-card__row-status-item-text">
-            {status}
-          </span>
-        </a>
+        <RedExclamationCircleIcon className="co-dashboard-icon nb-resource-providers-card__status-icon" />
+        <span className="nb-resource-providers-card__row-status-item-text">
+          {status}
+        </span>
       </div>
     </div>
   ));
 
 export const ResourceProvidersItem: React.FC<ResourceProvidersRowProps> =
   // eslint-disable-next-line react/display-name
-  React.memo(({ title, count, unhealthyProviders, link }) => (
+  React.memo(({ title, count, unhealthyProviders }) => (
     <div className="co-inventory-card__item">
       <div
         className="nb-resource-providers-card__row-title"
         data-test="nb-resource-providers-card"
       >{`${count} ${title}`}</div>
       {!_.isNil(unhealthyProviders[title]) && unhealthyProviders[title] > 0 ? (
-        <ResourceProvidersItemStatus
-          status={unhealthyProviders[title]}
-          link={link}
-        />
+        <ResourceProvidersItemStatus status={unhealthyProviders[title]} />
       ) : null}
     </div>
   ));
@@ -45,12 +35,10 @@ export type ProviderType = {
 
 type ResourceProvidersRowProps = {
   count: number;
-  link: string;
   title: string;
   unhealthyProviders: ProviderType;
 };
 
 type ResourceProvidersRowStatusProps = {
-  link: string;
   status: number;
 };

--- a/packages/ocs/dashboards/object-service/resource-providers-card/resource-providers-card.scss
+++ b/packages/ocs/dashboards/object-service/resource-providers-card/resource-providers-card.scss
@@ -24,7 +24,6 @@
 }
 
 .nb-resource-providers-card__row-status-item-text {
-  color: $pf-v5-color-blue-300;
   margin-left: 0.25em;
 }
 

--- a/packages/ocs/dashboards/object-service/resource-providers-card/resource-providers-card.tsx
+++ b/packages/ocs/dashboards/object-service/resource-providers-card/resource-providers-card.tsx
@@ -7,7 +7,6 @@ import {
   usePrometheusBasePath,
 } from '@odf/shared/hooks/custom-prometheus-poll';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
-import { getMetric } from '@odf/shared/utils';
 import { PrometheusResponse } from '@openshift-console/dynamic-plugin-sdk';
 import * as _ from 'lodash-es';
 import { Card, CardBody, CardHeader, CardTitle } from '@patternfly/react-core';
@@ -22,7 +21,6 @@ import './resource-providers-card.scss';
 const RESOURCE_PROVIDERS_QUERY = {
   PROVIDERS_TYPES: ' NooBaa_cloud_types',
   UNHEALTHY_PROVIDERS_TYPES: 'NooBaa_unhealthy_cloud_types',
-  RESOURCES_LINK_QUERY: 'NooBaa_system_links',
 };
 
 const getProviderType = (provider: ProviderPrometheusData): string =>
@@ -59,19 +57,10 @@ const MCGResourceProvidersBody: React.FC = () => {
     endpoint: 'api/v1/query' as any,
     basePath: usePrometheusBasePath(),
   });
-  const [resourcesLinksResponse, resourcesLinksResponseError] =
-    useCustomPrometheusPoll({
-      query: RESOURCE_PROVIDERS_QUERY.RESOURCES_LINK_QUERY,
-      endpoint: 'api/v1/query' as any,
-      basePath: usePrometheusBasePath(),
-    });
 
   const error =
     !!providersTypesQueryResultError ||
-    !!unhealthyProvidersTypesQueryResultError ||
-    !!resourcesLinksResponseError;
-
-  const noobaaResourcesLink = getMetric(resourcesLinksResponse, 'resources');
+    !!unhealthyProvidersTypesQueryResultError;
 
   const allProviders = createProvidersList(providersTypesQueryResult);
   const unhealthyProviders = createProvidersList(
@@ -93,7 +82,6 @@ const MCGResourceProvidersBody: React.FC = () => {
         <ResourceProvidersItem
           count={allProviders[provider]}
           key={provider}
-          link={noobaaResourcesLink}
           title={provider}
           unhealthyProviders={unhealthyProviders}
         />


### PR DESCRIPTION
https://issues.redhat.com/browse/DFBUGS-3901:

Remove the link and related items in resource providers card as mentioned in the above bug
UI after removal of the link
<img width="1728" height="1117" alt="Screenshot 2025-09-03 at 3 54 38 PM" src="https://github.com/user-attachments/assets/e91319f1-1aa5-469b-883e-74a6fff73c4f" />

The link is tested by replacing the unhealthy resource providers in with an arbitary array {AWS:2, Azure:1, GCP:1, Kubernetes:1, S3_Compatible:1}.

**Before changes:**

https://github.com/user-attachments/assets/7dd0cdad-e870-4b83-acd5-fba2d71401c8

**After Changes**


https://github.com/user-attachments/assets/b75696cd-9720-4ac7-b829-bbd93e4efa57


