### PR TITLE
Allow arbiter expansion for non multiples of 4 replica

### DIFF
--- a/locales/en/plugin__odf-console.json
+++ b/locales/en/plugin__odf-console.json
@@ -1828,7 +1828,7 @@
   "Tenant ID": "Tenant ID",
   "The aggregate resource requirements for {{selectedProfile}} mode is": "The aggregate resource requirements for {{selectedProfile}} mode is",
   "The amount of capacity that would be dynamically allocated on the selected StorageClass.": "The amount of capacity that would be dynamically allocated on the selected StorageClass.",
-  "The Arbiter stretch cluster requires a minimum of 4 nodes (2 different zones, 2 nodes per zone). Please choose a different StorageClass or create a new LocalVolumeSet that matches the minimum node requirement.": "The Arbiter stretch cluster requires a minimum of 4 nodes (2 different zones, 2 nodes per zone). Please choose a different StorageClass or create a new LocalVolumeSet that matches the minimum node requirement.",
+  "The Arbiter stretch cluster requires a minimum of 2 nodes (2 different zones, 1 nodes per zone) for expansion. Please choose a different StorageClass or create a new LocalVolumeSet that matches the minimum node requirement.": "The Arbiter stretch cluster requires a minimum of 2 nodes (2 different zones, 1 nodes per zone) for expansion. Please choose a different StorageClass or create a new LocalVolumeSet that matches the minimum node requirement.",
   "The available capacity is based on all attached disks associated with the selected StorageClass <3>{{storageClassName}}</3>": "The available capacity is based on all attached disks associated with the selected StorageClass <3>{{storageClassName}}</3>",
   "The backend path in Vault where the encryption keys will be stored.": "The backend path in Vault where the encryption keys will be stored.",
   "The bucket is being deleted. This may take a while.": "The bucket is being deleted. This may take a while.",

--- a/packages/odf/components/attach-storage-storagesystem/attach-storage.tsx
+++ b/packages/odf/components/attach-storage-storagesystem/attach-storage.tsx
@@ -165,7 +165,12 @@ const AttachStorage = () => {
       );
       const availablePvsCount = pvs.length || 0;
       const failureDomain = storageCluster?.status?.failureDomain;
-      const deviceSetCount = getDeviceSetCount(availablePvsCount, replica);
+      const deviceSetCount = getDeviceSetCount(
+        availablePvsCount,
+        replica,
+        hasFlexibleScaling,
+        isArbiterEnabled
+      );
       const filesystemName = `${clusterName}-cephfilesystem`;
       const payload = createPayload(
         state,

--- a/packages/odf/components/create-storage-system/create-storage-system-steps/capacity-and-nodes-step/capacity-and-nodes-step.tsx
+++ b/packages/odf/components/create-storage-system/create-storage-system-steps/capacity-and-nodes-step/capacity-and-nodes-step.tsx
@@ -445,7 +445,12 @@ export const CapacityAndNodes: React.FC<CapacityAndNodesProps> = ({
     flexibleScaling,
     nodes
   );
-  const deviceSetCount = getDeviceSetCount(pvCount, deviceSetReplica);
+  const deviceSetCount = getDeviceSetCount(
+    pvCount,
+    deviceSetReplica,
+    flexibleScaling,
+    enableArbiter
+  );
   const osdAmount = getOsdAmount(deviceSetCount, deviceSetReplica);
 
   const validations = capacityAndNodesValidate(

--- a/packages/odf/components/create-storage-system/footer.tsx
+++ b/packages/odf/components/create-storage-system/footer.tsx
@@ -160,7 +160,12 @@ const canJumpToNextStep = (
     flexibleScaling,
     nodes
   );
-  const deviceSetCount = getDeviceSetCount(pvCount, deviceSetReplica);
+  const deviceSetCount = getDeviceSetCount(
+    pvCount,
+    deviceSetReplica,
+    flexibleScaling,
+    enableArbiter
+  );
   const osdAmount = getOsdAmount(deviceSetCount, deviceSetReplica);
 
   switch (name) {

--- a/packages/odf/components/utils/common.spec.ts
+++ b/packages/odf/components/utils/common.spec.ts
@@ -1,6 +1,7 @@
 import {
   OCS_DEVICE_SET_FLEXIBLE_REPLICA,
   OCS_DEVICE_SET_MINIMUM_REPLICAS,
+  OCS_DEVICE_SET_ARBITER_REPLICAS,
 } from '../../constants';
 import { WizardNodeState } from '../create-storage-system/reducer';
 import { getDeviceSetReplica, getReplicasFromSelectedNodes } from './common';
@@ -77,7 +78,7 @@ describe('ODF common utilities', () => {
     // Stretch cluster.
     expect(
       getDeviceSetReplica(true, false, wizardNodeStates as WizardNodeState[])
-    ).toBe(5);
+    ).toBe(OCS_DEVICE_SET_ARBITER_REPLICAS);
 
     // Flexible scaling.
     expect(

--- a/packages/odf/constants/common.ts
+++ b/packages/odf/constants/common.ts
@@ -18,6 +18,7 @@ export const OCS_DISABLED_ANNOTATION = 'features.ocs.openshift.io/disabled';
 export const ODF_VENDOR_ANNOTATION = 'vendors.odf.openshift.io/kind';
 export const OCS_DEVICE_SET_FLEXIBLE_REPLICA = 1;
 export const OCS_DEVICE_SET_MINIMUM_REPLICAS = 3;
+export const OCS_DEVICE_SET_ARBITER_REPLICAS = 4;
 export const MINIMUM_NODES = 3;
 export const SECOND = 1000;
 

--- a/packages/odf/modals/add-capacity/add-capacity-modal.tsx
+++ b/packages/odf/modals/add-capacity/add-capacity-modal.tsx
@@ -267,7 +267,7 @@ const AddCapacityModal: React.FC<StorageClusterActionModalProps> = ({
     if (!isNoProvionerSC || hasFlexibleScaling) return '';
     if (isArbiterEnabled && !isArbiterSC(selectedSCName, pvData, nodesData)) {
       return t(
-        'The Arbiter stretch cluster requires a minimum of 4 nodes (2 different zones, 2 nodes per zone). Please choose a different StorageClass or create a new LocalVolumeSet that matches the minimum node requirement.'
+        'The Arbiter stretch cluster requires a minimum of 2 nodes (2 different zones, 1 nodes per zone) for expansion. Please choose a different StorageClass or create a new LocalVolumeSet that matches the minimum node requirement.'
       );
     }
     if (
@@ -330,7 +330,12 @@ const AddCapacityModal: React.FC<StorageClusterActionModalProps> = ({
       portable = false;
     }
     if (isNoProvionerSC)
-      deviceSetCount = getDeviceSetCount(availablePvsCount, deviceSetReplica);
+      deviceSetCount = getDeviceSetCount(
+        availablePvsCount,
+        deviceSetReplica,
+        hasFlexibleScaling,
+        isArbiterEnabled
+      );
 
     if (deviceSetIndex === -1) {
       patch.op = 'add';

--- a/packages/odf/utils/ocs.spec.ts
+++ b/packages/odf/utils/ocs.spec.ts
@@ -1,5 +1,9 @@
 import { createFakeNodesData } from '../../../jest/helpers';
-import { getNodeTotalMemory } from './ocs';
+import {
+  OCS_DEVICE_SET_MINIMUM_REPLICAS,
+  OCS_DEVICE_SET_ARBITER_REPLICAS,
+} from '../constants';
+import { getNodeTotalMemory, getDeviceSetCount } from './ocs';
 
 describe('getNodeTotalMemory', () => {
   it('returns node memory from metric by default', () => {
@@ -16,5 +20,58 @@ describe('getNodeTotalMemory', () => {
     const node = createFakeNodesData(1, 12, metricMemory, memory)[0];
 
     expect(getNodeTotalMemory(node)).toEqual(String(memory));
+  });
+});
+
+describe('getDeviceSetCount', () => {
+  it('Day-1: requires at least 4 PVs for arbiter cluster', () => {
+    expect(
+      getDeviceSetCount(2, OCS_DEVICE_SET_ARBITER_REPLICAS, false, true)
+    ).toBe(1); // fallback (not valid for real day-1)
+    expect(
+      getDeviceSetCount(3, OCS_DEVICE_SET_ARBITER_REPLICAS, false, true)
+    ).toBe(1); // fallback (not valid for real day-1)
+
+    expect(
+      getDeviceSetCount(4, OCS_DEVICE_SET_ARBITER_REPLICAS, false, true)
+    ).toBe(1);
+    expect(
+      getDeviceSetCount(6, OCS_DEVICE_SET_ARBITER_REPLICAS, false, true)
+    ).toBe(2);
+  });
+
+  it('Day-2: expansion by 2 PVs is allowed for arbiter cluster', () => {
+    expect(
+      getDeviceSetCount(6, OCS_DEVICE_SET_ARBITER_REPLICAS, false, true)
+    ).toBe(2);
+    expect(
+      getDeviceSetCount(10, OCS_DEVICE_SET_ARBITER_REPLICAS, false, true)
+    ).toBe(3);
+  });
+
+  it('Day-2: expansion by 4 PVs also works for arbiter cluster', () => {
+    expect(
+      getDeviceSetCount(8, OCS_DEVICE_SET_ARBITER_REPLICAS, false, true)
+    ).toBe(2);
+    expect(
+      getDeviceSetCount(12, OCS_DEVICE_SET_ARBITER_REPLICAS, false, true)
+    ).toBe(3);
+  });
+
+  it('Non arbiter/flexibleScaling cluster behaves normally', () => {
+    expect(
+      getDeviceSetCount(4, OCS_DEVICE_SET_MINIMUM_REPLICAS, false, false)
+    ).toBe(1);
+    expect(
+      getDeviceSetCount(6, OCS_DEVICE_SET_MINIMUM_REPLICAS, false, false)
+    ).toBe(2);
+    expect(
+      getDeviceSetCount(8, OCS_DEVICE_SET_MINIMUM_REPLICAS, false, false)
+    ).toBe(2);
+  });
+
+  it('Flexible scaling ignores arbiter logic', () => {
+    expect(getDeviceSetCount(5, 1, true, true)).toBe(5);
+    expect(getDeviceSetCount(7, 1, true, false)).toBe(7);
   });
 });

--- a/packages/odf/utils/ocs.ts
+++ b/packages/odf/utils/ocs.ts
@@ -250,8 +250,27 @@ export const createDeviceSet = (
   },
 });
 
-export const getDeviceSetCount = (pvCount: number, replica: number): number =>
-  Math.floor(pvCount / replica) || 1;
+export const getDeviceSetCount = (
+  pvCount: number,
+  replica: number,
+  isFlexibleScalingEnabled: boolean,
+  isArbiterEnabled: boolean
+): number => {
+  let count = Math.floor(pvCount / replica) || 1;
+
+  // day-1 (arbiter): allows creation for 4, 6, 8, 10... disks attached across 2 zones
+  // day-2 (arbiter): allows expansion for 2, 4, 6, 8... disks attached across 2 zones
+  if (
+    isArbiterEnabled &&
+    !isFlexibleScalingEnabled &&
+    pvCount > replica &&
+    pvCount % replica >= 2
+  ) {
+    count += 1;
+  }
+
+  return count;
+};
 
 export const getOsdAmount = (
   deviceSetCount: number,
@@ -268,6 +287,7 @@ export const getZone = (node: NodeKind) =>
   node.metadata.labels?.[ZONE_LABELS[0]] ||
   node.metadata.labels?.[ZONE_LABELS[1]];
 
+// isArbiterSC is used for day-2 validation only
 export const isArbiterSC = (
   scName: string,
   pvData: K8sResourceKind[],
@@ -279,7 +299,8 @@ export const isArbiterSC = (
   if (_.compact([...uniqZones]).length < 3) return false;
   if (uniqSelectedNodesZones.size !== 2) return false;
   const zonePerNode = countNodesPerZone(tableData);
-  return Object.keys(zonePerNode).every((zone) => zonePerNode[zone] >= 2);
+  // day-2: allows expansion for 2, 4, 6, 8... disks attached across 2 zones
+  return Object.keys(zonePerNode).every((zone) => zonePerNode[zone] >= 1);
 };
 
 export const isValidTopology = (


### PR DESCRIPTION
https://issues.redhat.com/browse/DFBUGS-3725

### 6W, 3 per zone, each with 1 attached disk (count = 2, replica = 4):
<img width="1161" height="853" alt="Screenshot 2025-09-03 at 6 46 22 PM" src="https://github.com/user-attachments/assets/e3465fd8-c03c-4ce2-942c-2fc6a87f510d" />

### Expansion is allowed when only 2 disks are attached (1 per zone):
<img width="874" height="540" alt="Screenshot 2025-09-03 at 7 02 56 PM" src="https://github.com/user-attachments/assets/98f74cb3-7007-4401-adfc-12e93fe109b4" />
