### PR TITLE
Fixing the issue of donut chart text not appearing clearly in dark mode

### DIFF
--- a/packages/odf/components/overview/storage-cluster-card/StorageClusterCard.tsx
+++ b/packages/odf/components/overview/storage-cluster-card/StorageClusterCard.tsx
@@ -44,7 +44,7 @@ import { global_warning_color_100 as warning1 } from '@patternfly/react-tokens/d
 import classNames from 'classnames';
 import * as _ from 'lodash-es';
 import { useNavigate } from 'react-router-dom-v5-compat';
-import { ChartDonut, ChartLabel } from '@patternfly/react-charts';
+import { ChartDonut, ChartLabel, ChartLegend } from '@patternfly/react-charts';
 import {
   DescriptionList,
   DescriptionListTerm,
@@ -163,7 +163,7 @@ export const StorageClusterCard: React.FC<CardProps> = ({ className }) => {
   }, [capacityRatio]);
 
   return (
-    <Card className={classNames(className)} isFlat={true}>
+    <Card className={classNames('odf-cluster-card', className)} isFlat>
       <CardHeader>
         <CardTitle>{t('Storage cluster')}</CardTitle>
       </CardHeader>
@@ -205,6 +205,7 @@ export const StorageClusterCard: React.FC<CardProps> = ({ className }) => {
                 </DescriptionListGroup>
               </DescriptionList>
             </GridItem>
+
             <GridItem
               md={8}
               rowSpan={2}
@@ -225,12 +226,25 @@ export const StorageClusterCard: React.FC<CardProps> = ({ className }) => {
                   padding={{ top: 0, bottom: 0, left: 0, right: 140 }}
                   constrainToVisibleArea
                   titleComponent={
-                    <ChartLabel className="odf-cluster-card__chart-title" />
+                    <ChartLabel
+                      className="odf-cluster-card__chart-title"
+                      style={{ fill: 'var(--pf-v5-global--Color--200)' }}
+                    />
                   }
                   subTitleComponent={
                     <ChartLabel
                       className="odf-cluster-card__chart-subtitle"
+                      style={{ fill: 'var(--pf-v5-global--Color--200)' }}
                       dy={5}
+                    />
+                  }
+                  legendComponent={
+                    <ChartLegend
+                      orientation="vertical"
+                      gutter={20}
+                      style={{
+                        labels: { fill: 'var(--pf-v5-global--Color--200)' },
+                      }}
                     />
                   }
                   legendData={[
@@ -248,6 +262,7 @@ export const StorageClusterCard: React.FC<CardProps> = ({ className }) => {
                 <>{t('No capacity data available.')}</>
               )}
             </GridItem>
+
             <GridItem md={4} sm={12}>
               <Button
                 variant={ButtonVariant.link}

--- a/packages/odf/components/overview/storage-cluster-card/StorageClusterCard.tsx
+++ b/packages/odf/components/overview/storage-cluster-card/StorageClusterCard.tsx
@@ -228,7 +228,7 @@ export const StorageClusterCard: React.FC<CardProps> = ({ className }) => {
                   titleComponent={
                     <ChartLabel
                       className="odf-cluster-card__chart-title"
-                      style={{ fill: 'var(--pf-v5-global--Color--200)' , fontSize: 20 }}
+                      style={{ fill: 'var(--pf-v5-global--Color--200)', fontSize: 20 }}
                     />
                   }
                   subTitleComponent={

--- a/packages/odf/components/overview/storage-cluster-card/StorageClusterCard.tsx
+++ b/packages/odf/components/overview/storage-cluster-card/StorageClusterCard.tsx
@@ -228,7 +228,7 @@ export const StorageClusterCard: React.FC<CardProps> = ({ className }) => {
                   titleComponent={
                     <ChartLabel
                       className="odf-cluster-card__chart-title"
-                      style={{ fill: 'var(--pf-v5-global--Color--200)' }}
+                      style={{ fill: 'var(--pf-v5-global--Color--200)' , fontSize: 20 }}
                     />
                   }
                   subTitleComponent={


### PR DESCRIPTION
The text in the donut chart was not appearing clearly in dark mode. I fixed this by adding the PatternFly CSS property fill: var(--pf-v5-global--Color--200), which dynamically adjusts the text color based on the UI’s dark or light mode.