### PR TITLE
Adding a hyperlink of RHACM policy page on the note and changing it's text

### DIFF
--- a/locales/en/plugin__odf-console.json
+++ b/locales/en/plugin__odf-console.json
@@ -1,5 +1,6 @@
 {
   " {{ peerConnectedCount }} Connected": " {{ peerConnectedCount }} Connected",
+  " for more details.": " for more details.",
   " selected": " selected",
   "(in {{suffixLabel}})": "(in {{suffixLabel}})",
   "{{ actionsCount }} actions": "{{ actionsCount }} actions",
@@ -1296,7 +1297,7 @@
   "Not validated": "Not validated",
   "NotAvailable": "NotAvailable",
   "Note:": "Note:",
-  "Note: If your cluster isn't visible on this list, verify its import status and refer to the steps outlined in the ACM documentation.": "Note: If your cluster isn't visible on this list, verify its import status and refer to the steps outlined in the ACM documentation.",
+  "Note: If your managed cluster doesn't appear here, confirm it's successfully imported and refer to the ": "Note: If your managed cluster doesn't appear here, confirm it's successfully imported and refer to the ",
   "Num Volumes": "Num Volumes",
   "Number of noncurrent versions of object.": "Number of noncurrent versions of object.",
   "Number of Volumes": "Number of Volumes",
@@ -1570,6 +1571,7 @@
   "Review and assign": "Review and assign",
   "Review and create": "Review and create",
   "Review BucketClass": "Review BucketClass",
+  "RHACM documentation": "RHACM documentation",
   "Role": "Role",
   "Rotate signing keys": "Rotate signing keys",
   "Rule": "Rule",

--- a/packages/mco/components/create-dr-policy/create-dr-policy.tsx
+++ b/packages/mco/components/create-dr-policy/create-dr-policy.tsx
@@ -240,8 +240,16 @@ const CreateDRPolicy: React.FC<{}> = () => {
               <HelperText>
                 <HelperTextItem>
                   {t(
-                    "Note: If your cluster isn't visible on this list, verify its import status and refer to the steps outlined in the ACM documentation."
+                    "Note: If your managed cluster doesn't appear here, confirm it's successfully imported and refer to the "
                   )}
+                  <a
+                    href="https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.14"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {t('RHACM documentation')}
+                  </a>
+                  {t(' for more details.')}
                 </HelperTextItem>
               </HelperText>
             </FormHelperText>


### PR DESCRIPTION
I updated the text on the DR policy page to:
"Note: If your managed cluster doesn’t appear here, confirm that it has been successfully imported and refer to the RHACM documentation for more details."
Additionally, I added a hyperlink to the words “RHACM documentation,” which opens in a new tab and navigates to:
https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.14.


Jira Link:
https://issues.redhat.com/browse/DFBUGS-4005

Screenshot of before the fix:
<img width="1600" height="953" alt="image" src="https://github.com/user-attachments/assets/8438e700-1af5-4a8d-a2e7-d88c3272f638" />
