### PR TITLE
changing the font of donut chart so that it is visible in dark mode

### DIFF
--- a/packages/odf/components/overview/storage-cluster-card/StorageClusterCard.tsx
+++ b/packages/odf/components/overview/storage-cluster-card/StorageClusterCard.tsx
@@ -44,7 +44,7 @@ import { global_warning_color_100 as warning1 } from '@patternfly/react-tokens/d
 import classNames from 'classnames';
 import * as _ from 'lodash-es';
 import { useNavigate } from 'react-router-dom-v5-compat';
-import { ChartDonut, ChartLabel } from '@patternfly/react-charts';
+import { ChartDonut, ChartLabel, ChartLegend } from '@patternfly/react-charts';
 import {
   DescriptionList,
   DescriptionListTerm,
@@ -225,12 +225,28 @@ export const StorageClusterCard: React.FC<CardProps> = ({ className }) => {
                   padding={{ top: 0, bottom: 0, left: 0, right: 140 }}
                   constrainToVisibleArea
                   titleComponent={
-                    <ChartLabel className="odf-cluster-card__chart-title" />
+                    <ChartLabel
+                      className="odf-cluster-card__chart-title"
+                      style={{
+                        fill: 'var(--pf-v5-global--Color--100)',
+                        fontSize: 20,
+                      }}
+                    />
                   }
                   subTitleComponent={
                     <ChartLabel
                       className="odf-cluster-card__chart-subtitle"
+                      style={{ fill: 'var(--pf-v5-global--Color--200)' }}
                       dy={5}
+                    />
+                  }
+                  legendComponent={
+                    <ChartLegend
+                      orientation="vertical"
+                      gutter={20}
+                      style={{
+                        labels: { fill: 'var(--pf-v5-global--Color--200)' },
+                      }}
                     />
                   }
                   legendData={[


### PR DESCRIPTION
I have raised this PR again. It now displays the donut chart where the text inside the chart and the legends are clearly visible in both dark and light modes.

Before:
<img width="568" height="460" alt="Before" src="https://github.com/user-attachments/assets/af479913-166c-43fd-b4b7-e7d5a32e8608" />

After:
<img width="568" height="942" alt="after-dark" src="https://github.com/user-attachments/assets/e072ab5a-076a-4529-a073-5f53dba5e3b5" />
<img width="568" height="532" alt="after-light" src="https://github.com/user-attachments/assets/bf48a01d-5256-462b-8bce-85b2b83abba2" />
