### PR TITLE
Fix consistency group volume type filter

### DIFF
--- a/packages/mco/components/modals/app-manage-policies/helper/consistency-groups.tsx
+++ b/packages/mco/components/modals/app-manage-policies/helper/consistency-groups.tsx
@@ -21,7 +21,7 @@ import {
   StatusBox,
   useCustomTranslation,
 } from '@odf/shared';
-import { BLOCK, FILESYSTEM } from '@odf/shared/constants/common';
+import { BLOCK, FILESYSTEM, PVCVolumeMode } from '@odf/shared/constants';
 import { referenceForModel } from '@odf/shared/utils';
 import {
   K8sResourceCommon,
@@ -71,8 +71,8 @@ const FILTERS = [
   FilterType.FILESYSTEMTYPE,
 ];
 
-const getCGType = (cgName: string) =>
-  cgName.startsWith('cephfs-') ? FILESYSTEM : BLOCK;
+const getCGType = (volumeMode: string) =>
+  PVCVolumeMode.Filesystem === volumeMode ? FILESYSTEM : BLOCK;
 
 const displayFilterText = (t: TFunction) => {
   return {
@@ -300,7 +300,7 @@ const buildConsistencyGroupMap = (
     if (!cgLabel) return;
 
     const cgName = cgLabel[1] as string;
-    const cgType = getCGType(cgName);
+    const cgType = getCGType(pvc.volumeMode);
     const schedulingInterval = vrg.spec.async?.schedulingInterval;
     const dataLastSyncedOn = pvc.lastSyncTime;
     const healthStatus = getReplicationHealth(

--- a/packages/mco/types/ramen.ts
+++ b/packages/mco/types/ramen.ts
@@ -117,6 +117,7 @@ export type DRVolumeReplicationGroupKind = K8sResourceCommon & {
       resources?: any;
       conditions?: K8sResourceCondition[];
       lastSyncTime?: string;
+      volumeMode: string;
     }[];
     conditions?: K8sResourceCondition[];
     observedGeneration?: number;

--- a/packages/shared/src/constants/k8s.ts
+++ b/packages/shared/src/constants/k8s.ts
@@ -12,3 +12,8 @@ export enum VolumeBindingMode {
   Immediate = 'Immediate',
   WaitForFirstConsumer = 'WaitForFirstConsumer',
 }
+
+export enum PVCVolumeMode {
+  Filesystem = 'Filesystem',
+  Block = 'Block',
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/DFBUGS-4065

UI retrieves all protected PVCs from the VRG's status. It then looks for PVCs that have the `ramendr.openshift.io/consistency-group` label and treats the value of that label as the name of the consistency group (CG). Then, for determining whether volume type is Block/Filesystem UI used-to-check/now-checks below respectively:

 **Previously -** If the CG name starts with `cephfs-`, the UI identifies it as a Filesystem-type CG else Block-type.

**Update -** Using PVC's `volumeMode` (https://github.com/red-hat-storage/ramen/blob/main/api/v1alpha1/volumereplicationgroup_types.go#L332) reported by VRG's status instead.