### PR TITLE
Change RHACM policy note

### DIFF
--- a/locales/en/plugin__odf-console.json
+++ b/locales/en/plugin__odf-console.json
@@ -1297,7 +1297,7 @@
   "Not validated": "Not validated",
   "NotAvailable": "NotAvailable",
   "Note:": "Note:",
-  "Note: If your cluster isn't visible on this list, verify its import status and refer to the steps outlined in the ACM documentation.": "Note: If your cluster isn't visible on this list, verify its import status and refer to the steps outlined in the ACM documentation.",
+  "Note: If your managed cluster does not appear here, confirm it is successfully imported and refer to the <2>RHACM documentation</2> for more details.": "Note: If your managed cluster does not appear here, confirm it is successfully imported and refer to the <2>RHACM documentation</2> for more details.",
   "Num Volumes": "Num Volumes",
   "Number of noncurrent versions of object.": "Number of noncurrent versions of object.",
   "Number of Volumes": "Number of Volumes",

--- a/packages/mco/components/create-dr-policy/create-dr-policy.tsx
+++ b/packages/mco/components/create-dr-policy/create-dr-policy.tsx
@@ -1,17 +1,19 @@
 import * as React from 'react';
 import { getMajorVersion } from '@odf/mco/utils';
 import {
+  ACM_DEFAULT_DOC_VERSION,
   DOC_VERSION,
   DRPolicyModel,
   getName,
   MirrorPeerModel,
   odfDRDocHome,
+  useDocVersion,
 } from '@odf/shared';
 import { StatusBox } from '@odf/shared/generic/status-box';
 import PageHeading from '@odf/shared/heading/page-heading';
 import { useFetchCsv } from '@odf/shared/hooks/use-fetch-csv';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
-import { referenceForModel } from '@odf/shared/utils';
+import { ExternalLink, referenceForModel } from '@odf/shared/utils';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { Trans } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
@@ -34,6 +36,8 @@ import {
   TextVariants,
 } from '@patternfly/react-core';
 import {
+  ACM_OPERATOR_SPEC_NAME,
+  acmDocHome,
   BackendType,
   MAX_ALLOWED_CLUSTERS,
   ODFMCO_OPERATOR,
@@ -189,7 +193,12 @@ const CreateDRPolicy: React.FC<{}> = () => {
     () => state.selectedClusters.map(getName),
     [state.selectedClusters]
   );
+  const acmDocVersion = useDocVersion({
+    defaultDocVersion: ACM_DEFAULT_DOC_VERSION,
+    specName: ACM_OPERATOR_SPEC_NAME,
+  });
 
+  const acmDoc = acmDocHome(acmDocVersion);
   return (
     <>
       <PageHeading title={t('Create DRPolicy')}>
@@ -239,9 +248,14 @@ const CreateDRPolicy: React.FC<{}> = () => {
             <FormHelperText>
               <HelperText>
                 <HelperTextItem>
-                  {t(
-                    "Note: If your cluster isn't visible on this list, verify its import status and refer to the steps outlined in the ACM documentation."
-                  )}
+                  <Trans>
+                    Note: If your managed cluster does not appear here, confirm
+                    it is successfully imported and refer to the{' '}
+                    <ExternalLink href={acmDoc}>
+                      RHACM documentation
+                    </ExternalLink>{' '}
+                    for more details.
+                  </Trans>
                 </HelperTextItem>
               </HelperText>
             </FormHelperText>


### PR DESCRIPTION
Adding a hyperlink of RHACM policy page on the note and changing it's text.
I updated the text on the DR policy page to:
"Note: If your managed cluster doesn’t appear here, confirm that it has been successfully imported and refer to the RHACM documentation for more details."
Additionally, I added a hyperlink to the words “RHACM documentation".

Jira Link:
https://issues.redhat.com/browse/DFBUGS-4005

before screenshot: 
<img width="1600" height="953" alt="image" src="https://github.com/user-attachments/assets/d94d19bb-2146-41dc-aef9-be7b5028a96d" />



