### PR TITLE
DFBUGS-4131: [backport to 4.19 compatibility ]Add TechPreview in CreateStorageSystem page

### DIFF
--- a/packages/odf/components/create-storage-system/create-storage-system-steps/backing-storage-step/backing-storage-step.tsx
+++ b/packages/odf/components/create-storage-system/create-storage-system-steps/backing-storage-step/backing-storage-step.tsx
@@ -10,6 +10,7 @@ import { BackingStorageType, DeploymentType } from '@odf/core/types';
 import { getSupportedVendors } from '@odf/core/utils';
 import { getStorageClassDescription } from '@odf/core/utils';
 import { StorageClassWizardStepExtensionProps as ExternalStorage } from '@odf/odf-plugin-sdk/extensions';
+import { TechPreviewBadge } from '@odf/shared';
 import { RHCS_SUPPORTED_INFRA } from '@odf/shared/constants/common';
 import ResourceDropdown from '@odf/shared/dropdown/ResourceDropdown';
 import { StatusBox } from '@odf/shared/generic/status-box';
@@ -420,7 +421,14 @@ export const BackingStorage: React.FC<BackingStorageProps> = ({
       {!hasOCS && (
         <Checkbox
           id="use-external-postgress"
-          label={t('Use external PostgreSQL')}
+          label={
+            <>
+              {t('Use external PostgreSQL')}
+              <span className="pf-v5-u-ml-sm">
+                <TechPreviewBadge />
+              </span>
+            </>
+          }
           description={t(
             'Allow Noobaa to connect to an external postgres server'
           )}


### PR DESCRIPTION
[DFBUGS-4131](https://issues.redhat.com/browse/DFBUGS-4131)

Add TechPreview label in Create Storage system page next to the Use external PostgreSQL checkbox.

UI After adding the label:
<img width="1728" height="1117" alt="Screenshot 2025-09-18 at 1 50 21 PM" src="https://github.com/user-attachments/assets/db168a87-1705-4bef-8ffe-893ed596159b" />
