### PR TITLE
Fix MCG-only deployment + MultiCluster deployment

### DIFF
--- a/packages/ocs/storage-pool/StoragePoolListPage.tsx
+++ b/packages/ocs/storage-pool/StoragePoolListPage.tsx
@@ -465,7 +465,11 @@ const getResources = (
 };
 
 const StoragePoolListPage: React.FC = () => {
-  const { odfNamespace: clusterNs } = useODFNamespaceSelector();
+  const {
+    odfNamespace: clusterNs,
+    isODFNsLoaded,
+    odfNsLoadError,
+  } = useODFNamespaceSelector();
   const { systemFlags, areFlagsLoaded, flagsLoadError } =
     useODFSystemFlagsSelector();
   const clusterName = systemFlags[clusterNs]?.ocsClusterName;
@@ -497,9 +501,17 @@ const StoragePoolListPage: React.FC = () => {
     poolsFromBlock && poolsFromFS ? poolsFromBlock.concat(poolsFromFS) : [];
 
   const loaded =
-    blockPoolsLoaded && filesystemLoaded && (areFlagsLoaded || scLoaded);
+    blockPoolsLoaded &&
+    filesystemLoaded &&
+    isODFNsLoaded &&
+    (areFlagsLoaded || scLoaded);
 
-  const error = flagsLoadError || scError || blockPoolsError || filesystemError;
+  const error =
+    odfNsLoadError ||
+    flagsLoadError ||
+    scError ||
+    blockPoolsError ||
+    filesystemError;
 
   return (
     <StoragePoolList

--- a/packages/odf/components/create-storage-system/create-storage-system.tsx
+++ b/packages/odf/components/create-storage-system/create-storage-system.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react';
 import { useODFSystemFlagsSelector } from '@odf/core/redux';
-import { BackingStorageType, DeploymentType } from '@odf/core/types';
+import {
+  BackingStorageType,
+  DeploymentType,
+  StartingPoint,
+} from '@odf/core/types';
 import {
   StorageClassWizardStepExtensionProps as ExternalStorage,
   isStorageClassWizardStep,
@@ -67,9 +71,9 @@ const useIsStorageClusterCRDPresent = (): boolean => {
 
 const convertModeToDeploymentType = (mode: string): DeploymentType => {
   switch (mode) {
-    case 'storage-cluster':
+    case StartingPoint.STORAGE_CLUSTER:
       return DeploymentType.FULL;
-    case 'mcg':
+    case StartingPoint.OBJECT_STORAGE:
       return DeploymentType.MCG;
   }
 };

--- a/packages/odf/components/create-storage-system/external-systems/CreateCephSystem/CephConnectionDetails/system-connection-details.tsx
+++ b/packages/odf/components/create-storage-system/external-systems/CreateCephSystem/CephConnectionDetails/system-connection-details.tsx
@@ -62,7 +62,8 @@ export const ConnectionDetails: React.FC<ExternalComponentProps<RHCSState>> = ({
 }) => {
   const { t } = useCustomTranslation();
 
-  const { odfNamespace, isNsSafe } = useODFNamespaceSelector();
+  const { odfNamespace, isNsSafe, isODFNsLoaded, odfNsLoadError } =
+    useODFNamespaceSelector();
 
   const [pods, podsLoaded, podsLoadError] =
     useK8sGet<ListKind<PodKind>>(PodModel);
@@ -117,8 +118,8 @@ export const ConnectionDetails: React.FC<ExternalComponentProps<RHCSState>> = ({
 
   return (
     <ErrorHandler
-      error={podsLoadError || ocsCSVError || cmLoadError}
-      loaded={podsLoaded && ocsCSVLoaded && cmLoaded}
+      error={odfNsLoadError || podsLoadError || ocsCSVError || cmLoadError}
+      loaded={isODFNsLoaded && podsLoaded && ocsCSVLoaded && cmLoaded}
     >
       <Form>
         <FormGroup

--- a/packages/odf/components/create-storage-system/external-systems/CreateFlashSystem/FlashSystemConnectionDetails/system-connection-details.tsx
+++ b/packages/odf/components/create-storage-system/external-systems/CreateFlashSystem/FlashSystemConnectionDetails/system-connection-details.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import NamespaceSafetyBox from '@odf/core/components/utils/safety-box';
 import { FLASH_STORAGE_CLASS } from '@odf/core/constants/common';
 import { useSafeK8sList } from '@odf/core/hooks';
 import { DeployDataFoundationModal } from '@odf/core/modals/ConfigureDF/DeployDataFoundationModal';
@@ -165,146 +166,150 @@ export const FlashSystemConnectionDetails: React.FC = () => {
         )}
       </PageHeading>
       <div className="odf-m-pane__body">
-        <Form isWidthLimited>
-          <FormGroupController
-            control={control}
-            name="endpoint-input"
-            formGroupProps={{
-              label: t('IP address'),
-              fieldId: 'endpoint-input',
-              isRequired: true,
-              helperText: t('Rest API IP address of IBM FlashSystem.'),
-            }}
-            render={({ value, onChange, onBlur }) => (
-              <TextInput
-                id="endpoint-input"
-                type="text"
-                value={value}
-                onChange={(_event, newValue: string) => {
-                  onChange(newValue);
-                  updateFormField('endpoint', newValue);
-                }}
-                onBlur={onBlur}
-                isRequired
-              />
-            )}
-          />
-          <FormGroupController
-            name="username-input"
-            control={control}
-            formGroupProps={{
-              label: t('Username'),
-              isRequired: true,
-              fieldId: 'username-input',
-            }}
-            render={({ value, onChange, onBlur }) => (
-              <TextInput
-                id="username-input"
-                value={value}
-                type="text"
-                onChange={(_event, newValue: string) => {
-                  onChange(newValue);
-                  updateFormField('username', newValue);
-                }}
-                onBlur={onBlur}
-                isRequired
-              />
-            )}
-          />
-          <FormGroupController
-            name="password-input"
-            control={control}
-            formGroupProps={{
-              label: t('Password'),
-              isRequired: true,
-              fieldId: 'password-input',
-            }}
-            render={({ value, onChange, onBlur }) => (
-              <InputGroup>
-                <InputGroupItem isFill>
-                  <TextInput
-                    id="password-input"
-                    value={value}
-                    type={reveal ? 'text' : 'password'}
-                    onChange={(_event, newValue: string) => {
-                      onChange(newValue);
-                      updateFormField('password', newValue);
-                    }}
-                    onBlur={onBlur}
-                    isRequired
-                  />
-                </InputGroupItem>
-                <InputGroupItem>
-                  <Tooltip
-                    content={reveal ? t('Hide password') : t('Reveal password')}
-                  >
-                    <Button
-                      variant="control"
-                      onClick={() => setReveal(!reveal)}
+        <NamespaceSafetyBox>
+          <Form isWidthLimited>
+            <FormGroupController
+              control={control}
+              name="endpoint-input"
+              formGroupProps={{
+                label: t('IP address'),
+                fieldId: 'endpoint-input',
+                isRequired: true,
+                helperText: t('Rest API IP address of IBM FlashSystem.'),
+              }}
+              render={({ value, onChange, onBlur }) => (
+                <TextInput
+                  id="endpoint-input"
+                  type="text"
+                  value={value}
+                  onChange={(_event, newValue: string) => {
+                    onChange(newValue);
+                    updateFormField('endpoint', newValue);
+                  }}
+                  onBlur={onBlur}
+                  isRequired
+                />
+              )}
+            />
+            <FormGroupController
+              name="username-input"
+              control={control}
+              formGroupProps={{
+                label: t('Username'),
+                isRequired: true,
+                fieldId: 'username-input',
+              }}
+              render={({ value, onChange, onBlur }) => (
+                <TextInput
+                  id="username-input"
+                  value={value}
+                  type="text"
+                  onChange={(_event, newValue: string) => {
+                    onChange(newValue);
+                    updateFormField('username', newValue);
+                  }}
+                  onBlur={onBlur}
+                  isRequired
+                />
+              )}
+            />
+            <FormGroupController
+              name="password-input"
+              control={control}
+              formGroupProps={{
+                label: t('Password'),
+                isRequired: true,
+                fieldId: 'password-input',
+              }}
+              render={({ value, onChange, onBlur }) => (
+                <InputGroup>
+                  <InputGroupItem isFill>
+                    <TextInput
+                      id="password-input"
+                      value={value}
+                      type={reveal ? 'text' : 'password'}
+                      onChange={(_event, newValue: string) => {
+                        onChange(newValue);
+                        updateFormField('password', newValue);
+                      }}
+                      onBlur={onBlur}
+                      isRequired
+                    />
+                  </InputGroupItem>
+                  <InputGroupItem>
+                    <Tooltip
+                      content={
+                        reveal ? t('Hide password') : t('Reveal password')
+                      }
                     >
-                      {reveal ? <EyeSlashIcon /> : <EyeIcon />}
-                    </Button>
-                  </Tooltip>
-                </InputGroupItem>
-              </InputGroup>
-            )}
-          />
+                      <Button
+                        variant="control"
+                        onClick={() => setReveal(!reveal)}
+                      >
+                        {reveal ? <EyeSlashIcon /> : <EyeIcon />}
+                      </Button>
+                    </Tooltip>
+                  </InputGroupItem>
+                </InputGroup>
+              )}
+            />
 
-          <FormGroupController
-            name="poolname-input"
-            control={control}
-            formGroupProps={{
-              label: t('Pool name'),
-              isRequired: true,
-              fieldId: 'poolname-input',
-            }}
-            render={({ value, onChange, onBlur }) => (
-              <TextInput
-                id="poolname-input"
-                value={value}
-                type="text"
-                onChange={(_event, newValue: string) => {
-                  onChange(newValue);
-                  updateFormField('poolname', newValue);
-                }}
-                onBlur={onBlur}
-                isRequired
-              />
+            <FormGroupController
+              name="poolname-input"
+              control={control}
+              formGroupProps={{
+                label: t('Pool name'),
+                isRequired: true,
+                fieldId: 'poolname-input',
+              }}
+              render={({ value, onChange, onBlur }) => (
+                <TextInput
+                  id="poolname-input"
+                  value={value}
+                  type="text"
+                  onChange={(_event, newValue: string) => {
+                    onChange(newValue);
+                    updateFormField('poolname', newValue);
+                  }}
+                  onBlur={onBlur}
+                  isRequired
+                />
+              )}
+            />
+            <FormGroup label={t('Volume mode')} fieldId="volume-mode-input">
+              <Select
+                onSelect={onModeSelect}
+                id="volume-mode-input"
+                selections={inverseVolumeMapper[formState.volmode]}
+                onToggle={onToggle}
+                isOpen={isOpen}
+                isDisabled={false}
+                placeholderText={Object.keys(volumeMapper)[0]}
+              >
+                {Object.keys(volumeMapper).map((mode) => (
+                  <SelectOption key={mode} value={mode} />
+                ))}
+              </Select>
+            </FormGroup>
+            {error && (
+              <Alert variant={AlertVariant.danger} isInline title={error} />
             )}
-          />
-          <FormGroup label={t('Volume mode')} fieldId="volume-mode-input">
-            <Select
-              onSelect={onModeSelect}
-              id="volume-mode-input"
-              selections={inverseVolumeMapper[formState.volmode]}
-              onToggle={onToggle}
-              isOpen={isOpen}
-              isDisabled={false}
-              placeholderText={Object.keys(volumeMapper)[0]}
-            >
-              {Object.keys(volumeMapper).map((mode) => (
-                <SelectOption key={mode} value={mode} />
-              ))}
-            </Select>
-          </FormGroup>
-          {error && (
-            <Alert variant={AlertVariant.danger} isInline title={error} />
-          )}
-          <ActionGroup>
-            <Button
-              isLoading={isLoading}
-              spinnerAriaLabel={t('Connecting')}
-              onClick={onSubmit}
-              variant={ButtonVariant.primary}
-              isDisabled={isLoading || !isValid}
-            >
-              {isLoading ? t('Connecting') : t('Connect')}
-            </Button>
-            <Button onClick={() => navigate(-1)} variant={ButtonVariant.link}>
-              {t('Cancel')}
-            </Button>
-          </ActionGroup>
-        </Form>
+            <ActionGroup>
+              <Button
+                isLoading={isLoading}
+                spinnerAriaLabel={t('Connecting')}
+                onClick={onSubmit}
+                variant={ButtonVariant.primary}
+                isDisabled={isLoading || !isValid}
+              >
+                {isLoading ? t('Connecting') : t('Connect')}
+              </Button>
+              <Button onClick={() => navigate(-1)} variant={ButtonVariant.link}>
+                {t('Cancel')}
+              </Button>
+            </ActionGroup>
+          </Form>
+        </NamespaceSafetyBox>
       </div>
     </>
   );

--- a/packages/odf/components/storage-consumers/CreateStorageConsumer.tsx
+++ b/packages/odf/components/storage-consumers/CreateStorageConsumer.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import NamespaceSafetyBox from '@odf/core/components/utils/safety-box';
 import { DiskSize } from '@odf/core/constants';
 import {
   useODFNamespaceSelector,
@@ -163,41 +164,43 @@ const CreateStorageConsumer: React.FC = () => {
       <TextContent className="odf-m-pane__heading odf-m-pane__heading--baseline">
         <Text component={TextVariants.h1}>{t('Create StorageConsumer')}</Text>
       </TextContent>
-      <Form onSubmit={handleSubmit(onSubmit)}>
-        <TextInputWithFieldRequirements
-          control={control}
-          fieldRequirements={fieldRequirements}
-          popoverProps={{
-            headerContent: t('Name requirements'),
-            footerContent: `${exampleTranslatedText}: stark-lab-consumer`,
-          }}
-          formGroupProps={{
-            label: t('StorageConsumer Name'),
-            fieldId: 'storageconsumer-name',
-            className: 'control-label',
-          }}
-          textInputProps={{
-            id: 'storageconsumer-name',
-            name: 'storageconsumerName',
-            className: 'pf-v5-c-form-control',
-            type: 'text',
-            placeholder: t('stark-lab-storage-consumer'),
-            'data-test': 'storage-consumer-name',
-            isRequired: true,
-          }}
-        />
-        <StorageQuotaBody quota={quota} setQuota={setQuota} />
-        <ButtonBar errorMessage={error} inProgress={progress}>
-          <ActionGroup className="pf-v5-c-form">
-            <Button id="submit-btn" type="submit" variant="primary">
-              {t('Create')}
-            </Button>
-            <Button onClick={() => navigate(-1)} variant="secondary">
-              {t('Cancel')}
-            </Button>
-          </ActionGroup>
-        </ButtonBar>
-      </Form>
+      <NamespaceSafetyBox>
+        <Form onSubmit={handleSubmit(onSubmit)}>
+          <TextInputWithFieldRequirements
+            control={control}
+            fieldRequirements={fieldRequirements}
+            popoverProps={{
+              headerContent: t('Name requirements'),
+              footerContent: `${exampleTranslatedText}: stark-lab-consumer`,
+            }}
+            formGroupProps={{
+              label: t('StorageConsumer Name'),
+              fieldId: 'storageconsumer-name',
+              className: 'control-label',
+            }}
+            textInputProps={{
+              id: 'storageconsumer-name',
+              name: 'storageconsumerName',
+              className: 'pf-v5-c-form-control',
+              type: 'text',
+              placeholder: t('stark-lab-storage-consumer'),
+              'data-test': 'storage-consumer-name',
+              isRequired: true,
+            }}
+          />
+          <StorageQuotaBody quota={quota} setQuota={setQuota} />
+          <ButtonBar errorMessage={error} inProgress={progress}>
+            <ActionGroup className="pf-v5-c-form">
+              <Button id="submit-btn" type="submit" variant="primary">
+                {t('Create')}
+              </Button>
+              <Button onClick={() => navigate(-1)} variant="secondary">
+                {t('Cancel')}
+              </Button>
+            </ActionGroup>
+          </ButtonBar>
+        </Form>
+      </NamespaceSafetyBox>
     </div>
   );
 };

--- a/packages/odf/components/storage-consumers/rotate-keys-modal.tsx
+++ b/packages/odf/components/storage-consumers/rotate-keys-modal.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import NamespaceSafetyBox from '@odf/core/components/utils/safety-box';
 import { ModalFooter } from '@odf/shared/generic';
 import { ModalBody, ModalTitle } from '@odf/shared/generic/ModalTitle';
 import { SecretModel } from '@odf/shared/models';
@@ -52,34 +53,36 @@ export const RotateKeysModal: RotateKeysModalProps = ({
   return (
     <Modal isOpen={isOpen} onClose={closeModal} variant={ModalVariant.medium}>
       <ModalTitle>{MODAL_TITLE}</ModalTitle>
-      <ModalBody>
-        <Flex direction={{ default: 'column' }}>
-          <FlexItem grow={{ default: 'grow' }}>
-            <div>
-              {t(
-                'This action will rotate the signing key currently used for generating and validating client onboarding tokens.'
-              )}
-            </div>
-            <div>
-              {t(
-                'Upon rotation, the existing signing key will be revoked and replaced with a new one.'
-              )}
-            </div>
-          </FlexItem>
-        </Flex>
-      </ModalBody>
-      <ModalFooter inProgress={inProgress} errorMessage={error?.message}>
-        <Flex direction={{ default: 'row' }}>
-          <FlexItem>
-            <Button variant="secondary" onClick={() => closeModal()}>
-              {t('Cancel')}
-            </Button>
-          </FlexItem>
-          <FlexItem>
-            <Button onClick={() => onRotate()}>{t('Confirm')}</Button>
-          </FlexItem>
-        </Flex>
-      </ModalFooter>
+      <NamespaceSafetyBox>
+        <ModalBody>
+          <Flex direction={{ default: 'column' }}>
+            <FlexItem grow={{ default: 'grow' }}>
+              <div>
+                {t(
+                  'This action will rotate the signing key currently used for generating and validating client onboarding tokens.'
+                )}
+              </div>
+              <div>
+                {t(
+                  'Upon rotation, the existing signing key will be revoked and replaced with a new one.'
+                )}
+              </div>
+            </FlexItem>
+          </Flex>
+        </ModalBody>
+        <ModalFooter inProgress={inProgress} errorMessage={error?.message}>
+          <Flex direction={{ default: 'row' }}>
+            <FlexItem>
+              <Button variant="secondary" onClick={() => closeModal()}>
+                {t('Cancel')}
+              </Button>
+            </FlexItem>
+            <FlexItem>
+              <Button onClick={() => onRotate()}>{t('Confirm')}</Button>
+            </FlexItem>
+          </Flex>
+        </ModalFooter>
+      </NamespaceSafetyBox>
     </Modal>
   );
 };

--- a/packages/odf/components/storage-consumers/update-storage-quota-modal.tsx
+++ b/packages/odf/components/storage-consumers/update-storage-quota-modal.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import NamespaceSafetyBox from '@odf/core/components/utils/safety-box';
 import { DiskSize as QuotaSize } from '@odf/core/constants';
 import { useRawCapacity } from '@odf/core/hooks';
 import {
@@ -180,11 +181,13 @@ const AvailableCapacity: React.FC = () => {
     icon = <BlueInfoCircleIcon />;
   }
   return (
-    <StatusIconAndText
-      title={title}
-      icon={icon}
-      className="text-muted pf-v5-u-font-size-sm odf-onboarding-modal__info-icon"
-    />
+    <NamespaceSafetyBox>
+      <StatusIconAndText
+        title={title}
+        icon={icon}
+        className="text-muted pf-v5-u-font-size-sm odf-onboarding-modal__info-icon"
+      />
+    </NamespaceSafetyBox>
   );
 };
 

--- a/packages/odf/modals/ConfigureDF/StorageClusterCreateModal.tsx
+++ b/packages/odf/modals/ConfigureDF/StorageClusterCreateModal.tsx
@@ -58,7 +58,7 @@ export const ConfigureDFSelections: React.FC<ConfigureDFSelectionsProps> = ({
           <CardHeader
             selectableActions={{
               onClickAction: redirectTo(StartingPoint.STORAGE_CLUSTER),
-              selectableActionId: 'storage-cluster',
+              selectableActionId: StartingPoint.STORAGE_CLUSTER,
             }}
           >
             <CardTitle>{t('Create Storage Cluster')}</CardTitle>
@@ -108,7 +108,7 @@ export const ConfigureDFSelections: React.FC<ConfigureDFSelectionsProps> = ({
           <CardHeader
             selectableActions={{
               onClickAction: redirectTo(StartingPoint.OBJECT_STORAGE),
-              selectableActionId: 'object-storage',
+              selectableActionId: StartingPoint.OBJECT_STORAGE,
             }}
           >
             <CardTitle>{t('Setup Multicloud Object Gateway')}</CardTitle>

--- a/packages/odf/modals/ConfigureDF/util.ts
+++ b/packages/odf/modals/ConfigureDF/util.ts
@@ -4,16 +4,5 @@ import { StartingPoint } from '@odf/core/types/install-ui';
 export const getModalStartPoint = (pathname: string): StartingPoint => {
   const pathParts = pathname.split('/');
   const lastPart = pathParts.pop();
-  switch (lastPart) {
-    case 'storage-cluster':
-      return StartingPoint.STORAGE_CLUSTER;
-    case 'overview':
-      return StartingPoint.OVERVIEW;
-    case 'external-systems':
-      return StartingPoint.EXTERNAL_SYSTEMS;
-    case 'object-storage':
-      return StartingPoint.OBJECT_STORAGE;
-    default:
-      return StartingPoint.OVERVIEW;
-  }
+  return StartingPoint[lastPart] || StartingPoint.OVERVIEW;
 };

--- a/packages/odf/types/index.ts
+++ b/packages/odf/types/index.ts
@@ -6,3 +6,4 @@ export * from './network';
 export * from './mcg';
 export * from './storage-consumer';
 export * from './s3-browser';
+export * from './install-ui';

--- a/packages/odf/types/install-ui.ts
+++ b/packages/odf/types/install-ui.ts
@@ -2,6 +2,6 @@
 export enum StartingPoint {
   OVERVIEW = 'overview',
   STORAGE_CLUSTER = 'storage-cluster',
-  OBJECT_STORAGE = 'object-storage', // Fusion only
+  OBJECT_STORAGE = 'object-storage',
   EXTERNAL_SYSTEMS = 'external-systems',
 }

--- a/plugins/odf/console-extensions.json
+++ b/plugins/odf/console-extensions.json
@@ -119,7 +119,7 @@
       "href": "/odf/object-storage"
     },
     "flags": {
-      "required": ["ODF_MODEL", "ODF_ADMIN"]
+      "required": ["ODF_MODEL"]
     }
   },
   {
@@ -520,7 +520,8 @@
       "component": { "$codeRef": "objectService.default" }
     },
     "flags": {
-      "required": ["ODF_MODEL"]
+      "required": ["ODF_MODEL"],
+      "disallowed": ["ODF_ADMIN"]
     }
   },
   {


### PR DESCRIPTION
https://issues.redhat.com/browse/DFBUGS-4141
https://issues.redhat.com/browse/DFBUGS-4139

Introduced changes:
- Adds `NamespaceSafetyBox` wrapper and `useODFNamespaceSelector` loading/error states (unrelated to this bug fix, but good/imp to have, we missed it at many places).
- Enable `Object storage` nav item for non-admin (unrelated to this bug fix, but imp to have, we disabled it by mistake).
- Fixes MCG-only deployment flow and shifted to `StartingPoint` enum every where to reduce such bugs.
- Fixes multi-cluster (external) deployment flow -
   - Namespace was not getting created.
   - Namespace was not getting labelled with cluster monitoring label.

<img width="1728" height="1030" alt="Screenshot 2025-09-19 at 4 47 27 PM" src="https://github.com/user-attachments/assets/6afa8dc8-f615-4941-a8d7-1719a31809f5" />
<img width="1718" height="1041" alt="Screenshot 2025-09-23 at 2 29 39 PM" src="https://github.com/user-attachments/assets/c13fff02-4663-4e68-ad8e-f3ffc4d9deb6" />

