### PR TITLE
DFBUGS-4088: [release 4.17] Add TechPreview in CreateStorageSystem page

### DIFF
--- a/packages/odf/components/create-storage-system/create-storage-system-steps/backing-storage-step/backing-storage-step.tsx
+++ b/packages/odf/components/create-storage-system/create-storage-system-steps/backing-storage-step/backing-storage-step.tsx
@@ -11,6 +11,7 @@ import { BackingStorageType, DeploymentType } from '@odf/core/types';
 import { getSupportedVendors } from '@odf/core/utils';
 import { getStorageClassDescription } from '@odf/core/utils';
 import { StorageClassWizardStepExtensionProps as ExternalStorage } from '@odf/odf-plugin-sdk/extensions';
+import { TechPreviewBadge } from '@odf/shared';
 import ResourceDropdown from '@odf/shared/dropdown/ResourceDropdown';
 import { useK8sGet } from '@odf/shared/hooks/k8s-get-hook';
 import {
@@ -425,7 +426,14 @@ export const BackingStorage: React.FC<BackingStorageProps> = ({
         {!hasOCS && (
           <Checkbox
             id="use-external-postgress"
-            label={t('Use external PostgreSQL')}
+            label={
+              <>
+                {t('Use external PostgreSQL')}
+                <span className="pf-v5-u-ml-sm">
+                  <TechPreviewBadge />
+                </span>
+              </>
+            }
             description={t(
               'Allow Noobaa to connect to an external postgres server'
             )}


### PR DESCRIPTION
[DFBUGS-4088](https://issues.redhat.com/browse/DFBUGS-4088)

Add TechPreview label in Create Storage system page next to the Use external PostgreSQL checkbox.

UI After adding the label:
<img width="1728" height="1117" alt="417" src="https://github.com/user-attachments/assets/ec0e360d-2bb1-4042-8d3a-64fb0ab4964f" />
