### PR TITLE
DFBUGS-4089: [release 4.16 compatibility ] Add TechPreview in CreateStorageSystem page

### DIFF
--- a/packages/odf/components/create-storage-system/create-storage-system-steps/backing-storage-step/backing-storage-step.tsx
+++ b/packages/odf/components/create-storage-system/create-storage-system-steps/backing-storage-step/backing-storage-step.tsx
@@ -10,6 +10,7 @@ import { BackingStorageType, DeploymentType } from '@odf/core/types';
 import { getSupportedVendors } from '@odf/core/utils';
 import { getStorageClassDescription } from '@odf/core/utils';
 import { StorageClassWizardStepExtensionProps as ExternalStorage } from '@odf/odf-plugin-sdk/extensions';
+import { TechPreviewBadge } from '@odf/shared';
 import ResourceDropdown from '@odf/shared/dropdown/ResourceDropdown';
 import { useK8sGet } from '@odf/shared/hooks/k8s-get-hook';
 import {
@@ -418,7 +419,14 @@ export const BackingStorage: React.FC<BackingStorageProps> = ({
         {!hasOCS && (
           <Checkbox
             id="use-external-postgress"
-            label={t('Use external PostgreSQL')}
+            label={
+              <>
+                {t('Use external PostgreSQL')}
+                <span className="pf-v5-u-ml-sm">
+                  <TechPreviewBadge />
+                </span>
+              </>
+            }
             description={t(
               'Allow Noobaa to connect to an external postgres server'
             )}


### PR DESCRIPTION
[DFBUGS-4089](https://issues.redhat.com/browse/DFBUGS-4089)

Add TechPreview label in Create Storage system page next to the Use external PostgreSQL checkbox.

UI After adding the label:
<img width="1728" height="1117" alt="416 compatibility" src="https://github.com/user-attachments/assets/5777f19c-aaea-4bd2-82e3-bf2099488488" />
