### PR TITLE
Stop setting target size ratio for custompools created by UI

### DIFF
--- a/packages/ocs/storage-pool/CreateStoragePool.tsx
+++ b/packages/ocs/storage-pool/CreateStoragePool.tsx
@@ -109,7 +109,6 @@ export const getPoolKindObj = (
     },
     replicated: {
       size: Number(state.replicaSize),
-      targetSizeRatio: 0.49,
     },
   },
 });

--- a/packages/shared/src/types/storage.ts
+++ b/packages/shared/src/types/storage.ts
@@ -9,7 +9,6 @@ export type DataPool = {
   name?: string;
   replicated?: {
     size: number;
-    targetSizeRatio?: number;
   };
 };
 


### PR DESCRIPTION
Recently after a lot of discussion, it was decided that ODF might be better of without setting the target size ratio for pools created by it.
Ref-https://issues.redhat.com/browse/DFBUGS-2665