### PR TITLE
DFBUGS-2803: [release-4.19-compatibility] Modify kebab menu in external mode.

### DIFF
--- a/packages/odf/components/system-list/odf-system-list.tsx
+++ b/packages/odf/components/system-list/odf-system-list.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
 import { LSO_OPERATOR, CREATE_SS_PAGE_URL } from '@odf/core/constants';
 import { storageClusterResource } from '@odf/core/resources';
-import { isCapacityAutoScalingAllowed } from '@odf/core/utils';
+import {
+  isCapacityAutoScalingAllowed,
+  isExternalCluster,
+} from '@odf/core/utils';
 import {
   DEFAULT_INFRASTRUCTURE,
   InfrastructureKind,
@@ -274,32 +277,39 @@ const StorageSystemRow: React.FC<RowProps<StorageSystemKind, CustomData>> = ({
     (storageClusterItem) => getName(storageClusterItem) === obj.spec.name
   );
 
+  const isExternalMode = isExternalCluster(storageCluster);
+
   const resourceProfile = storageCluster?.spec?.resourceProfile;
-  const customKebabItems: CustomKebabItem[] = [
-    {
-      key: 'ADD_CAPACITY',
-      value: t('Add Capacity'),
-      component: React.lazy(
-        () => import('./../../modals/add-capacity/add-capacity-modal')
-      ),
-    },
-    {
-      key: 'CONFIGURE_PERFORMANCE',
-      value: t('Configure performance'),
-      component: React.lazy(
-        () =>
-          import(
-            '@odf/core/modals/configure-performance/configure-performance-modal'
-          )
-      ),
-    },
-  ];
+  const customKebabItems: CustomKebabItem[] = [];
+
+  if (!isExternalMode) {
+    customKebabItems.push(
+      {
+        key: 'ADD_CAPACITY',
+        value: t('Add Capacity'),
+        component: React.lazy(
+          () => import('./../../modals/add-capacity/add-capacity-modal')
+        ),
+      },
+      {
+        key: 'CONFIGURE_PERFORMANCE',
+        value: t('Configure performance'),
+        component: React.lazy(
+          () =>
+            import(
+              '@odf/core/modals/configure-performance/configure-performance-modal'
+            )
+        ),
+      }
+    );
+  }
 
   if (
     isCapacityAutoScalingAllowed(
       getInfrastructurePlatform(infrastructure),
       resourceProfile
-    )
+    ) &&
+    !isExternalMode
   ) {
     customKebabItems.push({
       key: 'CAPACITY_AUTOSCALING',
@@ -312,7 +322,7 @@ const StorageSystemRow: React.FC<RowProps<StorageSystemKind, CustomData>> = ({
       ),
     });
   }
-  if (isLSOInstalled) {
+  if (isLSOInstalled && !isExternalMode) {
     customKebabItems.push({
       key: 'ATTACH_STORAGE',
       value: t('Attach Storage'),


### PR DESCRIPTION
https://issues.redhat.com/browse/DFBUGS-2803

Remove Add capacity, Configure performance, Attach Storage and Automatic capacity scaling from kebab menu of storage system in external mode.

Changes are tested by temporarily setting the
**const isExternalMode = isExternalCluster(storageCluster) || true;** in external mode. and
**const isExternalMode = isExternalCluster(storageCluster) && false;** in normal mode. in
**packages/odf/components/system-list/odf-system-list.tsx** file
**UI in external mode:**
<img width="1728" height="1117" alt="Screenshot 2025-10-14 at 3 33 01 PM" src="https://github.com/user-attachments/assets/2f9198ab-718b-445a-9244-35692c4de453" />


**UI in Normal mode**
<img width="1728" height="1117" alt="Screenshot 2025-10-14 at 3 34 16 PM" src="https://github.com/user-attachments/assets/d5e08c2f-1dc9-4369-9ddb-6fa86e5bcabd" />

