### PR TITLE
Changes to cluster validator for third party storage

### DIFF
--- a/packages/mco/components/create-dr-policy/selected-cluster-validator.tsx
+++ b/packages/mco/components/create-dr-policy/selected-cluster-validator.tsx
@@ -473,20 +473,26 @@ export const SelectedClusterValidation: React.FC<
   // Determine selection validity
   const isSelectionValid = !isInvalidPeering && !invalidClusters.length;
 
+  // Either of the clusters lack ODF
+  const eitherClustersWithoutODF = selectedClusters.some((cluster) =>
+    clusterValidation.clustersWithoutODF.includes(getName(cluster))
+  );
+
   // Dispatch selection validation state
   React.useEffect(() => {
     if (loaded && !loadError) {
       dispatch({
         type: DRPolicyActionType.SET_CLUSTER_SELECTION_VALIDATION,
-        payload: isSelectionValid,
+        payload: isSelectionValid || eitherClustersWithoutODF,
       });
     }
   }, [isSelectionValid, loaded, loadError, dispatch]);
 
   // Check for version mismatch
-  const isVersionMismatch =
-    selectedClusters[0]?.odfInfo?.odfVersion !==
-    selectedClusters[1]?.odfInfo?.odfVersion;
+  const isVersionMismatch = eitherClustersWithoutODF
+    ? false
+    : selectedClusters[0]?.odfInfo?.odfVersion !==
+      selectedClusters[1]?.odfInfo?.odfVersion;
 
   return (
     <StatusBox
@@ -502,7 +508,7 @@ export const SelectedClusterValidation: React.FC<
         />
       }
     >
-      {isSelectionValid ? (
+      {isSelectionValid || eitherClustersWithoutODF ? (
         <>
           <Alert
             data-test="odf-not-found-alert"

--- a/packages/mco/hooks/use-storage-provisioner.ts
+++ b/packages/mco/hooks/use-storage-provisioner.ts
@@ -52,29 +52,22 @@ export function useStorageProvisioners(clusters: string[]): {
 
   const providersByCluster = React.useMemo<ClusterProviders[]>(() => {
     if (!loaded) return [];
-
     const supportedProvisioners = [...CEPH_PROVISIONERS, ...IBM_PROVISIONERS];
-
     return Object.entries(itemsByCluster).map(([cluster, items]) => {
-      const odfCount = items.filter((i) =>
-        supportedProvisioners.includes(i.provisioner)
-      ).length;
-
-      const tpMap = new Map<string, number>();
+      const provMap = new Map<string, number>();
       items.forEach(({ provisioner }) => {
-        if (!supportedProvisioners.includes(provisioner)) {
-          tpMap.set(provisioner, (tpMap.get(provisioner) || 0) + 1);
-        }
+        const isODF = supportedProvisioners.some((sp) =>
+          provisioner.includes(sp)
+        );
+        const displayName = isODF
+          ? `${provisioner} [Data Foundation]`
+          : provisioner;
+        provMap.set(displayName, (provMap.get(displayName) || 0) + 1);
       });
-
       const provs: Provider[] = [];
-      if (odfCount > 0) {
-        provs.push({ displayName: 'Data Foundation', count: odfCount });
-      }
-      tpMap.forEach((cnt, prov) =>
+      provMap.forEach((cnt, prov) =>
         provs.push({ displayName: prov, count: cnt })
       );
-
       return { cluster, providers: provs };
     });
   }, [loaded, itemsByCluster]);


### PR DESCRIPTION
- Allow DR policy creation to proceed when clusters lack ODF storage
- Add eitherClustersWithoutODF check to determine if any selected cluster is missing ODF provisioners
- Skip ODF version mismatch validation when either cluster lacks ODF
- Update selection validation to pass when clusters are valid OR lack ODF

This provides better visibility into specific storage provisioners while gracefully handling non-ODF cluster configurations.