### PR TITLE
DFBUGS-3998: [release-4.19-compatibility] prevent duplicate MirrorPeer creation by fixing ODF peer name comparison

### DIFF
--- a/packages/mco/components/create-dr-policy/utils/k8s-utils.ts
+++ b/packages/mco/components/create-dr-policy/utils/k8s-utils.ts
@@ -112,8 +112,8 @@ export const createPolicyPromises = (
       peerNames
     )
   );
-  const odfPeerNames: string[] = state.selectedClusters.map((cluster) =>
-    getODFPeers(cluster).join(',')
+  const odfPeerNames: string[] = state.selectedClusters.map(
+    (cluster) => getODFPeers(cluster)[0]
   );
   const mirrorPeer: MirrorPeerKind = fetchMirrorPeer(
     mirrorPeers,


### PR DESCRIPTION
The MirrorPeer existence check was failing because odfPeerNames included a trailing comma (name,namespace) while existing CRs contain only the storageCluster name (no namespace). This mismatch caused fetchMirrorPeer to return undefined and led to unintended creation of new MirrorPeer resources.