### PR TITLE
Fallback to node CR when Prometheus unavailable

### DIFF
--- a/packages/odf/hooks/useNodesData.spec.ts
+++ b/packages/odf/hooks/useNodesData.spec.ts
@@ -84,4 +84,20 @@ describe('useNodesData', () => {
     const [nodesData] = result.current;
     expect(nodesData).toStrictEqual([]);
   });
+
+  it('returns nodes when prom response errors out', () => {
+    const nodes = createFakeNodes(1, cpu, memory);
+    (useK8sWatchResource as jest.Mock).mockReturnValue([nodes, true, null]);
+    (useCustomPrometheusPoll as jest.Mock).mockReturnValue([
+      null,
+      new Error('Bad Gateway'),
+      false,
+    ]);
+
+    const { result } = renderHook(() => useNodesData());
+    const [nodesData, loaded] = result.current;
+    expect(nodesData).toHaveLength(1);
+    expect(nodesData[0].metrics.memory).toBeUndefined();
+    expect(loaded).toBe(true);
+  });
 });

--- a/packages/odf/hooks/useNodesData.ts
+++ b/packages/odf/hooks/useNodesData.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { nodeResource } from '@odf/core/resources';
+import { getName } from '@odf/shared';
 import {
   useCustomPrometheusPoll,
   usePrometheusBasePath,
@@ -25,18 +26,19 @@ export const useNodesData = (
 ): [NodeData[], boolean, any] => {
   const [nodes, nodesLoaded, nodesLoadError] =
     useK8sWatchResource<NodeKind[]>(nodeResource);
-  const [utilization, promError, promLoading] = useCustomPrometheusPoll({
+  const [utilization, , promLoading] = useCustomPrometheusPoll({
     query: allNodesUtilizationQueries[NodeQueries.ALL_NODES_MEMORY_TOTAL],
     endpoint: 'api/v1/query' as any,
     basePath: usePrometheusBasePath(),
   });
 
   const loaded = nodesLoaded && !promLoading;
-  const error = nodesLoadError || promError;
+  const error = nodesLoadError;
+
   const nodesData = React.useMemo(() => {
     let nodesData = [];
-    // For data consistency, we must return nodes with their metrics.
-    if (nodes && utilization && loaded && !error) {
+    // Fallback to node.status.capacity when prometheus is unavailable
+    if (nodes && loaded && !error) {
       nodesData = nodes
         .filter(
           (node) =>
@@ -46,9 +48,9 @@ export const useNodesData = (
             )
         )
         .map((node: Partial<NodeData>): NodeData => {
-          const metric = _.find(utilization.data.result, [
+          const metric = _.find(utilization?.data?.result || [], [
             'metric.instance',
-            node.metadata.name,
+            getName(node),
           ]);
           node['metrics'] = { memory: metric ? metric.value[1] : undefined };
           return node as NodeData;


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/DFBUGS-4424

On ROSA HCP clusters, Prometheus may be unreachable causing
node selection table to fail during storage system creation.

Modified useNodesData to check for prometheus errors and return
nodes with undefined metrics, allowing fallback to node.status.capacity.