### PR TITLE
Change the resource requirement base calculation from 6 to 3 OSDs

### DIFF
--- a/packages/odf/components/create-storage-system/create-storage-system-steps/capacity-and-nodes-step/configure-performance.spec.tsx
+++ b/packages/odf/components/create-storage-system/create-storage-system-steps/capacity-and-nodes-step/configure-performance.spec.tsx
@@ -118,7 +118,7 @@ describe('Configure Performance', () => {
       name: /options menu/i,
     });
     expect(dropdown).toHaveTextContent('Balanced mode');
-    expect(screen.getByText(/36 CPUs/i)).toBeInTheDocument();
-    expect(screen.getByText(/87 GiB/i)).toBeInTheDocument();
+    expect(screen.getByText(/42 CPUs/i)).toBeInTheDocument();
+    expect(screen.getByText(/102 GiB/i)).toBeInTheDocument();
   });
 });

--- a/packages/odf/utils/ocs.ts
+++ b/packages/odf/utils/ocs.ts
@@ -114,14 +114,14 @@ export const isFlexibleScaling = (
 
 /**
  * Returns the minimum required resources taking into account the OSD pods.
- * Default requirements assume 6 OSDs deployed.
+ * Default requirements assume 3 OSDs deployed.
  */
 export const getResourceProfileRequirements = (
   profile: ResourceProfile,
   osdAmount: number
 ): { minCpu: number; minMem: number } => {
   const { minCpu, minMem, osd } = RESOURCE_PROFILE_REQUIREMENTS_MAP[profile];
-  const extraOsds = osdAmount - 6;
+  const extraOsds = osdAmount - 3;
   let cpu = minCpu;
   let mem = minMem;
   if (extraOsds > 0) {


### PR DESCRIPTION
In 4.16 when we implemented this change we had assumed the base to be 6 OSDs, but since than we have added a lot more pods to the ODF deployment.
The ODF docs also mention the resource requirement to be based on 3 OSDs
Ref-https://issues.redhat.com/browse/DFBUGS-4484