### PR TITLE
Fix the status input for update access key from access key card

### DIFF
--- a/packages/odf/components/s3-iam/access-keys-details/AccessKeyCard.tsx
+++ b/packages/odf/components/s3-iam/access-keys-details/AccessKeyCard.tsx
@@ -96,7 +96,10 @@ const HeaderActions: React.FC<HeaderProps> = ({ headerProps }) => {
               extraProps: {
                 name: accessKeyCard.UserName,
                 AccessKeyId: accessKeyCard.AccessKeyId,
-                status: accessKeyCard.Status,
+                status:
+                  accessKeyCard.Status === AccessKeyStatus.ACTIVE
+                    ? AccessKeyStatus.INACTIVE
+                    : AccessKeyStatus.ACTIVE,
                 iamClient,
               },
             })

--- a/packages/odf/modals/s3-iam/UpdateAccessKeyModal.tsx
+++ b/packages/odf/modals/s3-iam/UpdateAccessKeyModal.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { StatusType } from '@aws-sdk/client-iam';
 import { AccessKeyStatus } from '@odf/core/constants/s3-iam';
 import { useCustomTranslation } from '@odf/shared';
 import { ButtonBar } from '@odf/shared/generic/ButtonBar';
@@ -17,7 +16,7 @@ import {
 export type UpdateAccessKeyModalProps = {
   name: string;
   AccessKeyId: string;
-  status: StatusType;
+  status: AccessKeyStatus;
   iamClient: IamCommands;
 };
 


### PR DESCRIPTION
'Activate access key' is displayed even when the access key's status is active, and similarly, 'Deactivate access key' is displayed even when the access key's status is inactive. Consequently, attempts to deactivate an active access key or activate an inactive access key are unsuccessful.
<img width="1728" height="1117" alt="Screenshot 2025-12-08 at 1 07 01 PM" src="https://github.com/user-attachments/assets/353e1e74-4854-4b05-b7e8-42ef253ed522" />

<img width="1728" height="1117" alt="Screenshot 2025-12-08 at 1 08 00 PM" src="https://github.com/user-attachments/assets/63a7d8ba-4bee-44da-b265-54b35a1349ee" />

after the fix :
https://github.com/user-attachments/assets/b5053016-9548-4733-804e-e8b217460a1c


