### PR TITLE
Add default IAM user policy on user creation

### DIFF
--- a/packages/odf/constants/s3-iam.ts
+++ b/packages/odf/constants/s3-iam.ts
@@ -12,6 +12,8 @@ export const UPDATE_ACCESS_KEY_CLEANUP_MUTATION_KEY =
   'update-access-key-cleanup';
 export const DELETE_ACCESS_KEY_CLEANUP_MUTATION_KEY =
   'delete-access-key-cleanup';
+export const DELETE_USER_POLICY_CLEANUP_MUTATION_KEY =
+  'delete-user-policy-cleanup';
 export const DELETE_IAM_USER_CLEANUP_MUTATION_KEY = 'delete-iam-user-cleanup';
 
 export const MAX_USERS = 50;
@@ -38,3 +40,8 @@ export const TAG_VALUE_ALLOWED_CHARS_REGEX = /^[\p{L}\p{Z}\p{N}_.:/=+\-@]*$/u;
 export const USER_NAME_MIN_LENGTH = 1;
 export const USER_NAME_MAX_LENGTH = 64;
 export const USER_NAME_ALLOWED_CHARS_REGEX = /^[A-Za-z0-9+=,.@_-]*$/;
+
+//default IAM policy for a user
+export const POLICY_DOCUMENT =
+  '{ "Version": "2012-10-17", "Statement": [ { "Effect": "Allow", "Action": [ "s3:*" ], "Resource": "*" } ] }';
+export const POLICY_NAME = 'policy_allow_all_s3_actions';

--- a/packages/shared/src/iam/commands.ts
+++ b/packages/shared/src/iam/commands.ts
@@ -10,6 +10,8 @@ import {
   CreateAccessKeyCommand,
   CreateUserCommand,
   TagUserCommand,
+  PutUserPolicyCommand,
+  DeleteUserPolicyCommand,
 } from '@aws-sdk/client-iam';
 import {
   GetUser,
@@ -22,6 +24,8 @@ import {
   CreateAccessKey,
   CreateUser,
   TagUser,
+  PutUserPolicy,
+  DeleteUserPolicy,
 } from './types';
 
 export class IamCommands extends IAMClient {
@@ -63,4 +67,10 @@ export class IamCommands extends IAMClient {
     this.send(new CreateUserCommand(input));
 
   tagUser: TagUser = (input) => this.send(new TagUserCommand(input));
+
+  putUserPolicy: PutUserPolicy = (input) =>
+    this.send(new PutUserPolicyCommand(input));
+
+  deleteUserPolicy: DeleteUserPolicy = (input) =>
+    this.send(new DeleteUserPolicyCommand(input));
 }

--- a/packages/shared/src/iam/types.ts
+++ b/packages/shared/src/iam/types.ts
@@ -19,6 +19,10 @@ import {
   CreateUserCommandOutput,
   TagUserCommandInput,
   TagUserCommandOutput,
+  PutUserPolicyCommandInput,
+  PutUserPolicyCommandOutput,
+  DeleteUserPolicyCommandInput,
+  DeleteUserPolicyCommandOutput,
 } from '@aws-sdk/client-iam';
 
 export type GetUser = (
@@ -60,3 +64,11 @@ export type CreateUser = (
 export type TagUser = (
   input: TagUserCommandInput
 ) => Promise<TagUserCommandOutput>;
+
+export type PutUserPolicy = (
+  input: PutUserPolicyCommandInput
+) => Promise<PutUserPolicyCommandOutput>;
+
+export type DeleteUserPolicy = (
+  input: DeleteUserPolicyCommandInput
+) => Promise<DeleteUserPolicyCommandOutput>;


### PR DESCRIPTION
Add default IAM user policy on user creation as suggested in the jira comment 

https://issues.redhat.com/browse/RHSTOR-7353?focusedId=28589274&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-28589274

the below screen shot is the displayed metadata returned by the api call putUserPolicy on successful creation of user and default policy
<img width="1728" height="1117" alt="Screenshot 2025-12-08 at 2 58 06 PM" src="https://github.com/user-attachments/assets/d665ff90-9ad5-477c-9f3c-71d8839d8533" />
