### PR TITLE
Filter out PAVs with deletionTimestamp

### DIFF
--- a/packages/mco/components/protected-applications/list-page.tsx
+++ b/packages/mco/components/protected-applications/list-page.tsx
@@ -150,28 +150,39 @@ export const ProtectedApplicationsListPage: React.FC = () => {
     ProtectedApplicationViewKind[]
   >(getProtectedApplicationViewResourceObj());
 
+  // Filter out resources marked for deletion (deletionTimestamp set)
+  // Resources with deletionTimestamp are being garbage collected and should not be displayed
+  const activePAVs = React.useMemo(() => {
+    if (!pavsLoaded || !pavs) return [];
+    return pavs.filter((pav) => !pav.metadata?.deletionTimestamp);
+  }, [pavs, pavsLoaded]);
+
   const [drpcs, drpcsLoaded, drpcsError] = useK8sWatchResource<
     DRPlacementControlKind[]
   >(getDRPlacementControlResourceObj({}));
 
-  // Monitor for DR operation completions and show alerts
-  useDROperationAlert(drpcs || []);
+  // Filter out DRPCs marked for deletion
+  const activeDRPCs = React.useMemo(() => {
+    if (!drpcsLoaded || !drpcs) return [];
+    return drpcs.filter((drpc) => !drpc.metadata?.deletionTimestamp);
+  }, [drpcs, drpcsLoaded]);
+
+  // Monitor for DR operation completions and show alerts (only for active DRPCs)
+  useDROperationAlert(activeDRPCs);
 
   const drpcMap = React.useMemo(() => {
     const map = new Map<string, DRPlacementControlKind>();
-    if (drpcsLoaded && drpcs) {
-      drpcs.forEach((drpc) => {
-        const key = `${drpc.metadata.namespace}/${drpc.metadata.name}`;
-        map.set(key, drpc);
-      });
-    }
+    activeDRPCs.forEach((drpc) => {
+      const key = `${drpc.metadata.namespace}/${drpc.metadata.name}`;
+      map.set(key, drpc);
+    });
     return map;
-  }, [drpcs, drpcsLoaded]);
+  }, [activeDRPCs]);
 
   const isAllLoadedWOAnyError =
     pavsLoaded && drpcsLoaded && !pavsError && !drpcsError;
 
-  const [data, filteredData, onFilterChange] = useListPageFilter(pavs || []);
+  const [data, filteredData, onFilterChange] = useListPageFilter(activePAVs);
 
   return (
     <PaginatedListPage


### PR DESCRIPTION
https://issues.redhat.com/browse/DFBUGS-5066

When a DRPC is deleted, the associated PAV is marked for garbage collection. This garbage collection may take a few seconds to happen during which PAVs can display on the protected applications page causing a mismatch

Filtering active PAVs allows to show consistent data on the list page and disallows for operations on non active PAVs till the time they are garbage collected