### PR TITLE
DFBUGS-5212: Fix HealthOverviewCard messages in no ceph case

### DIFF
--- a/packages/odf/components/overview/Overview.spec.tsx
+++ b/packages/odf/components/overview/Overview.spec.tsx
@@ -10,6 +10,7 @@ import { BrowserRouter } from 'react-router-dom-v5-compat';
 import Overview from './Overview';
 
 const odfNamespace = 'test-ns';
+
 jest.mock('@odf/core/redux/selectors', () => ({
   useODFNamespaceSelector: () => ({
     odfNamespace,
@@ -17,6 +18,16 @@ jest.mock('@odf/core/redux/selectors', () => ({
     odfNsLoadError: null,
     isNsSafe: true,
     isFallbackSafe: true,
+  }),
+  useODFSystemFlagsSelector: () => ({
+    systemFlags: {
+      [odfNamespace]: {
+        isInternalMode: true,
+        isExternalMode: false,
+        isNoobaaStandalone: false,
+      },
+    },
+    areFlagsSafe: true,
   }),
 }));
 

--- a/packages/odf/components/overview/Overview.tsx
+++ b/packages/odf/components/overview/Overview.tsx
@@ -4,11 +4,13 @@ import { ExternalSystemsCard } from '@odf/core/components/overview/external-syst
 import { ObjectStorageCard } from '@odf/core/components/overview/object-storage-card/ObjectStorageCard';
 import { StorageClusterCard } from '@odf/core/components/overview/storage-cluster-card/StorageClusterCard';
 import { StorageClusterCreateModal } from '@odf/core/modals/ConfigureDF/StorageClusterCreateModal';
+import { useODFSystemFlagsSelector } from '@odf/core/redux/selectors';
 import { PageHeading, useCustomTranslation } from '@odf/shared';
 import { useModalWrapper } from '@odf/shared';
 import { Helmet } from 'react-helmet';
 import { useLocation } from 'react-router-dom-v5-compat';
 import { Grid, GridItem } from '@patternfly/react-core';
+import { hasAnyInternalCeph } from '../../utils';
 import { HealthOverviewCard } from './health-overview-card/HealthOverviewCard';
 import './Overview.scss';
 
@@ -20,6 +22,12 @@ const Overview: React.FC = () => {
   const searchParams = new URLSearchParams(location.search);
   const showWelcomeModal = searchParams.get('show-welcome-modal');
   const launchModal = useModalWrapper();
+
+  // Show health card only for internal Ceph clusters.
+  // Can't use hasAnyInternalOCS because MCG standalone is also internal mode,
+  // but it has no Ceph, so ocs_health_score metric won't exist.
+  const { systemFlags, areFlagsSafe } = useODFSystemFlagsSelector();
+  const showHealthCard = areFlagsSafe && hasAnyInternalCeph(systemFlags);
 
   React.useEffect(() => {
     if (showWelcomeModal === 'true') {
@@ -37,9 +45,11 @@ const Overview: React.FC = () => {
         <GridItem xl2={5}>
           <StorageClusterCard />
         </GridItem>
-        <GridItem xl2={3}>
-          <HealthOverviewCard />
-        </GridItem>
+        {showHealthCard && (
+          <GridItem xl2={3}>
+            <HealthOverviewCard />
+          </GridItem>
+        )}
         <GridItem xl2={4} xl2RowSpan={3} order={{ '2xl': '0', default: '3' }}>
           <GeneralOverviewActivityCard />
         </GridItem>

--- a/packages/odf/utils/odf.ts
+++ b/packages/odf/utils/odf.ts
@@ -78,6 +78,15 @@ export const hasAnyInternalOCS = (
   systemFlags: ODFSystemFlagsPayload['systemFlags']
 ): boolean => _.some(systemFlags, (flags) => !!flags.isInternalMode);
 
+// Returns true if there's at least one internal mode cluster with Ceph (not MCG standalone)
+export const hasAnyInternalCeph = (
+  systemFlags: ODFSystemFlagsPayload['systemFlags']
+): boolean =>
+  _.some(
+    systemFlags,
+    (flags) => !!flags.isInternalMode && !flags.isNoobaaStandalone
+  );
+
 export const hasAnyCeph = (
   systemFlags: ODFSystemFlagsPayload['systemFlags']
 ): boolean => _.some(systemFlags, (flags) => !!flags.isCephAvailable);


### PR DESCRIPTION
A waiting message was shown in 'HealthOverviewCard' in case of no OSDs (or no Ceph). This change is to fix it by providing appropriate messages in those cases.

For more details see: https://issues.redhat.com/browse/DFBUGS-5212