### PR TITLE
Fix HealthOverview's Silence modal duration dropdown

### DIFF
--- a/packages/odf/components/HealthOverview/SilenceAlertModal.tsx
+++ b/packages/odf/components/HealthOverview/SilenceAlertModal.tsx
@@ -275,6 +275,7 @@ export const SilenceAlertModal: React.FC<SilenceAlertModalProps> = ({
                 isDisabled={isSubmitting}
                 shouldFocusFirstItemOnOpen
                 shouldFocusToggleOnSelect
+                popperProps={{ appendTo: () => document.body }}
               >
                 <SelectList>
                   {durationUnitOptions.map((option) => (

--- a/packages/odf/components/HealthOverview/SilenceAlertModal.tsx
+++ b/packages/odf/components/HealthOverview/SilenceAlertModal.tsx
@@ -421,6 +421,7 @@ export const SilenceAlertModal: React.FC<SilenceAlertModalProps> = ({
                   toggle={unitToggle}
                   shouldFocusFirstItemOnOpen
                   shouldFocusToggleOnSelect
+                  popperProps={{ appendTo: () => document.body }}
                 >
                   <SelectList>
                     {durationUnitOptions.map((option) => (


### PR DESCRIPTION
Duration dropdown was giving a vertical scroll bar that renders inside the modal body, instead of poping out and show all the options.

The change should render the dropdown menu as a child of 'document.body' instead of inside the modal. The dropdown will now "pop out" of the modal and be fully visible.

BZ: https://redhat.atlassian.net/browse/DFBUGS-5375