### PR TITLE
fix for icon colors not rendering

### DIFF
--- a/packages/shared/src/styles/_icons.scss
+++ b/packages/shared/src/styles/_icons.scss
@@ -1,3 +1,12 @@
+// Bridge PF5 icon color variables used by @openshift-console/dynamic-plugin-sdk
+// The SDK's icons.scss uses PF5 vars which are undefined when only PF6 CSS is loaded.
+* {
+  --pf-v5-global--palette--green-500: var(--pf-t--global--icon--color--status--success--default, #3d7317);
+  --pf-v5-global--danger-color--100: var(--pf-t--global--icon--color--status--danger--default, #b1380b);
+  --pf-v5-global--warning-color--100: var(--pf-t--global--icon--color--status--warning--default, #73480b);
+  --pf-v5-global--palette--blue-300: var(--pf-t--global--icon--color--status--info--default, #4394e5);
+}
+
 .odf-icon-space-r {
   margin-right: 0.25em;
 }


### PR DESCRIPTION
Jira Bug link: https://redhat.atlassian.net/browse/DFBUGS-6223

Problem: The icons who's colours are not getting rendered are declared in the ocp-console and not in odf-console.
file: ocp-console/frontend/packages/console-dynamic-plugin-sdk/src/app/components/status/icons.tsx.
The icons use the classNames: dps-icons__red-exclamation-icon, dps-icons__yellow-exclamation-icon etc...
declared in the file : ocp-console/frontend/packages/console-dynamic-plugin-sdk/src/app/components/status/icons.scss

So when we run just the ocp-console and not the odf-console -> The icons pick the patternfly v6 color tokens from the classNames declared in the file icons.scss. Hence the icon colours are rendered properly in this case.

But now when I run the UI plugin odf-console -> The icon colours become black ( I am shocked..). What happens is that the classNames which have been declared in icons.scss(ocp-console) are declared again with the same names in the dynamic-plugin-sdk inside odf-console node modules (node_modules/@openshift-console/dynamic-plugin-sdk/lib/app/components/status/icons.scss) where they use patternfly v5 tokens for colours.
Since at both the places classes have !important remark for the icon colours, it picks the colour from classname that has been declared later which is from dynamic-plugin-sdk that uses pf5. 

The Fix: 
In odf-console/node_modules/@openshift-console/dynamic-plugin-sdk/lib/app/components/status/icons.scss we only have 5 colour variables being used. 
We can point these 5 pfv5 css variables to it's pfv6 counterparts until dynamic-plugin-sdk code is updated with [pf-6](https://redhat.atlassian.net/browse/pf-6) variables.

Fixed window:
<img width="1917" height="1080" alt="image" src="https://github.com/user-attachments/assets/58f19091-0b80-4a73-9f21-c1d9e499f033" />

Console Tab :
<img width="1917" height="1080" alt="image" src="https://github.com/user-attachments/assets/b51a2716-5ff8-48a9-b67c-cff1fa0f4f4b" />
