### PR TITLE
Fix Cypress config and update exec result property for Cypress v13+

### DIFF
--- a/cypress/cypress.config.ts
+++ b/cypress/cypress.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'cypress';
 import { SECOND } from './consts';
-import * as setupNodeEvents from './plugin.js';
+import setupNodeEvents from './plugin.js';
 
 export default defineConfig({
   defaultCommandTimeout: 30 * SECOND,

--- a/cypress/support.ts
+++ b/cypress/support.ts
@@ -46,8 +46,8 @@ Cypress.Commands.add('install', () => {
     {
       failOnNonZeroExit: false,
     }
-  ).then(({ code }) => {
-    if (code !== 0) {
+  ).then(({ exitCode }) => {
+    if (exitCode !== 0) {
       cy.clickNavLink(['Storage', 'Storage cluster']);
       // Clicks create Data Foundation button
       cy.byTestID('configure-data-foundation').click();

--- a/cypress/support/vault-standalone.ts
+++ b/cypress/support/vault-standalone.ts
@@ -14,9 +14,9 @@ import { commandPoll } from '../views/common';
 export const configureVault = () => {
   cy.exec('oc get project hashicorp', {
     failOnNonZeroExit: false,
-  }).then(({ code }) => {
+  }).then(({ exitCode }) => {
     // Deploy vault only if doesn't already exist
-    if (code !== 0) {
+    if (exitCode !== 0) {
       cy.log('Create a new project for internel vault');
       cy.exec('oc new-project hashicorp');
 

--- a/cypress/views/pvc.ts
+++ b/cypress/views/pvc.ts
@@ -33,7 +33,7 @@ export const deletePVCFromCLI = (pvcName: string, ns = 'default') => {
   cy.exec(`oc delete pvc ${pvcName} -n ${ns}`, {
     failOnNonZeroExit: false,
   }).then((result) => {
-    if (result.code !== 0 && !result.stderr.includes('not found')) {
+    if (result.exitCode !== 0 && !result.stderr.includes('not found')) {
       throw new Error(`PVC deletion failed: ${result.stderr}`);
     }
   });


### PR DESCRIPTION
Fix setupNodeEvents import in cypress.config.ts to use default import instead of namespace import, which resolved to an empty object {}. Update cy.exec() result destructuring from `code` to `exitCode` across support and view files, matching the breaking API change in Cypress v13.


<img width="2048" height="1060" alt="Screenshot 2026-04-15 at 12 19 04 PM" src="https://github.com/user-attachments/assets/a4273eda-b35e-4c08-88dc-5df7ba10c439" />
