### PR TITLE
Remove unnecessary getObject API calls

### DIFF
--- a/packages/odf/components/s3-browser/object-details/ObjectDetailsSidebar.tsx
+++ b/packages/odf/components/s3-browser/object-details/ObjectDetailsSidebar.tsx
@@ -274,12 +274,12 @@ const ObjectOverview: React.FC<ObjectOverviewProps> = ({
   const isDeleteMarker = object?.isDeleteMarker;
 
   const { data: objectData, isLoading: isObjectDataLoading } = useSWR(
-    // don't fetch if object is a delete marker ("getObject" not supported)
+    // don't fetch if object is a delete marker ("headObject" not supported)
     isDeleteMarker
       ? null
       : `${s3Client.providerType}-${objectKey}-${lastModified}-${OBJECT_CACHE_KEY_SUFFIX}`,
     () =>
-      s3Client.getObject({
+      s3Client.headObject({
         Bucket: bucketName,
         Key: objectKey,
         ...(showVersioning && { VersionId: versionId }),

--- a/packages/shared/src/s3/commands.ts
+++ b/packages/shared/src/s3/commands.ts
@@ -5,6 +5,7 @@ import {
   CreateBucketCommand,
   PutBucketTaggingCommand,
   GetObjectCommand,
+  HeadObjectCommand,
   GetObjectTaggingCommand,
   DeleteObjectsCommand,
   GetBucketEncryptionCommand,
@@ -37,6 +38,7 @@ import {
   PutBucketTags,
   GetSignedUrl,
   GetObject,
+  HeadObject,
   GetObjectTagging,
   DeleteObjects,
   DeleteBucket,
@@ -175,6 +177,8 @@ export class S3Commands extends S3Client {
   };
 
   getObject: GetObject = (input) => this.send(new GetObjectCommand(input));
+
+  headObject: HeadObject = (input) => this.send(new HeadObjectCommand(input));
 
   getObjectTagging: GetObjectTagging = (input) =>
     this.send(new GetObjectTaggingCommand(input));

--- a/packages/shared/src/s3/types.ts
+++ b/packages/shared/src/s3/types.ts
@@ -23,6 +23,8 @@ import {
   DeleteObjectsCommandOutput,
   GetObjectCommandInput,
   GetObjectCommandOutput,
+  HeadObjectCommandInput,
+  HeadObjectCommandOutput,
   GetObjectTaggingCommandInput,
   GetObjectTaggingCommandOutput,
   ListObjectVersionsCommandInput,
@@ -146,6 +148,10 @@ export type DeleteObjects = (
 export type GetObject = (
   input: GetObjectCommandInput
 ) => Promise<GetObjectCommandOutput>;
+
+export type HeadObject = (
+  input: HeadObjectCommandInput
+) => Promise<HeadObjectCommandOutput>;
 
 export type GetObjectTagging = (
   input: GetObjectTaggingCommandInput


### PR DESCRIPTION
https://redhat.atlassian.net/browse/DFBUGS-6113

Remove unnecessary "getObject" API call from the sidebar and use "headObject" instead for metadata.

<img width="1423" height="853" alt="Screenshot 2026-04-22 at 4 30 45 PM" src="https://github.com/user-attachments/assets/5768808d-086e-44f3-84e7-72355744a9ba" />