### PR TITLE
DFBUGS-6479: Support schedulingInterval=0m for async DRPolicy (FusionAccess)

### DIFF
--- a/packages/mco/components/modals/app-failover-relocate/failover-relocate-modal-body.tsx
+++ b/packages/mco/components/modals/app-failover-relocate/failover-relocate-modal-body.tsx
@@ -302,16 +302,17 @@ export const FailoverRelocateModalBody: React.FC<
             <DRActionReadiness canInitiate={canInitiate} />
           </FlexItem>
         </Flex>
-        {placement?.replicationType === ReplicationType.ASYNC && (
-          <Flex>
-            <FlexItem>
-              <strong>{t('Volume last synced on:')}</strong>
-            </FlexItem>
-            <FlexItem>
-              <DateTimeFormat dateTime={placement?.snapshotTakenTime} />
-            </FlexItem>
-          </Flex>
-        )}
+        {placement?.replicationType === ReplicationType.ASYNC &&
+          placement?.schedulingInterval !== '0m' && (
+            <Flex>
+              <FlexItem>
+                <strong>{t('Volume last synced on:')}</strong>
+              </FlexItem>
+              <FlexItem>
+                <DateTimeFormat dateTime={placement?.snapshotTakenTime} />
+              </FlexItem>
+            </Flex>
+          )}
 
         {
           // ToDo: Enable this once DRPC has kube object last sync time.

--- a/packages/mco/components/modals/app-manage-policies/manage-policy-view.tsx
+++ b/packages/mco/components/modals/app-manage-policies/manage-policy-view.tsx
@@ -404,7 +404,9 @@ const DRInformation: React.FC<DRInformationProps> = ({
       </DRInformationGroup>
       {(isAsync || appType === DRApplication.DISCOVERED) && (
         <DRInformationGroup title={t('Replication details')}>
-          {isAsync && replicationStatus(t('Volume:'), lastGroupSyncTime, t)}
+          {isAsync &&
+            schedulingInterval !== '0m' &&
+            replicationStatus(t('Volume:'), lastGroupSyncTime, t)}
           {replicationStatus(
             t('Kubernetes object:'),
             lastKubeObjectProtectionTime,

--- a/packages/mco/utils/disaster-recovery.tsx
+++ b/packages/mco/utils/disaster-recovery.tsx
@@ -272,6 +272,11 @@ export const getReplicationHealth = (
   if (replicationType && replicationType === ReplicationType.SYNC) {
     return VolumeReplicationHealth.HEALTHY;
   }
+  // No replication monitoring needed when schedulingInterval is 0m
+  // (e.g. FusionAccess async with no active replication).
+  if (schedulingInterval === '0m') {
+    return VolumeReplicationHealth.HEALTHY;
+  }
   const seconds = !!lastSyncTime
     ? getTimeDifferenceInSeconds(lastSyncTime)
     : LEAST_SECONDS_IN_PROMETHEUS;
@@ -432,6 +437,10 @@ export const getVolumeReplicationHealth = (
   const [syncIntervalInSeconds] = convertSyncIntervalToSeconds(
     scheduledSyncInterval
   );
+  // Guard against division by zero when schedulingInterval is 0m.
+  if (syncIntervalInSeconds === 0) {
+    return [VolumeReplicationHealth.HEALTHY, 0];
+  }
   const slaDiff = slaTakenInSeconds / syncIntervalInSeconds || 0;
   if (slaDiff >= THRESHOLD) return [VolumeReplicationHealth.CRITICAL, slaDiff];
   else if (slaDiff > THRESHOLD - 1 && slaDiff < THRESHOLD)


### PR DESCRIPTION
Skip replication health checks (lastGroupSyncTime) when schedulingInterval is 0m for async policies. This supports FusionAccess and global offload scenarios where no active volume replication occurs.