### PR TITLE
Fix the typo in data-test-id attribute

### DIFF
--- a/locales/en/plugin__odf-console.json
+++ b/locales/en/plugin__odf-console.json
@@ -1275,7 +1275,6 @@
   "Internal": "Internal",
   "Internal mode cluster not available": "Internal mode cluster not available",
   "Internal mode cluster setup path is unavailable because an External mode cluster has already been configured.": "Internal mode cluster setup path is unavailable because an External mode cluster has already been configured.",
-  "Intiating": "Intiating",
   "Invalid": "Invalid",
   "Invalid disk data: missing required fields (WWN: {{wwn}}, path: {{path}}, nodeName: {{nodeName}})": "Invalid disk data: missing required fields (WWN: {{wwn}}, path: {{path}}, nodeName: {{nodeName}})",
   "Invalid DR Policy": "Invalid DR Policy",

--- a/locales/es/plugin__odf-console.json
+++ b/locales/es/plugin__odf-console.json
@@ -1018,7 +1018,6 @@
   "Integrate Data Foundation with an existing storage backend such as external Ceph cluster on IBM FlashSystem.": "Integre Data Foundation con un backend de almacenamiento existente, como un clúster Ceph externo en IBM FlashSystem.",
   "Internal": "Interno",
   "Internal cluster": "Clúster interno",
-  "Intiating": "Iniciando",
   "Invalid": "No válido",
   "Invalid file: File size exceeds 4MB limit or incorrect file extension (only .pem files allowed).": "Archivo no válido: el tamaño del archivo excede el límite de 4 MB o la extensión del archivo es incorrecta (solo se permiten archivos .pem).",
   "Invalid label name": "Nombre de etiqueta no válido",

--- a/locales/fr/plugin__odf-console.json
+++ b/locales/fr/plugin__odf-console.json
@@ -1018,7 +1018,6 @@
   "Integrate Data Foundation with an existing storage backend such as external Ceph cluster on IBM FlashSystem.": "Intégre Data Foundation à un backend de stockage existant tel qu'un cluster Ceph externe sur IBM FlashSystem.",
   "Internal": "Interne",
   "Internal cluster": "Cluster interne",
-  "Intiating": "Initiation",
   "Invalid": "Non valide",
   "Invalid file: File size exceeds 4MB limit or incorrect file extension (only .pem files allowed).": "Fichier non valide : la taille du fichier dépasse la limite de 4 Mo ou l’extension de fichier est incorrecte (seuls les fichiers .pem sont autorisés).",
   "Invalid label name": "Nom d’étiquette non valide",

--- a/locales/ja/plugin__odf-console.json
+++ b/locales/ja/plugin__odf-console.json
@@ -1018,7 +1018,6 @@
   "Integrate Data Foundation with an existing storage backend such as external Ceph cluster on IBM FlashSystem.": "Data Foundation を IBM FlashSystem 上の外部 Ceph クラスターなどの既存のストレージバックエンドと統合します。",
   "Internal": "内部",
   "Internal cluster": "内部クラスター",
-  "Intiating": "開始しています",
   "Invalid": "無効",
   "Invalid file: File size exceeds 4MB limit or incorrect file extension (only .pem files allowed).": "無効なファイル: ファイルサイズが 4MB の制限を超えているか､ファイル拡張子 (許可される.pem ファイルのみ) が正しくありません。",
   "Invalid label name": "無効なラベル名",

--- a/locales/ko/plugin__odf-console.json
+++ b/locales/ko/plugin__odf-console.json
@@ -1018,7 +1018,6 @@
   "Integrate Data Foundation with an existing storage backend such as external Ceph cluster on IBM FlashSystem.": "IBM FlashSystem의 외부 Ceph 클러스터와 같은 기존 스토리지 백엔드와 Data Foundation을 통합합니다.",
   "Internal": "내부",
   "Internal cluster": "내부 클러스터",
-  "Intiating": "시작 중",
   "Invalid": "유효하지 않음",
   "Invalid file: File size exceeds 4MB limit or incorrect file extension (only .pem files allowed).": "잘못된 파일: 파일 크기가 4MB 제한을 초과하거나 파일 확장자가 잘못되었습니다 (.pem 파일만 허용됨).",
   "Invalid label name": "레이블 이름이 유효하지 않음",

--- a/locales/zh/plugin__odf-console.json
+++ b/locales/zh/plugin__odf-console.json
@@ -1018,7 +1018,6 @@
   "Integrate Data Foundation with an existing storage backend such as external Ceph cluster on IBM FlashSystem.": "将 Data Foundation 与一个现有的存储后端（如 IBM FlashSystem 上的外部 Ceph 集群）集成。",
   "Internal": "内部",
   "Internal cluster": "内部集群",
-  "Intiating": "启动",
   "Invalid": "无效",
   "Invalid file: File size exceeds 4MB limit or incorrect file extension (only .pem files allowed).": "无效文件：文件大小超过了 4MB 的限制，或有不正确的文件扩展名（只允许 .pem 文件）。",
   "Invalid label name": "无效的标签名称",

--- a/packages/mco/components/modals/app-failover-relocate/failover-relocate-modal.tsx
+++ b/packages/mco/components/modals/app-failover-relocate/failover-relocate-modal.tsx
@@ -144,9 +144,9 @@ export const FailoverRelocateModal: React.FC<FailoverRelocateModalProps> = (
           {t('Cancel')}
         </Button>
         <Button
-          key="modal-intiate-action"
-          id={'modal-intiate-action'}
-          data-test-id={'modal-intiate-action'}
+          key="modal-initiate-action"
+          id={'modal-initiate-action'}
+          data-test-id={'modal-initiate-action'}
           type={ButtonType.button}
           variant={ButtonVariant.primary}
           isDisabled={

--- a/packages/mco/components/modals/app-failover-relocate/subscriptions/failover-relocate-modal.tsx
+++ b/packages/mco/components/modals/app-failover-relocate/subscriptions/failover-relocate-modal.tsx
@@ -39,7 +39,7 @@ const generatefooterButtons = (props: ModalFooterProps): FooterButtonProps => ({
       onClick: props.close,
     },
     {
-      id: 'modal-intiate-action',
+      id: 'modal-initiate-action',
       label: props.t('Initiate'),
       type: ButtonType.button,
       variant: ButtonVariant.primary,
@@ -56,8 +56,8 @@ const generatefooterButtons = (props: ModalFooterProps): FooterButtonProps => ({
       onClick: props.close,
     },
     {
-      id: 'modal-intiating-action',
-      label: props.t('Intiating'),
+      id: 'modal-initiating-action',
+      label: props.t('Initiating'),
       type: ButtonType.button,
       variant: ButtonVariant.primary,
       isLoading: true,


### PR DESCRIPTION
https://redhat.atlassian.net/browse/DFBUGS-5574

Fix the "Initiate" button in the Failover and Relocate modals on the Protected Applications page, has a typo in its data-test-id attribute; "modal-intiate-action" should be "modal-initiate-action"

**before fix:**

<img width="3398" height="1328" alt="image" src="https://github.com/user-attachments/assets/73d5c3b9-eb64-43cc-8636-dbe5392e7aaf" />

<img width="3374" height="1324" alt="image" src="https://github.com/user-attachments/assets/d5d50968-ee80-4fda-bcdb-09a81da8f07a" />

**after fix:**

<img width="1728" height="1117" alt="Screenshot 2026-04-28 at 3 58 29 PM" src="https://github.com/user-attachments/assets/b9757650-fa53-4794-a135-eaa44731e151" />

<img width="1728" height="1117" alt="Screenshot 2026-04-28 at 3 59 27 PM" src="https://github.com/user-attachments/assets/f2de9072-07c4-4491-8af1-e3322ae2b6f3" />
