### PR TITLE
Update the Add Capacity modal

### DIFF
--- a/cypress/tests/multiple-storageclass-selection.spec.ts
+++ b/cypress/tests/multiple-storageclass-selection.spec.ts
@@ -1,17 +1,13 @@
 import { K8sResourceKind, getCurrentDeviceSetIndex } from '../mocks/ksm';
-import {
-  testEbsSC,
-  testNoProvisionerSC,
-  getPVJSON,
-} from '../mocks/storageclass';
+import { testEbsSC, testNoProvisionerSC } from '../mocks/storageclass';
 import {
   withJSONResult,
   fetchStorageClusterJson,
-  fetchWorkerNodesJson,
   addCapacity,
-  newStorageClassTests,
+  assertStorageClassNamesAbsentInAddCapacityDropdown,
   existingStorageClassTests,
   IndexAndDeviceSet,
+  openAddCapacityModal,
   UidAndDeviceSet,
 } from '../views/multiple-storageclass';
 
@@ -28,18 +24,6 @@ describe('Add capacity using multiple storage classes', () => {
     cy.exec(
       `echo '${JSON.stringify(testNoProvisionerSC)}' | kubectl apply -f -`
     );
-    fetchWorkerNodesJson().then((res) => {
-      const nodes = JSON.parse(res.stdout);
-      const { name: scName } = testNoProvisionerSC.metadata;
-      nodes.items.forEach((node, id) => {
-        const nodeName = node.metadata.name;
-        cy.exec(
-          `echo '${JSON.stringify(
-            getPVJSON(id, nodeName, scName)
-          )}' | kubectl apply -f -`
-        );
-      });
-    });
   });
 
   beforeEach(() => {
@@ -56,35 +40,30 @@ describe('Add capacity using multiple storage classes', () => {
     cy.exec(
       `echo '${JSON.stringify(testNoProvisionerSC)}' | kubectl delete -f -`
     );
-    fetchWorkerNodesJson().then((res) => {
-      const nodes = JSON.parse(res.stdout);
-      const { name: scName } = testNoProvisionerSC.metadata;
-      nodes.items.forEach((node, id) => {
-        const nodeName = node.metadata.name;
-        cy.exec(
-          `echo '${JSON.stringify(
-            getPVJSON(id, nodeName, scName)
-          )}' | kubectl delete -f -`
-        );
-      });
-    });
   });
 
-  it('Add capacity with a new storage class having EBS as provisioner', () => {
-    const { name: scName } = testEbsSC.metadata;
-    const iAndD: IndexAndDeviceSet = { index: 0, deviceSets: [] };
-    addCapacity(scName);
-    fetchStorageClusterJson().then((res) => {
-      withJSONResult(res, scName, iAndD);
-      newStorageClassTests(beforeCapacityAddition, iAndD, true);
-    });
+  it('Add Capacity modal does not list StorageClasses that are not already used by the cluster', () => {
+    openAddCapacityModal();
+    assertStorageClassNamesAbsentInAddCapacityDropdown([
+      testEbsSC.metadata.name,
+      testNoProvisionerSC.metadata.name,
+    ]);
   });
 
   it('Add capacity with an existing storage class having EBS as provisioner', () => {
-    const { name: scName } = testEbsSC.metadata;
     const iAndD: IndexAndDeviceSet = { index: 0, deviceSets: [] };
     const { deviceSets } = beforeCapacityAddition;
-    const index = getCurrentDeviceSetIndex(deviceSets, scName);
+    let scName = testEbsSC.metadata.name;
+    let index = getCurrentDeviceSetIndex(deviceSets, scName);
+    if (index === -1) {
+      const installSC = deviceSets[0]?.dataPVCTemplate?.spec?.storageClassName;
+      expect(
+        installSC,
+        'storageDeviceSets[0] must declare a StorageClass when test-ebs-sc is not used by the cluster'
+      ).to.be.a('string');
+      scName = installSC;
+      index = getCurrentDeviceSetIndex(deviceSets, scName);
+    }
     cy.log('Count is:', index.toString());
     beforeCapacityAddition.portability = deviceSets[index].portable;
     beforeCapacityAddition.devicesCount = deviceSets[index].count;
@@ -92,16 +71,6 @@ describe('Add capacity using multiple storage classes', () => {
     fetchStorageClusterJson().then((res) => {
       withJSONResult(res, scName, iAndD);
       existingStorageClassTests(beforeCapacityAddition, iAndD);
-    });
-  });
-
-  it(`Add capacity with a new storage class having NO-PROVISIONER as provisioner`, () => {
-    const { name: scName } = testNoProvisionerSC.metadata;
-    const iAndD: IndexAndDeviceSet = { index: 0, deviceSets: [] };
-    addCapacity(scName);
-    fetchStorageClusterJson().then((res) => {
-      withJSONResult(res, scName, iAndD);
-      newStorageClassTests(beforeCapacityAddition, iAndD, false);
     });
   });
 });

--- a/cypress/views/multiple-storageclass.ts
+++ b/cypress/views/multiple-storageclass.ts
@@ -21,34 +21,31 @@ export const fetchStorageClusterJson = () =>
     `kubectl get --ignore-not-found storagecluster ${OCS_INTERNAL_CR_NAME} -n ${NS} -o json`
   );
 
-export const fetchWorkerNodesJson = () =>
-  cy.exec('oc get nodes -l "node-role.kubernetes.io/worker" -o json');
-
-export const addCapacity = (scName: string) => {
+export const openAddCapacityModal = () => {
   cy.byTestID('kebab-button').click();
   cy.contains('Add Capacity').click();
+};
+
+export const addCapacity = (scName: string) => {
+  openAddCapacityModal();
   // eslint-disable-next-line cypress/no-unnecessary-waiting
   cy.byTestID('add-cap-sc-dropdown').wait(1500).click();
   cy.contains(scName).click();
   cy.byLegacyTestID('confirm-action').click();
 };
 
-export const newStorageClassTests = (
-  beforeCapacityAddition: UidAndDeviceSet,
-  iAndD: IndexAndDeviceSet,
-  portability: boolean
+export const assertStorageClassNamesAbsentInAddCapacityDropdown = (
+  scNames: string[]
 ) => {
-  const portabilityStatus = portability ? 'enabled' : 'disabled';
-  cy.log('New device set is created');
-  expect(iAndD.deviceSets.length).to.equal(
-    beforeCapacityAddition.deviceSets.length + 1
-  );
-
-  cy.log('Device count is 1 in the new device set');
-  expect(iAndD.deviceSets[iAndD.index].count).to.equal(1);
-
-  cy.log(`Osd portability is ${portabilityStatus} in the new device set`);
-  expect(iAndD.deviceSets[iAndD.index].portable).to.equal(portability);
+  cy.byTestID('add-cap-sc-dropdown', { timeout: 10000 }).should('be.visible');
+  // eslint-disable-next-line cypress/no-unnecessary-waiting
+  cy.byTestID('add-cap-sc-dropdown').wait(1500).click();
+  scNames.forEach((name) => {
+    cy.contains('[data-test="dropdown-menu-item-link"]', name).should(
+      'not.exist'
+    );
+  });
+  cy.byLegacyTestID('modal-cancel-action').click();
 };
 
 export const existingStorageClassTests = (

--- a/packages/odf/modals/add-capacity/add-capacity-modal.tsx
+++ b/packages/odf/modals/add-capacity/add-capacity-modal.tsx
@@ -55,7 +55,6 @@ import {
   getDeviceSetReplica,
 } from '../../components/utils';
 import {
-  DefaultRequestSize,
   deviceClassTooltip,
   NO_PROVISIONER,
   requestedCapacityTooltip,
@@ -65,7 +64,6 @@ import { CAPACITY_INFO_QUERIES, StorageDashboardQuery } from '../../queries';
 import {
   checkArbiterCluster,
   checkFlexibleScaling,
-  createDeviceSet,
   filterSC,
   getCurrentDeviceSetIndex,
   getDeviceSetCount,
@@ -329,6 +327,16 @@ const AddCapacityModal: React.FC<StorageClusterActionModalProps> = ({
     [installStorageClass]
   );
 
+  const storageClassesUsedByDeviceSets = React.useMemo(() => {
+    const storageClasses = new Set<string>();
+    for (const ds of deviceSets) {
+      if (ds.dataPVCTemplate?.spec?.storageClassName) {
+        storageClasses.add(ds.dataPVCTemplate.spec.storageClassName);
+      }
+    }
+    return storageClasses;
+  }, [deviceSets]);
+
   const deviceClasses = React.useMemo(
     () => getDeviceClassesForSC(deviceSets, selectedSCName),
     [deviceSets, selectedSCName]
@@ -353,6 +361,9 @@ const AddCapacityModal: React.FC<StorageClusterActionModalProps> = ({
   // Stops users from moving from no-prov SC to prov SC. (Bug 2213183)
   const storageClassFilter = React.useCallback(
     (sc: StorageClassResourceKind) => {
+      if (!storageClassesUsedByDeviceSets.has(getName(sc))) {
+        return undefined;
+      }
       if (scResourcesLoaded && !scResourcesLoadError) {
         const initialSC = scResources?.find(
           (item) => getName(item) === installStorageClass
@@ -363,7 +374,13 @@ const AddCapacityModal: React.FC<StorageClusterActionModalProps> = ({
       }
       return sc;
     },
-    [installStorageClass, scResources, scResourcesLoadError, scResourcesLoaded]
+    [
+      storageClassesUsedByDeviceSets,
+      installStorageClass,
+      scResources,
+      scResourcesLoadError,
+      scResourcesLoaded,
+    ]
   );
 
   const validateSC = React.useCallback(() => {
@@ -418,39 +435,27 @@ const AddCapacityModal: React.FC<StorageClusterActionModalProps> = ({
   const submit = (event: React.FormEvent<EventTarget>) => {
     event.preventDefault();
     setProgress(true);
-    const patch = {
-      op: '',
-      path: '',
-      value: null,
-    };
-    const osdSizeRequest = isNoProvionerSC
-      ? DefaultRequestSize.BAREMETAL
-      : osdSizeWithUnit;
-    let portable = !isNoProvionerSC;
-    let deviceSetReplica = replica;
-    let deviceSetCount = 1;
-
-    if (hasFlexibleScaling) {
-      portable = false;
-    }
-    if (isNoProvionerSC)
-      deviceSetCount = getDeviceSetCount(availablePvsCount, deviceSetReplica);
 
     if (deviceSetIndex === -1) {
-      patch.op = 'add';
-      patch.path = `/spec/storageDeviceSets/-`;
-      patch.value = createDeviceSet(
-        selectedSCName,
-        osdSizeRequest,
-        portable,
-        deviceSetReplica,
-        deviceSetCount
+      // eslint-disable-next-line no-console -- intentional diagnostics if state and UI ever diverge
+      console.error(
+        '[Add Capacity] No StorageDeviceSet matches the selected StorageClass; adding new device sets is not supported.',
+        { selectedSCName, deviceClass }
       );
-    } else {
-      patch.op = 'replace';
-      patch.path = `/spec/storageDeviceSets/${deviceSetIndex}/count`;
-      patch.value = deviceSets[deviceSetIndex].count + deviceSetCount;
+      setProgress(false);
+      return;
     }
+
+    let deviceSetCount = 1;
+    if (isNoProvionerSC) {
+      deviceSetCount = getDeviceSetCount(availablePvsCount, replica);
+    }
+
+    const patch = {
+      op: 'replace',
+      path: `/spec/storageDeviceSets/${deviceSetIndex}/count`,
+      value: deviceSets[deviceSetIndex].count + deviceSetCount,
+    };
 
     const validation: string = validateSC();
     if (validation) {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/DFBUGS-5050

Update the Add Capacity modal to only list StorageClasses already in use by existing deviceSet

created a new storage class set1 not in use by any device sets.

**before fix:**

<img width="1728" height="1117" alt="Screenshot 2026-04-28 at 2 13 12 PM" src="https://github.com/user-attachments/assets/b5f8f043-c5fc-4a9d-8f5f-37dad19b7465" />

**after fix:**

https://github.com/user-attachments/assets/30043968-1dd8-4128-8508-c42926d1e8a7



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The Add Capacity dialog now lists only storage classes already used by the cluster.
  - Capacity additions now target an existing matching device set and update its capacity.

- **Bug Fixes**
  - Prevented capacity additions from creating new device sets when no matching device set exists.
  - The operation now stops safely when no suitable device set is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->