### PR TITLE
Add Lazy loading to IAM

### DIFF
--- a/packages/odf/components/s3-iam/access-keys-details/AccessKeysDetails.tsx
+++ b/packages/odf/components/s3-iam/access-keys-details/AccessKeysDetails.tsx
@@ -155,3 +155,5 @@ export const AccessKeysDetails: React.FC<IamAccesskeysDetailsProps> = ({
     <LoadingBox />
   );
 };
+
+export default AccessKeysDetails;

--- a/packages/odf/components/s3-iam/tags-details/TagsDetails.tsx
+++ b/packages/odf/components/s3-iam/tags-details/TagsDetails.tsx
@@ -94,3 +94,5 @@ export const TagsDetails: React.FC<TagsDetailsProps> = ({ obj }) => {
     <LoadingBox />
   );
 };
+
+export default TagsDetails;

--- a/packages/odf/components/s3-iam/user-overview/UserOverview.tsx
+++ b/packages/odf/components/s3-iam/user-overview/UserOverview.tsx
@@ -12,9 +12,7 @@ import { Button, ButtonVariant } from '@patternfly/react-core';
 import { ActionsColumn } from '@patternfly/react-table';
 import { DeleteIamUserModal } from '../../../modals/s3-iam/DeleteIamUserModal';
 import { CustomActionsToggle } from '../../s3-browser/objects-list';
-import { AccessKeysDetails } from '../access-keys-details/AccessKeysDetails';
 import { IamContext, IamProvider } from '../iam-context';
-import { TagsDetails } from '../tags-details/TagsDetails';
 
 const UserOverview: React.FC<{}> = () => {
   const { t } = useCustomTranslation();
@@ -27,12 +25,14 @@ const UserOverview: React.FC<{}> = () => {
       {
         href: 'details',
         name: t('Details'),
-        component: TagsDetails,
+        component: React.lazy(() => import('../tags-details/TagsDetails')),
       },
       {
         href: 'access-keys',
         name: t('Access Keys'),
-        component: AccessKeysDetails,
+        component: React.lazy(
+          () => import('../access-keys-details/AccessKeysDetails')
+        ),
       },
     ],
     [t]


### PR DESCRIPTION
**_An internal dev change without a bug_**

Add lazy-loaded chunks for the IAM user overview Details and Access Keys tabs using the same React.lazy pattern as S3 bucket and vector bucket overviews.

Switch those tab modules to a default export so dynamic imports resolve cleanly. 

No functional change intended beyond loading those panels on demand when the tab is opened.

everything seems working as usual

https://github.com/user-attachments/assets/f3fd2637-9306-4bc4-aa33-477d30b3dc11
