### PR TITLE
fix: TNF day-1 device set count/replica

### DIFF
--- a/packages/odf/components/utils/common.ts
+++ b/packages/odf/components/utils/common.ts
@@ -516,7 +516,7 @@ export const getOCSRequestData = ({
       },
     };
   } else if (isTNFEnabled) {
-    requestData.spec = getTNFSpecs(scName, storage);
+    requestData.spec = getTNFSpecs(scName, storage, availablePvsCount);
   } else {
     // for full deployment - ceph + mcg
     requestData.spec = {

--- a/packages/odf/utils/ocs.ts
+++ b/packages/odf/utils/ocs.ts
@@ -288,7 +288,11 @@ export const createDeviceSet = (
   },
 });
 
-export const getTNFSpecs = (scName: string, storage: string) => ({
+export const getTNFSpecs = (
+  scName: string,
+  storage: string,
+  pvCount: number
+) => ({
   flexibleScaling: true,
   managedResources: {
     cephObjectStoreUsers: {
@@ -306,8 +310,8 @@ export const getTNFSpecs = (scName: string, storage: string) => ({
     {
       name: 'ocs-deviceset',
       config: {},
-      count: 1,
-      replica: 2,
+      count: getDeviceSetCount(pvCount, 1),
+      replica: 1,
       portable: false,
       resources: {},
       dataPVCTemplate: {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/DFBUGS-6474

TNF day‑1 was hardcoding count: 1 and replica: 2 in getTNFSpecs, which is wrong for host failure domain.  Now it sets replica: 1 and count from available PVs via getDeviceSetCount,
and getOCSRequestData passes availablePvsCount into getTNFSpecs.