### PR TITLE
Fix null reference crashes in DR components

### DIFF
--- a/packages/mco/components/dr-status-popover/acm-column-callback.tsx
+++ b/packages/mco/components/dr-status-popover/acm-column-callback.tsx
@@ -10,6 +10,8 @@ import { ApplicationSetParser, SubscriptionParser } from './parsers';
 import VirtualMachineParser from './parsers/virtualmachine-parser';
 
 const DRStatus: React.FC<DRStatusProps> = ({ resource }) => {
+  if (!resource) return null;
+
   const application =
     'apigroup' in resource ? convertSearchResult(resource as any) : resource;
   const gvk = getGVKFromK8Resource(application);

--- a/packages/mco/components/modals/app-manage-policies/app-manage-policies-modal.tsx
+++ b/packages/mco/components/modals/app-manage-policies/app-manage-policies-modal.tsx
@@ -25,7 +25,10 @@ export const AppManagePoliciesModal: React.FC<AppManagePoliciesModalProps> = ({
   // This causes performance issues and unnecessary recalculations.
   // Fix: useMemo ensures parsing only happens when 'resource' changes.
   const application = React.useMemo(
-    () => ('apigroup' in resource ? convertSearchResult(resource) : resource),
+    () =>
+      resource && 'apigroup' in resource
+        ? convertSearchResult(resource)
+        : resource,
     [resource]
   );
 

--- a/packages/shared/src/hooks/custom-prometheus-poll/safe-fetch-hook.ts
+++ b/packages/shared/src/hooks/custom-prometheus-poll/safe-fetch-hook.ts
@@ -10,10 +10,10 @@ export type SafeFetchProps = {
 };
 
 export const useSafeFetch = () => {
-  const controller = useRef<AbortController>();
+  const controller = useRef<AbortController>(new AbortController());
   useEffect(() => {
-    controller.current = new AbortController();
-    return () => controller.current.abort();
+    const ctrl = controller.current;
+    return () => ctrl.abort();
   }, []);
 
   return (props: SafeFetchProps) =>


### PR DESCRIPTION
[DFBUGS-6377](https://redhat.atlassian.net/browse/DFBUGS-6377): Add null guards to prevent TypeError when resource is undefined in DRStatus and AppManagePoliciesModal components (the `in` operator requires an object operand), and initialize the AbortController ref to avoid accessing an uninitialized signal in useSafeFetch.