### PR TITLE
Add sdk-wrapper for ListPageFilter (error boundary) and useModal (deferred launch)

### DIFF
--- a/packages/mco/components/create-dr-policy/select-cluster-list.tsx
+++ b/packages/mco/components/create-dr-policy/select-cluster-list.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { getManagedClusterResourceObj } from '@odf/mco/hooks';
 import { useStorageProvisioners } from '@odf/mco/hooks/use-storage-provisioner';
-import { ACMManagedClusterViewModel } from '@odf/shared';
+import { ACMManagedClusterViewModel, ListPageFilterWrapper } from '@odf/shared';
 import { DASH } from '@odf/shared/constants';
 import { useDeepCompareMemoize } from '@odf/shared/hooks/deep-compare-memoize';
 import { getName } from '@odf/shared/selectors';
@@ -18,7 +18,6 @@ import {
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { getPageRange, referenceForModel } from '@odf/shared/utils';
 import {
-  ListPageFilter,
   useK8sWatchResource,
   useListPageFilter,
 } from '@openshift-console/dynamic-plugin-sdk';
@@ -184,7 +183,7 @@ const PaginatedClusterTable: React.FC<PaginatedClusterTableProps> = ({
     <>
       <Grid>
         <GridItem md={8} sm={12} className="pf-v6-u-mt-md">
-          <ListPageFilter
+          <ListPageFilterWrapper
             data={data}
             loaded={isLoaded}
             onFilterChange={onFilterChange}

--- a/packages/mco/components/discovered-application-wizard/wizard-steps/namespace-step/namespace-table.tsx
+++ b/packages/mco/components/discovered-application-wizard/wizard-steps/namespace-step/namespace-table.tsx
@@ -10,6 +10,7 @@ import {
   queryNamespacesUsingCluster,
   convertSearchResultToK8sResourceCommon,
 } from '@odf/mco/utils';
+import { ListPageFilterWrapper } from '@odf/shared';
 import { NamespaceModel } from '@odf/shared/models';
 import { ResourceIcon } from '@odf/shared/resource-link/resource-link';
 import { getAnnotations, getName } from '@odf/shared/selectors';
@@ -23,7 +24,6 @@ import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { isSystemNamespace, sortRows } from '@odf/shared/utils';
 import {
   K8sResourceCommon,
-  ListPageFilter,
   useListPageFilter,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { TFunction } from 'react-i18next';
@@ -189,7 +189,7 @@ export const NamespaceSelectionTable: React.FC<
         </Content>
       </GridItem>
       <GridItem span={10}>
-        <ListPageFilter
+        <ListPageFilterWrapper
           data={data}
           loaded={searchLoaded}
           onFilterChange={onFilterChange}

--- a/packages/mco/components/drpolicy-list-page/drpolicy-list-page.tsx
+++ b/packages/mco/components/drpolicy-list-page/drpolicy-list-page.tsx
@@ -8,6 +8,7 @@ import {
 import {
   DRClusterModel,
   DRPolicyModel,
+  ListPageFilterWrapper,
   MirrorPeerModel,
   SecretModel,
 } from '@odf/shared';
@@ -22,7 +23,6 @@ import {
   ListPageCreateLink,
   VirtualizedTable,
   useListPageFilter,
-  ListPageFilter,
   TableData,
   RowProps,
   useActiveColumns,
@@ -317,7 +317,7 @@ export const DRPolicyListPage: React.FC = () => {
       ) : (
         <>
           <div className="mco-drpolicy-list__header">
-            <ListPageFilter
+            <ListPageFilterWrapper
               data={data}
               loaded={!!drPolicies?.length}
               onFilterChange={onFilterChange}

--- a/packages/mco/components/protected-applications/components.tsx
+++ b/packages/mco/components/protected-applications/components.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react';
 import { ProtectedApplicationViewKind } from '@odf/mco/types/pav';
-import { DRPlacementControlModel, getName, getNamespace } from '@odf/shared';
+import {
+  DRPlacementControlModel,
+  getName,
+  getNamespace,
+  useModalWrapper,
+} from '@odf/shared';
 import {
   ActionDropdown,
   ToggleVariant,
@@ -12,10 +17,7 @@ import { ResourceNameWIcon } from '@odf/shared/resource-link/resource-link';
 import { PopoverStatus } from '@odf/shared/status';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { referenceForModel } from '@odf/shared/utils';
-import {
-  useK8sWatchResources,
-  useModal,
-} from '@openshift-console/dynamic-plugin-sdk';
+import { useK8sWatchResources } from '@openshift-console/dynamic-plugin-sdk';
 import { WatchK8sResource } from '@openshift-console/dynamic-plugin-sdk-internal/lib/extensions/console-types';
 import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
 import classNames from 'classnames';
@@ -81,7 +83,7 @@ export const EnrollApplicationButton: React.FC<{
 }> = ({ isNoDataMessage, toggleVariant }) => {
   const { t } = useCustomTranslation();
   const navigate = useNavigate();
-  const launcher = useModal();
+  const launcher = useModalWrapper();
 
   return (
     <div

--- a/packages/mco/components/protected-applications/list-page.tsx
+++ b/packages/mco/components/protected-applications/list-page.tsx
@@ -6,7 +6,11 @@ import {
   getPAVDRPolicyName,
   getPrimaryCluster,
 } from '@odf/mco/utils';
-import { DRPlacementControlModel, getNamespace } from '@odf/shared';
+import {
+  DRPlacementControlModel,
+  getNamespace,
+  useModalWrapper,
+} from '@odf/shared';
 import { DASH } from '@odf/shared/constants';
 import { PaginatedListPage } from '@odf/shared/list-page';
 import ResourceLink from '@odf/shared/resource-link/resource-link';
@@ -15,7 +19,6 @@ import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import {
   useK8sWatchResource,
   useListPageFilter,
-  useModal,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { LaunchModal } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
 import {
@@ -144,7 +147,7 @@ const ProtectedAppsTableRow: React.FC<
 
 export const ProtectedApplicationsListPage: React.FC = () => {
   const { t } = useCustomTranslation();
-  const launcher = useModal();
+  const launcher = useModalWrapper();
   const navigate = useNavigate();
 
   const [pavs, pavsLoaded, pavsError] = useK8sWatchResource<

--- a/packages/ocs/storage-class/sc-form.tsx
+++ b/packages/ocs/storage-class/sc-form.tsx
@@ -31,7 +31,7 @@ import {
   K8sResourceObj,
 } from '@odf/core/types';
 import { getResourceInNs } from '@odf/core/utils';
-import { CephFileSystemModel } from '@odf/shared';
+import { CephFileSystemModel, useModalWrapper } from '@odf/shared';
 import { DEFAULT_INFRASTRUCTURE } from '@odf/shared/constants';
 import ResourceDropdown from '@odf/shared/dropdown/ResourceDropdown';
 import { ButtonBar } from '@odf/shared/generic/ButtonBar';
@@ -63,7 +63,6 @@ import { getInfrastructurePlatform, isNotFoundError } from '@odf/shared/utils';
 import {
   ProvisionerProps,
   useK8sWatchResource,
-  useModal,
   WatchK8sResource,
 } from '@openshift-console/dynamic-plugin-sdk';
 import * as _ from 'lodash-es';
@@ -318,7 +317,7 @@ export const CephFsPoolComponent: React.FC<ProvisionerProps> = ({
   // reference of "onParamChange" changes on each re-render, hence storing in a "useRef"
   onParamChangeRef.current = onParamChange;
 
-  const launchModal = useModal();
+  const launchModal = useModalWrapper();
 
   const [isOpen, setOpen] = React.useState(false);
 
@@ -459,7 +458,7 @@ export const BlockPoolResourceComponent: React.FC<ProvisionerProps> = ({
   // reference of "onParamChange" changes on each re-render, hence storing in a "useRef"
   onParamChangeRef.current = onParamChange;
 
-  const launchModal = useModal();
+  const launchModal = useModalWrapper();
 
   const [cephClusters, cephClustersLoaded, cephClustersLoadError] =
     useK8sWatchResource<CephClusterKind[]>(cephClusterResource);

--- a/packages/ocs/storage-pool/StoragePoolListPage.tsx
+++ b/packages/ocs/storage-pool/StoragePoolListPage.tsx
@@ -4,7 +4,11 @@ import {
   useODFSystemFlagsSelector,
 } from '@odf/core/redux';
 import { getCephBlockPoolResource } from '@odf/core/resources';
-import { CephBlockPoolModel, CephFileSystemModel } from '@odf/shared';
+import {
+  CephBlockPoolModel,
+  CephFileSystemModel,
+  ListPageFilterWrapper,
+} from '@odf/shared';
 import {
   useCustomPrometheusPoll,
   usePrometheusBasePath,
@@ -25,7 +29,6 @@ import {
 import {
   ListPageBody,
   ListPageCreateLink,
-  ListPageFilter,
   ListPageHeader,
   RowProps,
   TableColumn,
@@ -695,7 +698,7 @@ const StoragePoolList: React.FC<StoragePoolListProps> = ({
         )}
       </ListPageHeader>
       <ListPageBody>
-        <ListPageFilter
+        <ListPageFilterWrapper
           data={data}
           loaded={loaded}
           onFilterChange={onFilterChange}

--- a/packages/odf/components/ResourceDistribution/ResourceDistributionTable.tsx
+++ b/packages/odf/components/ResourceDistribution/ResourceDistributionTable.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
-import { getName } from '@odf/shared';
+import { getName, ListPageFilterWrapper } from '@odf/shared';
 import { TableSkeletonLoader } from '@odf/shared/skeletal-loader/TableSkeleton';
 import {
   K8sResourceCommon,
-  ListPageFilter,
   useListPageFilter,
 } from '@openshift-console/dynamic-plugin-sdk';
 import * as _ from 'lodash-es';
@@ -102,7 +101,7 @@ export const ResourceDistributionTable: React.FC<
     <TableSkeletonLoader columns={4} rows={8} />
   ) : (
     <>
-      <ListPageFilter
+      <ListPageFilterWrapper
         data={unfilteredData}
         loaded={loaded}
         onFilterChange={onFilterChange}

--- a/packages/odf/components/Sections/InitialEmptyStatePage.tsx
+++ b/packages/odf/components/Sections/InitialEmptyStatePage.tsx
@@ -8,9 +8,9 @@ import {
   PageHeading,
   useCustomTranslation,
 } from '@odf/shared';
+import { useModalWrapper } from '@odf/shared';
 import { DOC_VERSION } from '@odf/shared/hooks/use-doc-version';
 import { ViewDocumentation } from '@odf/shared/utils';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
 import { Helmet } from 'react-helmet';
 import { TFunction, Trans } from 'react-i18next';
 import { useLocation } from 'react-router-dom-v5-compat';
@@ -103,7 +103,7 @@ const EmptyStatePageBody: React.FC = () => {
 
 const ExternalSystemsEmptyState: React.FC = () => {
   const { t } = useCustomTranslation();
-  const launchModal = useModal();
+  const launchModal = useModalWrapper();
   return (
     <EmptyState
       headingLevel="h4"
@@ -140,7 +140,7 @@ const InitialEmptyStatePage: React.FC = () => {
   const location = useLocation();
   const path = location.pathname;
   const title = getPageTitle(path, t);
-  const launchModal = useModal();
+  const launchModal = useModalWrapper();
   const isExternalSystems = path.includes(StartingPoint.EXTERNAL_SYSTEMS);
 
   return (

--- a/packages/odf/components/actions/csv-actions.ts
+++ b/packages/odf/components/actions/csv-actions.ts
@@ -12,6 +12,7 @@ import {
   StorageClusterKind,
   useFetchCsv,
   useK8sGet,
+  useModalWrapper,
 } from '@odf/shared';
 import {
   InfrastructureModel,
@@ -32,7 +33,6 @@ import {
   useFlag,
   useK8sModel,
   useK8sWatchResource,
-  useModal,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { LaunchModal } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
 import { PROVIDER_MODE } from '../../features';
@@ -46,7 +46,7 @@ export const useCsvActions = ({
   const [k8sModel, inFlight] = useK8sModel(
     referenceFor(group)(version)(resource.kind)
   );
-  const launchModal = useModal();
+  const launchModal = useModalWrapper();
   const isProviderMode = useFlag(PROVIDER_MODE);
   const [csv, csvLoaded, csvLoadError] = useFetchCsv({
     specName: LSO_OPERATOR,

--- a/packages/odf/components/bucket-class/backingstore-table.tsx
+++ b/packages/odf/components/bucket-class/backingstore-table.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useSafeK8sWatchResource } from '@odf/core/hooks';
 import { useODFNamespaceSelector } from '@odf/core/redux';
-import { NooBaaBackingStoreModel } from '@odf/shared';
+import { ListPageFilterWrapper, NooBaaBackingStoreModel } from '@odf/shared';
 import { useDeepCompareMemoize } from '@odf/shared/hooks/deep-compare-memoize';
 import { useSelectList } from '@odf/shared/hooks/select-list';
 import { getName, getNamespace, getUID } from '@odf/shared/selectors';
@@ -9,7 +9,6 @@ import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { referenceForModel } from '@odf/shared/utils';
 import {
   ListPageBody,
-  ListPageFilter,
   ResourceLink,
   RowProps,
   TableColumn,
@@ -201,7 +200,7 @@ const BackingStoreListWrapper: React.FC<BackingStoreListWrapperProps> = ({
 
   return (
     <ListPageBody>
-      <ListPageFilter
+      <ListPageFilterWrapper
         data={data}
         loaded={loaded && isODFNsLoaded}
         onFilterChange={onFilterChange}

--- a/packages/odf/components/bucket-class/create-bc.tsx
+++ b/packages/odf/components/bucket-class/create-bc.tsx
@@ -1,14 +1,13 @@
 import * as React from 'react';
 import NamespaceSafetyBox from '@odf/core/components/utils/safety-box';
 import { useODFNamespaceSelector } from '@odf/core/redux';
-import { NooBaaBucketClassModel } from '@odf/shared';
+import { NooBaaBucketClassModel, useModalWrapper } from '@odf/shared';
 import { getName } from '@odf/shared/selectors';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { referenceForModel } from '@odf/shared/utils';
 import {
   getAPIVersionForModel,
   k8sCreate,
-  useModal,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { useParams, useNavigate } from 'react-router-dom-v5-compat';
 import {
@@ -372,7 +371,7 @@ const CreateBucketClass: React.FC = () => {
   const { ns } = useParams();
   const namespace = ns || odfNamespace;
 
-  const launcher = useModal();
+  const launcher = useModalWrapper();
 
   const launchNamespaceStoreModal = React.useCallback(
     () =>

--- a/packages/odf/components/bucket-class/wizard-pages/backingstore-page.tsx
+++ b/packages/odf/components/bucket-class/wizard-pages/backingstore-page.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
+import { useModalWrapper } from '@odf/shared';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
 import { Alert, AlertActionCloseButton } from '@patternfly/react-core';
 import { ExternalLink } from '../../mcg-endpoints/gcp-endpoint-type';
 import BackingStoreSelection from '../backingstore-table';
@@ -18,7 +18,7 @@ const BackingStorePage: React.FC<BackingStorePageProps> = React.memo(
       state;
     const [showHelp, setShowHelp] = React.useState(true);
     const { t } = useCustomTranslation();
-    const launcher = useModal();
+    const launcher = useModalWrapper();
 
     const launchModal = () =>
       launcher(CreateBackingStoreModal, { isOpen: true });

--- a/packages/odf/components/create-storage-system/external-systems/CreateFlashSystem/FlashSystemConnectionDetails/system-connection-details.tsx
+++ b/packages/odf/components/create-storage-system/external-systems/CreateFlashSystem/FlashSystemConnectionDetails/system-connection-details.tsx
@@ -10,7 +10,7 @@ import {
 } from '@odf/core/redux';
 import { getExternalSubSystemName, hasAnyInternalOCS } from '@odf/core/utils';
 import { CreatePayload } from '@odf/odf-plugin-sdk/extensions';
-import { PageHeading } from '@odf/shared';
+import { PageHeading, useModalWrapper } from '@odf/shared';
 import { FormGroupController } from '@odf/shared/form-group-controller';
 import { useK8sList } from '@odf/shared/hooks/useK8sList';
 import { SecretModel } from '@odf/shared/models';
@@ -23,7 +23,6 @@ import {
   k8sCreate,
   K8sModel,
   useFlag,
-  useModal,
 } from '@openshift-console/dynamic-plugin-sdk';
 import * as _ from 'lodash-es';
 import { useForm } from 'react-hook-form';
@@ -86,7 +85,7 @@ export const FlashSystemConnectionDetails: React.FC = () => {
   const [error, setError] = React.useState(null);
   const { odfNamespace } = useODFNamespaceSelector();
   const navigate = useNavigate();
-  const launchModal = useModal();
+  const launchModal = useModalWrapper();
   // Internal form state
   const [formState, setFormState] = React.useState<FlashSystemState>({
     endpoint: '',

--- a/packages/odf/components/create-storage-system/external-systems/CreateSANSystem/LUNsTable.tsx
+++ b/packages/odf/components/create-storage-system/external-systems/CreateSANSystem/LUNsTable.tsx
@@ -1,12 +1,9 @@
 import * as React from 'react';
 import { DiscoveredDevice } from '@odf/core/types/scale';
-import { DASH, useCustomTranslation } from '@odf/shared';
+import { DASH, ListPageFilterWrapper, useCustomTranslation } from '@odf/shared';
 import { TableSkeletonLoader } from '@odf/shared/skeletal-loader/TableSkeleton';
 import { humanizeBinaryBytes } from '@odf/shared/utils';
-import {
-  ListPageFilter,
-  useListPageFilter,
-} from '@openshift-console/dynamic-plugin-sdk';
+import { useListPageFilter } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Table,
   Tbody,
@@ -143,7 +140,7 @@ export const LUNsTable: React.FC<LUNsTableProps> = ({
 
   return (
     <div className="odf-luns-table">
-      <ListPageFilter
+      <ListPageFilterWrapper
         data={lunsData}
         loaded={loaded}
         onFilterChange={onLunsFilterChange}

--- a/packages/odf/components/create-storage-system/select-nodes-table/select-nodes-table.tsx
+++ b/packages/odf/components/create-storage-system/select-nodes-table/select-nodes-table.tsx
@@ -8,6 +8,7 @@ import {
   getNodeCPUCapacity,
   getNodeTotalMemory,
 } from '@odf/core/utils';
+import { ListPageFilterWrapper } from '@odf/shared';
 import { StatusBox } from '@odf/shared/generic/status-box';
 import { NodeModel } from '@odf/shared/models';
 import ResourceLink from '@odf/shared/resource-link/resource-link';
@@ -28,7 +29,6 @@ import {
 } from '@odf/shared/utils';
 import {
   ListPageBody,
-  ListPageFilter,
   useListPageFilter,
 } from '@openshift-console/dynamic-plugin-sdk';
 import classNames from 'classnames';
@@ -202,7 +202,7 @@ export const SelectNodesTable: React.FC<SelectNodesTableProps> = ({
   return (
     <div className="odf-capacity-and-nodes__select-nodes">
       <ListPageBody>
-        <ListPageFilter
+        <ListPageFilterWrapper
           data={data}
           loaded={nodesLoaded}
           onFilterChange={onFilterChange}

--- a/packages/odf/components/kms-config/vault-config.tsx
+++ b/packages/odf/components/kms-config/vault-config.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
+import { useModalWrapper } from '@odf/shared';
 import { useDeepCompareMemoize } from '@odf/shared/hooks/deep-compare-memoize';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { getValidatedProp } from '@odf/shared/utils';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
 import * as _ from 'lodash-es';
 import { TFunction } from 'react-i18next';
 import {
@@ -50,7 +50,7 @@ export const VaultConfigure: React.FC<KMSConfigureProps> = ({
 }) => {
   const { t } = useCustomTranslation();
 
-  const launchModal = useModal();
+  const launchModal = useModalWrapper();
 
   const vaultState = useDeepCompareMemoize(
     state.kms.providerState,

--- a/packages/odf/components/lso/disks-list/disk-list-page.tsx
+++ b/packages/odf/components/lso/disks-list/disk-list-page.tsx
@@ -12,6 +12,7 @@ import {
   getLabel,
   getName,
   getNamespace,
+  ListPageFilterWrapper,
   LocalVolumeDiscoveryResult,
   SubscriptionKind,
   SubscriptionModel,
@@ -25,7 +26,6 @@ import {
 } from '@odf/shared/utils';
 import {
   ListPageBody,
-  ListPageFilter,
   ListPageHeader,
   NodeKind,
   RowFilter,
@@ -284,7 +284,7 @@ export const NodesDisksListPage: React.FC<{ obj: NodeKind }> = ({ obj }) => {
     <>
       <ListPageHeader title={t('Disks')} />
       <ListPageBody>
-        <ListPageFilter
+        <ListPageFilterWrapper
           data={data}
           loaded={loaded}
           onFilterChange={onFilterChange}

--- a/packages/odf/components/mcg/ObjectBucket.tsx
+++ b/packages/odf/components/mcg/ObjectBucket.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
-import { NooBaaObjectBucketClaimModel } from '@odf/shared';
+import {
+  ListPageFilterWrapper,
+  NooBaaObjectBucketClaimModel,
+} from '@odf/shared';
 import DetailsPage, {
   ResourceSummary,
 } from '@odf/shared/details-page/DetailsPage';
@@ -14,7 +17,6 @@ import { EventStreamWrapped, YAMLEditorWrapped } from '@odf/shared/utils/Tabs';
 import {
   K8sResourceCommon,
   ListPageBody,
-  ListPageFilter,
   ResourceLink as ResourceLinkWithKind,
   RowProps,
   TableColumn,
@@ -197,7 +199,7 @@ export const ObjectBucketListPage: React.FC<ObjectBucketsPageProps> = (
 
   return (
     <ListPageBody>
-      <ListPageFilter
+      <ListPageFilterWrapper
         data={data}
         loaded={loaded}
         onFilterChange={onFilterChange}

--- a/packages/odf/components/mcg/ObjectBucketClaim.tsx
+++ b/packages/odf/components/mcg/ObjectBucketClaim.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
-import { NooBaaObjectBucketClaimModel } from '@odf/shared';
-import { NooBaaObjectBucketModel } from '@odf/shared';
+import {
+  ListPageFilterWrapper,
+  NooBaaObjectBucketClaimModel,
+  NooBaaObjectBucketModel,
+} from '@odf/shared';
 import DetailsPage, {
   ResourceSummary,
 } from '@odf/shared/details-page/DetailsPage';
@@ -16,7 +19,6 @@ import { EventStreamWrapped, YAMLEditorWrapped } from '@odf/shared/utils/Tabs';
 import {
   ListPageBody,
   ListPageCreateLink,
-  ListPageFilter,
   ListPageHeader,
   ResourceLink as ResourceLinkWithKind,
   RowProps,
@@ -278,7 +280,7 @@ export const OBCListPage: React.FC<ObjectBucketClaimsPageProps> = (props) => {
         </ListPageCreateLink>
       </ListPageHeader>
       <ListPageBody>
-        <ListPageFilter
+        <ListPageFilterWrapper
           data={data}
           loaded={loaded}
           onFilterChange={onFilterChange}

--- a/packages/odf/components/mcg/replication-policy-form.tsx
+++ b/packages/odf/components/mcg/replication-policy-form.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { NamespaceStoreKind } from '@odf/core/types';
+import { useModalWrapper } from '@odf/shared';
 import { getName } from '@odf/shared/selectors';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Flex,
   FlexItem,
@@ -64,7 +64,7 @@ export const ReplicationPolicyForm: React.FC<ReplicationFormProps> = ({
 
   const { t } = useCustomTranslation();
 
-  const launchModal = useModal();
+  const launchModal = useModalWrapper();
 
   const [eventLogsEnabled, toggleEventLogs] = React.useState(false);
 

--- a/packages/odf/components/namespace-store/namespace-store-table.tsx
+++ b/packages/odf/components/namespace-store/namespace-store-table.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useSafeK8sWatchResource } from '@odf/core/hooks';
 import { useODFNamespaceSelector } from '@odf/core/redux';
-import { NooBaaNamespaceStoreModel } from '@odf/shared';
+import { ListPageFilterWrapper, NooBaaNamespaceStoreModel } from '@odf/shared';
 import { useDeepCompareMemoize } from '@odf/shared/hooks/deep-compare-memoize';
 import { useSelectList } from '@odf/shared/hooks/select-list';
 import { getName, getNamespace } from '@odf/shared/selectors';
@@ -9,7 +9,6 @@ import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { referenceForModel } from '@odf/shared/utils';
 import {
   ListPageBody,
-  ListPageFilter,
   ResourceLink,
   RowProps,
   TableColumn,
@@ -162,7 +161,7 @@ const NamespaceStoreListWrapper: React.FC<NamespaceStoreListWrapperProps> = ({
   );
   return (
     <ListPageBody>
-      <ListPageFilter
+      <ListPageFilterWrapper
         data={data}
         loaded={loaded && isODFNsLoaded}
         onFilterChange={onFilterChange}

--- a/packages/odf/components/overview/Overview.tsx
+++ b/packages/odf/components/overview/Overview.tsx
@@ -5,7 +5,7 @@ import { ObjectStorageCard } from '@odf/core/components/overview/object-storage-
 import { StorageClusterCard } from '@odf/core/components/overview/storage-cluster-card/StorageClusterCard';
 import { StorageClusterCreateModal } from '@odf/core/modals/ConfigureDF/StorageClusterCreateModal';
 import { PageHeading, useCustomTranslation } from '@odf/shared';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useModalWrapper } from '@odf/shared';
 import { Helmet } from 'react-helmet';
 import { useLocation } from 'react-router-dom-v5-compat';
 import { Grid, GridItem } from '@patternfly/react-core';
@@ -19,7 +19,7 @@ const Overview: React.FC = () => {
   const location = useLocation();
   const searchParams = new URLSearchParams(location.search);
   const showWelcomeModal = searchParams.get('show-welcome-modal');
-  const launchModal = useModal();
+  const launchModal = useModalWrapper();
 
   React.useEffect(() => {
     if (showWelcomeModal === 'true') {

--- a/packages/odf/components/resource-pages/list-page.tsx
+++ b/packages/odf/components/resource-pages/list-page.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useSafeK8sWatchResource } from '@odf/core/hooks';
 import { useODFNamespaceSelector } from '@odf/core/redux';
 import {
+  ListPageFilterWrapper,
   NooBaaBackingStoreModel,
   NooBaaBucketClassModel,
   NooBaaNamespaceStoreModel,
@@ -18,7 +19,6 @@ import {
   K8sResourceCommon,
   ListPageBody,
   ListPageCreateLink,
-  ListPageFilter,
   ListPageHeader,
   RowProps,
   TableColumn,
@@ -204,7 +204,7 @@ const GenericListPage: React.FC<GenericListPageProps> = ({
         </ListPageCreateLink>
       </ListPageHeader>
       <ListPageBody>
-        <ListPageFilter
+        <ListPageFilterWrapper
           data={data}
           loaded={loaded && isODFNsLoaded}
           onFilterChange={onFilterChange}

--- a/packages/odf/components/s3-browser/bucket-details/BucketDetails.tsx
+++ b/packages/odf/components/s3-browser/bucket-details/BucketDetails.tsx
@@ -10,7 +10,7 @@ import {
 import SetVersioningModal, {
   SetVersioningModalModalProps,
 } from '@odf/core/modals/s3-browser/set-versioning/SetVersioningModal';
-import { DASH } from '@odf/shared';
+import { DASH, useModalWrapper } from '@odf/shared';
 import { LoadingBox } from '@odf/shared/generic/status-box';
 import { SectionHeading } from '@odf/shared/heading/page-heading';
 import {
@@ -18,10 +18,7 @@ import {
   getIsVersioningEnabled,
 } from '@odf/shared/s3/utils';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
-import {
-  K8sResourceCommon,
-  useModal,
-} from '@openshift-console/dynamic-plugin-sdk';
+import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import { useParams } from 'react-router-dom-v5-compat';
 import useSWR from 'swr';
 import {
@@ -109,7 +106,7 @@ const S3BucketProperties: React.FC<{}> = ({}) => {
   const versioningStatus = getVersioningStatus(versioningData, t);
   const isVersioningEnabled = getIsVersioningEnabled(versioningData);
 
-  const launcher = useModal();
+  const launcher = useModalWrapper();
 
   React.useEffect(
     () => setIsVersioningChecked(isVersioningEnabled),

--- a/packages/odf/components/s3-browser/bucket-overview/BucketOverview.tsx
+++ b/packages/odf/components/s3-browser/bucket-overview/BucketOverview.tsx
@@ -10,6 +10,7 @@ import {
   LazyDeleteBucketModal,
 } from '@odf/core/modals/s3-browser/delete-and-empty-bucket/lazy-delete-and-empty-bucket';
 import { S3ProviderType } from '@odf/core/types';
+import { useModalWrapper } from '@odf/shared';
 import PageHeading from '@odf/shared/heading/page-heading';
 import { useRefresh } from '@odf/shared/hooks';
 import { ModalKeys, defaultModalMap } from '@odf/shared/modals/types';
@@ -20,7 +21,6 @@ import { K8sResourceKind } from '@odf/shared/types';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import Tabs, { TabPage, YAMLEditorWrapped } from '@odf/shared/utils/Tabs';
 import {
-  useModal,
   K8sResourceCommon,
   useFlag,
 } from '@openshift-console/dynamic-plugin-sdk';
@@ -143,7 +143,7 @@ const createBucketActions = (
   fresh: boolean,
   triggerRefresh: () => void,
   foldersPath: string | null,
-  launcher: ReturnType<typeof useModal>,
+  launcher: ReturnType<typeof useModalWrapper>,
   navigate: NavigateFunction,
   bucketName: string,
   allowResourceEditing: boolean,
@@ -189,7 +189,7 @@ const BucketOverview: React.FC<{}> = () => {
   const { t } = useCustomTranslation();
   const [fresh, triggerRefresh] = useRefresh();
 
-  const launcher = useModal();
+  const launcher = useModalWrapper();
   const navigate = useNavigate();
 
   const { bucketName } = useParams();

--- a/packages/odf/components/s3-browser/bucket-policy/BucketPolicy.tsx
+++ b/packages/odf/components/s3-browser/bucket-policy/BucketPolicy.tsx
@@ -8,9 +8,9 @@ import {
 import { BUCKET_POLICY_CACHE_KEY_SUFFIX } from '@odf/core/constants';
 import DeleteBucketPolicyModal from '@odf/core/modals/s3-common/bucket-policy/DeleteBucketPolicy';
 import SaveBucketPolicyModal from '@odf/core/modals/s3-common/bucket-policy/SaveBucketPolicy';
+import { useModalWrapper } from '@odf/shared';
 import { StatusBox, LoadingBox } from '@odf/shared/generic/status-box';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
 import { useParams } from 'react-router-dom-v5-compat';
 import useSWRMutation from 'swr/mutation';
 import { PreConfiguredPolicies } from './PreConfiguredPolicies';
@@ -49,7 +49,7 @@ const BucketPolicyContent: React.FC<BucketPolicyContentProps> = ({
   const [edit, setEdit] = React.useState(false);
   const { s3Client } = React.useContext(S3Context);
   const { bucketName } = useParams();
-  const launcher = useModal();
+  const launcher = useModalWrapper();
 
   const launchDeleteModal = () =>
     launcher(DeleteBucketPolicyModal, {

--- a/packages/odf/components/s3-browser/buckets-list-page/bucketListTable.tsx
+++ b/packages/odf/components/s3-browser/buckets-list-page/bucketListTable.tsx
@@ -9,6 +9,7 @@ import {
   LazyEmptyBucketModal,
 } from '@odf/core/modals/s3-browser/delete-and-empty-bucket/lazy-delete-and-empty-bucket';
 import { BucketCrFormat, S3ProviderType } from '@odf/core/types';
+import { useModalWrapper } from '@odf/shared';
 import { Timestamp } from '@odf/shared/details-page/timestamp';
 import { EmptyPage } from '@odf/shared/empty-state-page';
 import { useUserSettingsLocalStorage } from '@odf/shared/hooks/useUserSettingsLocalStorage';
@@ -19,7 +20,6 @@ import {
 } from '@odf/shared/table/composable-table';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { sortRows } from '@odf/shared/utils';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
 import { LaunchModal } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
 import { TFunction } from 'react-i18next';
 import { Link } from 'react-router-dom-v5-compat';
@@ -233,7 +233,7 @@ export const BucketsListTable: React.FC<BucketsListTableProps> = ({
     true,
     []
   );
-  const launcher = useModal();
+  const launcher = useModalWrapper();
 
   return (
     <ComposableTable

--- a/packages/odf/components/s3-browser/buckets-list-page/bucketsListPage.tsx
+++ b/packages/odf/components/s3-browser/buckets-list-page/bucketsListPage.tsx
@@ -5,17 +5,16 @@ import {
   EmptyBucketResponse,
 } from '@odf/core/modals/s3-browser/delete-and-empty-bucket/EmptyBucketModal';
 import { S3ProviderType } from '@odf/core/types';
+import { ListPageFilterWrapper, useModalWrapper } from '@odf/shared';
 import { useRefresh } from '@odf/shared/hooks';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { getValidFilteredData, isClientPlugin } from '@odf/shared/utils';
 import {
   ListPageBody,
   ListPageCreateLink,
-  ListPageFilter,
   ListPageHeader,
   useListPageFilter,
   useFlag,
-  useModal,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 import {
@@ -91,7 +90,7 @@ const BucketsListPageBody: React.FC<BucketsListPageBodyProps> = ({
       <Flex className="pf-v6-u-mt-md">
         <Flex flex={{ default: 'flex_1' }}>
           <FlexItem className="pf-v6-u-mr-md">
-            <ListPageFilter
+            <ListPageFilterWrapper
               loaded={true}
               hideLabelFilter={true}
               nameFilterPlaceholder={t('Search a bucket by name')}
@@ -139,7 +138,7 @@ const BucketsListPageContent: React.FC = () => {
 
   const isAdmin = useFlag(ODF_ADMIN);
   const { s3Client, logout, setSecretRef } = React.useContext(S3Context);
-  const launcher = useModal();
+  const launcher = useModalWrapper();
 
   const providerType = s3Client.providerType as S3ProviderType;
 

--- a/packages/odf/components/s3-browser/cors-details/CorsDetailsPage.tsx
+++ b/packages/odf/components/s3-browser/cors-details/CorsDetailsPage.tsx
@@ -7,12 +7,12 @@ import {
 } from '@odf/core/components/s3-browser/s3-context';
 import { S3ProviderType } from '@odf/core/types';
 import { DASH } from '@odf/shared';
+import { useModalWrapper } from '@odf/shared';
 import { StatusBox } from '@odf/shared/generic/status-box';
 import PageHeading from '@odf/shared/heading/page-heading';
 import { S3Commands } from '@odf/shared/s3';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { deepSortObject } from '@odf/shared/utils';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
 import { LaunchModal } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
 import * as _ from 'lodash-es';
 import { murmur3 } from 'murmurhash-js';
@@ -146,7 +146,7 @@ export const CorsDetailsContent: React.FC<CorsDetailsContentProps> = ({
 const CorsDetails: React.FC = () => {
   const { t } = useCustomTranslation();
 
-  const launcher = useModal();
+  const launcher = useModalWrapper();
   const navigate = useNavigate();
 
   const { bucketName } = useParams();

--- a/packages/odf/components/s3-browser/cors-rules-list/CORSRulesList.tsx
+++ b/packages/odf/components/s3-browser/cors-rules-list/CORSRulesList.tsx
@@ -10,7 +10,7 @@ import {
 import DeleteCorsRuleModal from '@odf/core/modals/s3-browser/delete-corsrules/DeleteCorsRuleModal';
 import { S3ProviderType } from '@odf/core/types';
 import { isAllowAllConfig } from '@odf/core/utils';
-import { DASH } from '@odf/shared';
+import { DASH, ListPageFilterWrapper, useModalWrapper } from '@odf/shared';
 import EmptyPage from '@odf/shared/empty-state-page/empty-page';
 import { LoadingBox, StatusBox } from '@odf/shared/generic/status-box';
 import { S3Commands } from '@odf/shared/s3';
@@ -20,7 +20,6 @@ import { fuzzyCaseInsensitive, deepSortObject } from '@odf/shared/utils';
 import {
   ListPageBody,
   ListPageCreateLink,
-  ListPageFilter,
   ListPageHeader,
   RowFilter,
   RowProps,
@@ -28,7 +27,6 @@ import {
   TableData,
   useActiveColumns,
   useListPageFilter,
-  useModal,
   VirtualizedTable,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { LaunchModal } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
@@ -279,7 +277,7 @@ const CORSRulesListContent: React.FC = () => {
   const { t } = useCustomTranslation();
   const { bucketName } = useParams();
   const navigate = useNavigate();
-  const launcher = useModal();
+  const launcher = useModalWrapper();
   const { s3Client } = React.useContext(S3Context);
 
   const { data, isLoading, error, mutate } = useSWR(
@@ -330,7 +328,7 @@ const CORSRulesListContent: React.FC = () => {
           />
         ) : (
           <>
-            <ListPageFilter
+            <ListPageFilterWrapper
               data={unfilteredCorsRules}
               loaded
               hideLabelFilter={true}

--- a/packages/odf/components/s3-browser/lifecycle-rules-list/LifecycleRulesList.tsx
+++ b/packages/odf/components/s3-browser/lifecycle-rules-list/LifecycleRulesList.tsx
@@ -5,7 +5,7 @@ import {
 } from '@aws-sdk/client-s3';
 import { S3Context } from '@odf/core/components/s3-browser/s3-context';
 import { S3ProviderType } from '@odf/core/types';
-import { DASH } from '@odf/shared';
+import { DASH, ListPageFilterWrapper, useModalWrapper } from '@odf/shared';
 import EmptyPage from '@odf/shared/empty-state-page/empty-page';
 import { LoadingBox, StatusBox } from '@odf/shared/generic/status-box';
 import { S3Commands } from '@odf/shared/s3';
@@ -16,7 +16,6 @@ import { fuzzyCaseInsensitive } from '@odf/shared/utils';
 import {
   ListPageBody,
   ListPageCreateLink,
-  ListPageFilter,
   ListPageHeader,
   RowProps,
   TableColumn,
@@ -25,7 +24,6 @@ import {
   useListPageFilter,
   VirtualizedTable,
   RowFilter,
-  useModal,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { LaunchModal } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
 import { murmur3 } from 'murmurhash-js';
@@ -313,7 +311,7 @@ const LifecycleRulesListContent: React.FC = () => {
 
   const { bucketName } = useParams();
   const navigate = useNavigate();
-  const launcher = useModal();
+  const launcher = useModalWrapper();
   const { s3Client } = React.useContext(S3Context);
 
   const { data, isLoading, error, mutate } = useSWR(
@@ -368,7 +366,7 @@ const LifecycleRulesListContent: React.FC = () => {
           />
         ) : (
           <>
-            <ListPageFilter
+            <ListPageFilterWrapper
               data={unfilteredRules}
               loaded
               hideLabelFilter={true}

--- a/packages/odf/components/s3-browser/object-details/ObjectDetailsSidebar.tsx
+++ b/packages/odf/components/s3-browser/object-details/ObjectDetailsSidebar.tsx
@@ -20,10 +20,10 @@ import {
   LoadingBox,
   useCustomTranslation,
 } from '@odf/shared';
+import { useModalWrapper } from '@odf/shared';
 import { PaginatedListPage } from '@odf/shared/list-page';
 import { S3Commands } from '@odf/shared/s3';
 import { CopyToClipboard } from '@odf/shared/utils/copy-to-clipboard';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
 import { TFunction } from 'react-i18next';
 import { useParams, useSearchParams } from 'react-router-dom-v5-compat';
 import useSWR from 'swr';
@@ -177,7 +177,7 @@ const ObjectVersions: React.FC<ObjectVersionsProps> = ({
     closeObjectSidebar,
   } = extraProps;
 
-  const launcher = useModal();
+  const launcher = useModalWrapper();
 
   const [objectVersions, setObjectVersions] = React.useState<ObjectCrFormat[]>(
     []

--- a/packages/odf/components/s3-browser/objects-list/ObjectListWithSidebar.tsx
+++ b/packages/odf/components/s3-browser/objects-list/ObjectListWithSidebar.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { ObjectDetailsSidebar } from '@odf/core/components/s3-browser/object-details/ObjectDetailsSidebar';
 import { BUCKET_VERSIONING_CACHE_KEY_SUFFIX } from '@odf/core/constants';
 import { ObjectCrFormat } from '@odf/core/types';
+import { useModalWrapper } from '@odf/shared';
 import { LoadingBox } from '@odf/shared/generic/status-box';
 import { S3Commands } from '@odf/shared/s3';
 import {
@@ -10,7 +11,6 @@ import {
 } from '@odf/shared/s3/utils';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { isClientPlugin } from '@odf/shared/utils';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
 import { useParams } from 'react-router-dom-v5-compat';
 import useSWR from 'swr';
 import { Alert, AlertActionLink } from '@patternfly/react-core';
@@ -42,7 +42,7 @@ const ClientCorsAlert: React.FC<ClientCorsAlertProps> = ({
   triggerRefresh,
 }) => {
   const { t } = useCustomTranslation();
-  const launcher = useModal();
+  const launcher = useModalWrapper();
 
   return (
     <Alert

--- a/packages/odf/components/s3-browser/objects-list/ObjectsList.tsx
+++ b/packages/odf/components/s3-browser/objects-list/ObjectsList.tsx
@@ -2,10 +2,10 @@ import * as React from 'react';
 import { DeleteObjectsCommandOutput } from '@aws-sdk/client-s3';
 import { pluralize } from '@odf/core/components/utils';
 import { FieldLevelHelp } from '@odf/shared';
+import { useModalWrapper } from '@odf/shared';
 import { S3Commands } from '@odf/shared/s3';
 import { SelectableTable } from '@odf/shared/table';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
 import { LaunchModal } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
 import { TFunction, Trans } from 'react-i18next';
 import {
@@ -290,7 +290,7 @@ export const DeletionAlerts: React.FC<DeletionAlertsProps> = ({
 }) => {
   const { t } = useCustomTranslation();
 
-  const launcher = useModal();
+  const launcher = useModalWrapper();
 
   const [errorResponse, setErrorResponse] = React.useState<
     DeleteObjectsCommandOutput['Errors']
@@ -398,7 +398,7 @@ export const ObjectsList: React.FC<ObjectsListProps> = ({
   const { bucketName } = useParams();
   const [searchParams] = useSearchParams();
 
-  const launcher = useModal();
+  const launcher = useModalWrapper();
 
   // if non-empty means we are inside particular folder(s) of a bucket, else just inside a bucket (top-level)
   const foldersPath = searchParams.get(PREFIX) || '';

--- a/packages/odf/components/s3-browser/public-access-block/PublicAccessBlock.tsx
+++ b/packages/odf/components/s3-browser/public-access-block/PublicAccessBlock.tsx
@@ -4,6 +4,7 @@ import {
   GetBucketPolicyStatusCommandOutput,
 } from '@aws-sdk/client-s3';
 import { S3Context } from '@odf/core/components/s3-browser/s3-context';
+import { useModalWrapper } from '@odf/shared';
 import { CheckboxTree } from '@odf/shared/checkbox-tree';
 import { ButtonBar } from '@odf/shared/generic/ButtonBar';
 import { StatusBox, LoadingBox } from '@odf/shared/generic/status-box';
@@ -13,7 +14,6 @@ import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import {
   ListPageBody,
   ListPageHeader,
-  useModal,
 } from '@openshift-console/dynamic-plugin-sdk';
 import * as _ from 'lodash-es';
 import { useParams } from 'react-router-dom-v5-compat';
@@ -130,7 +130,7 @@ const PabFooter: React.FC<PabFooterProps> = ({
 }) => {
   const { t } = useCustomTranslation();
 
-  const launcher = useModal();
+  const launcher = useModalWrapper();
 
   const [inProgress, setInProgress] = React.useState<boolean>(false);
   const [error, setError] = React.useState<Error>();

--- a/packages/odf/components/s3-iam/access-keys-details/AccessKeyCard.tsx
+++ b/packages/odf/components/s3-iam/access-keys-details/AccessKeyCard.tsx
@@ -4,12 +4,9 @@ import { AccessKeyStatus } from '@odf/core/constants/s3-iam';
 import DeleteAccessKeyModal from '@odf/core/modals/s3-iam/DeleteAccessKeyModal';
 import EditDescriptionTagModal from '@odf/core/modals/s3-iam/EditDescriptonTagModal';
 import UpdateAccessKeyModal from '@odf/core/modals/s3-iam/UpdateAccessKeyModal';
-import { DASH, useCustomTranslation } from '@odf/shared';
+import { DASH, useCustomTranslation, useModalWrapper } from '@odf/shared';
 import { IamCommands } from '@odf/shared/iam';
-import {
-  GreenCheckCircleIcon,
-  useModal,
-} from '@openshift-console/dynamic-plugin-sdk';
+import { GreenCheckCircleIcon } from '@openshift-console/dynamic-plugin-sdk';
 import { LaunchModal } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
 import { TFunction } from 'react-i18next';
 import {
@@ -178,7 +175,7 @@ const AccessKeyCard: React.FC<AccessKeyCardProps> = ({
   iamClient,
 }) => {
   const { t } = useCustomTranslation();
-  const launchModal = useModal();
+  const launchModal = useModalWrapper();
 
   const descriptionTag = React.useMemo(
     () =>

--- a/packages/odf/components/s3-iam/access-keys-details/AccessKeysDetails.tsx
+++ b/packages/odf/components/s3-iam/access-keys-details/AccessKeysDetails.tsx
@@ -4,9 +4,9 @@ import { MAX_ACCESS_KEYS } from '@odf/core/constants/s3-iam';
 import { GenerateAnotherAccessKeyModal } from '@odf/core/modals/s3-iam/GenerateAnotherAccessKeyModal';
 import { IamUserDetails } from '@odf/core/types';
 import { useCustomTranslation } from '@odf/shared';
+import { useModalWrapper } from '@odf/shared';
 import { LoadingBox, StatusBox } from '@odf/shared/generic/status-box';
 import { IamCommands } from '@odf/shared/iam';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Alert,
   AlertVariant,
@@ -38,7 +38,7 @@ const AccessKeysDetailsContent: React.FC<AccessKeysDetailsContentProps> = ({
   triggerRefresh,
 }) => {
   const { t } = useCustomTranslation();
-  const launchModal = useModal();
+  const launchModal = useModalWrapper();
 
   // Fetch user details (for tags)
   const {

--- a/packages/odf/components/s3-iam/create-user/CreateUserForm.tsx
+++ b/packages/odf/components/s3-iam/create-user/CreateUserForm.tsx
@@ -5,9 +5,9 @@ import {
   TextInputWithFieldRequirements,
   useCustomTranslation,
 } from '@odf/shared';
+import { useModalWrapper } from '@odf/shared';
 import { ButtonBar } from '@odf/shared/generic/ButtonBar';
 import { CommonModalProps } from '@odf/shared/modals/common';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
 import { useForm, Resolver } from 'react-hook-form';
 import { Link, useNavigate } from 'react-router-dom-v5-compat';
 import useSWRMutation from 'swr/mutation';
@@ -58,7 +58,7 @@ export const CreateUserFormContent = () => {
   const [tagErrors, setTagErrors] = React.useState('');
   const { t } = useCustomTranslation();
   const navigate = useNavigate();
-  const launchModal = useModal();
+  const launchModal = useModalWrapper();
 
   const {
     trigger: createUser,

--- a/packages/odf/components/s3-iam/user-overview/UserOverview.tsx
+++ b/packages/odf/components/s3-iam/user-overview/UserOverview.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { IamUserDetails } from '@odf/core/types';
+import { useModalWrapper } from '@odf/shared';
 import PageHeading from '@odf/shared/heading/page-heading';
 import { useRefresh } from '@odf/shared/hooks';
 import { BlueSyncIcon } from '@odf/shared/status';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import Tabs, { TabPage } from '@odf/shared/utils/Tabs';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
 import { LaunchModal } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
 import { useParams } from 'react-router-dom-v5-compat';
 import { Button, ButtonVariant } from '@patternfly/react-core';
@@ -20,7 +20,7 @@ const UserOverview: React.FC<{}> = () => {
   const { t } = useCustomTranslation();
   const [fresh, triggerRefresh] = useRefresh();
   const { userName } = useParams();
-  const launcher = useModal();
+  const launcher = useModalWrapper();
 
   const navPages: TabPage[] = React.useMemo(
     () => [

--- a/packages/odf/components/s3-iam/users-list-page/UsersListPage.tsx
+++ b/packages/odf/components/s3-iam/users-list-page/UsersListPage.tsx
@@ -2,16 +2,15 @@ import * as React from 'react';
 import { USERS_CREATE_PAGE_PATH } from '@odf/core/constants/s3-iam';
 import { ODF_ADMIN } from '@odf/core/features';
 import { IamUserCrFormat, S3ProviderType } from '@odf/core/types';
+import { ListPageFilterWrapper, useModalWrapper } from '@odf/shared';
 import { useRefresh } from '@odf/shared/hooks';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { getValidFilteredData } from '@odf/shared/utils';
 import {
   ListPageBody,
   ListPageCreateLink,
-  ListPageFilter,
   ListPageHeader,
   useFlag,
-  useModal,
   useListPageFilter,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { Button, ButtonVariant, Flex, FlexItem } from '@patternfly/react-core';
@@ -43,7 +42,7 @@ const UsersListPageBody: React.FC<UsersListPageBodyProps> = ({
       <Flex className="pf-v6-u-mt-md">
         <Flex flex={{ default: 'flex_1' }}>
           <FlexItem className="pf-v6-u-mr-md">
-            <ListPageFilter
+            <ListPageFilterWrapper
               loaded={true}
               hideLabelFilter={true}
               nameFilterPlaceholder={t('Find by accountname')}
@@ -91,7 +90,7 @@ const UsersListPageContent: React.FC = () => {
 
   const isAdmin = useFlag(ODF_ADMIN);
   const { logout, setSecretRef } = React.useContext(IamContext);
-  const launcher = useModal();
+  const launcher = useModalWrapper();
 
   return (
     <>

--- a/packages/odf/components/s3-iam/users-list-page/UsersListTable.tsx
+++ b/packages/odf/components/s3-iam/users-list-page/UsersListTable.tsx
@@ -5,6 +5,7 @@ import {
 } from '@odf/core/constants/s3-iam';
 import { IamUserCrFormat } from '@odf/core/types';
 import { DASH } from '@odf/shared';
+import { useModalWrapper } from '@odf/shared';
 import { useUserSettingsLocalStorage } from '@odf/shared/hooks/useUserSettingsLocalStorage';
 import { IamCommands } from '@odf/shared/iam';
 import {
@@ -13,7 +14,6 @@ import {
 } from '@odf/shared/table/composable-table';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { sortRows } from '@odf/shared/utils';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
 import { LaunchModal } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
 import { TFunction } from 'react-i18next';
 import { Link } from 'react-router-dom-v5-compat';
@@ -172,7 +172,7 @@ export const UsersListTable: React.FC<UsersListTableProps> = ({
     true,
     []
   );
-  const launcher = useModal();
+  const launcher = useModalWrapper();
 
   return (
     <ComposableTable

--- a/packages/odf/components/s3-vectors/vector-bucket-overview/VectorBucketOverview.tsx
+++ b/packages/odf/components/s3-vectors/vector-bucket-overview/VectorBucketOverview.tsx
@@ -6,15 +6,12 @@ import {
 } from '@odf/core/constants/s3-vectors';
 import { LazyDeleteVectorBucketModal } from '@odf/core/modals/s3-vectors/delete-vector-bucket/lazy-delete-vector-bucket';
 import { S3ProviderType } from '@odf/core/types';
-import { BlueSyncIcon, PageHeading } from '@odf/shared';
+import { BlueSyncIcon, PageHeading, useModalWrapper } from '@odf/shared';
 import { useRefresh } from '@odf/shared/hooks';
 import { S3VectorsCommands } from '@odf/shared/s3-vectors';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import Tabs, { TabPage } from '@odf/shared/utils/Tabs';
-import {
-  K8sResourceKind,
-  useModal,
-} from '@openshift-console/dynamic-plugin-sdk';
+import { K8sResourceKind } from '@openshift-console/dynamic-plugin-sdk';
 import { LaunchModal } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
 import { TFunction } from 'react-i18next';
 import { useParams } from 'react-router-dom-v5-compat';
@@ -53,7 +50,7 @@ const createVectorBucketActions = (
   t: TFunction,
   fresh: boolean,
   triggerRefresh: () => void,
-  launcher: ReturnType<typeof useModal>,
+  launcher: ReturnType<typeof useModalWrapper>,
   vectorBucketName: string,
   s3VectorsClient: S3VectorsCommands
 ) => {
@@ -87,7 +84,7 @@ const VectorBucketOverview: React.FC<{}> = () => {
   const { t } = useCustomTranslation();
   const [fresh, triggerRefresh] = useRefresh();
 
-  const launcher = useModal();
+  const launcher = useModalWrapper();
 
   const { vectorBucketName, providerType } = useParams();
 

--- a/packages/odf/components/s3-vectors/vector-bucket-policy/VectorBucketPolicy.tsx
+++ b/packages/odf/components/s3-vectors/vector-bucket-policy/VectorBucketPolicy.tsx
@@ -8,9 +8,9 @@ import { BUCKET_POLICY_CACHE_KEY_SUFFIX } from '@odf/core/constants';
 import DeleteBucketPolicyModal from '@odf/core/modals/s3-common/bucket-policy/DeleteBucketPolicy';
 import SaveBucketPolicyModal from '@odf/core/modals/s3-common/bucket-policy/SaveBucketPolicy';
 import { S3ProviderType } from '@odf/core/types';
+import { useModalWrapper } from '@odf/shared';
 import { StatusBox, LoadingBox } from '@odf/shared/generic/status-box';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
 import { useParams } from 'react-router-dom-v5-compat';
 import useSWRMutation from 'swr/mutation';
 import { S3VectorsContext } from '../s3-vectors-context';
@@ -51,7 +51,7 @@ const VectorBucketPolicyContent: React.FC<VectorBucketPolicyContentProps> = ({
   const { s3VectorsClient } = React.useContext(S3VectorsContext);
   const { vectorBucketName } = useParams();
   const providerType = s3VectorsClient.providerType as S3ProviderType;
-  const launcher = useModal();
+  const launcher = useModalWrapper();
 
   const launchDeleteModal = () =>
     launcher(DeleteBucketPolicyModal, {

--- a/packages/odf/components/s3-vectors/vector-buckets-list-page/VectorBucketsListPage.tsx
+++ b/packages/odf/components/s3-vectors/vector-buckets-list-page/VectorBucketsListPage.tsx
@@ -2,17 +2,20 @@ import * as React from 'react';
 import { getVectorBucketCreatePageRoute } from '@odf/core/constants/s3-vectors';
 import { ODF_ADMIN } from '@odf/core/features';
 import { S3ProviderType } from '@odf/core/types';
-import { useCustomTranslation, useRefresh } from '@odf/shared';
+import {
+  ListPageFilterWrapper,
+  useCustomTranslation,
+  useModalWrapper,
+  useRefresh,
+} from '@odf/shared';
 import { getValidFilteredData } from '@odf/shared/utils';
 import {
   K8sResourceCommon,
   ListPageBody,
   ListPageCreateLink,
-  ListPageFilter,
   ListPageHeader,
   useFlag,
   useListPageFilter,
-  useModal,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { Button, ButtonVariant, Flex, FlexItem } from '@patternfly/react-core';
 import { SyncAltIcon } from '@patternfly/react-icons';
@@ -45,7 +48,7 @@ const VectorBucketsListPageBody: React.FC<VectorBucketsListPageBodyProps> = ({
       <Flex className="pf-v6-u-mt-md">
         <Flex flex={{ default: 'flex_1' }}>
           <FlexItem className="pf-v6-u-mr-md">
-            <ListPageFilter
+            <ListPageFilterWrapper
               loaded={true}
               hideLabelFilter={true}
               nameFilterPlaceholder={t('Search a bucket by name')}
@@ -92,7 +95,7 @@ const VectorBucketsListPageContent: React.FC = () => {
   const isAdmin = useFlag(ODF_ADMIN);
   const { s3VectorsClient, logout, setSecretRef } =
     React.useContext(S3VectorsContext);
-  const launcher = useModal();
+  const launcher = useModalWrapper();
   const providerType = s3VectorsClient.providerType as S3ProviderType;
   return (
     <>

--- a/packages/odf/components/s3-vectors/vector-buckets-list-page/VectorBucketsListTable.tsx
+++ b/packages/odf/components/s3-vectors/vector-buckets-list-page/VectorBucketsListTable.tsx
@@ -10,15 +10,13 @@ import {
   EmptyPage,
   RowComponentType,
   useCustomTranslation,
+  useModalWrapper,
   useUserSettingsLocalStorage,
 } from '@odf/shared';
 import { Timestamp } from '@odf/shared/details-page/timestamp';
 import { S3VectorsCommands } from '@odf/shared/s3-vectors';
 import { sortRows } from '@odf/shared/utils';
-import {
-  K8sResourceCommon,
-  useModal,
-} from '@openshift-console/dynamic-plugin-sdk';
+import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import { LaunchModal } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
 import { TFunction } from 'react-i18next';
 import { Link } from 'react-router-dom-v5-compat';
@@ -179,7 +177,7 @@ export const VectorBucketsListTable: React.FC<VectorBucketsListTableProps> = ({
     true,
     []
   );
-  const launcher = useModal();
+  const launcher = useModalWrapper();
   return (
     <ComposableTable
       rows={filteredVectorBuckets}

--- a/packages/odf/components/s3-vectors/vector-indexes-list-page/VectorIndexesListPage.tsx
+++ b/packages/odf/components/s3-vectors/vector-indexes-list-page/VectorIndexesListPage.tsx
@@ -2,12 +2,11 @@ import * as React from 'react';
 import { getVectorBucketOverviewBaseRoute } from '@odf/core/constants/s3-vectors';
 import type { VectorIndexesDeleteResponse } from '@odf/core/modals/s3-vectors/delete-vector-index/DeleteVectorIndexModal';
 import { S3ProviderType } from '@odf/core/types';
-import { useCustomTranslation } from '@odf/shared';
+import { ListPageFilterWrapper, useCustomTranslation } from '@odf/shared';
 import { S3VectorsCommands } from '@odf/shared/s3-vectors';
 import { getValidFilteredData } from '@odf/shared/utils';
 import {
   useListPageFilter,
-  ListPageFilter,
   OnFilterChange,
   K8sResourceCommon,
 } from '@openshift-console/dynamic-plugin-sdk';
@@ -60,7 +59,7 @@ const TableActions: React.FC<TableActionsProps> = ({
   return (
     <Flex flex={{ default: 'flex_1' }}>
       <FlexItem className="pf-v6-u-mr-md pf-v6-u-display-flex pf-v6-u-align-items-center">
-        <ListPageFilter
+        <ListPageFilterWrapper
           loaded={true}
           hideLabelFilter={true}
           nameFilterPlaceholder={t('Find by name')}

--- a/packages/odf/components/s3-vectors/vector-indexes-list-page/VectorIndexesListTable.tsx
+++ b/packages/odf/components/s3-vectors/vector-indexes-list-page/VectorIndexesListTable.tsx
@@ -12,14 +12,12 @@ import {
   ComposableTable,
   getName,
   getCreationTimestamp,
+  useModalWrapper,
 } from '@odf/shared';
 import { Timestamp } from '@odf/shared/details-page/timestamp';
 import { S3VectorsCommands } from '@odf/shared/s3-vectors';
 import { sortRows } from '@odf/shared/utils';
-import {
-  K8sResourceCommon,
-  useModal,
-} from '@openshift-console/dynamic-plugin-sdk';
+import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import { LaunchModal } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
 import { TFunction } from 'react-i18next';
 import { Link } from 'react-router-dom-v5-compat';
@@ -164,7 +162,7 @@ export const VectorIndexesListTable: React.FC<VectorIndexesListTableProps> = ({
   setDeleteResponse,
 }) => {
   const { t } = useCustomTranslation();
-  const launcher = useModal();
+  const launcher = useModalWrapper();
   const providerType = s3VectorsClient.providerType as S3ProviderType;
 
   return (

--- a/packages/odf/components/san-dashboard/LUNCard.tsx
+++ b/packages/odf/components/san-dashboard/LUNCard.tsx
@@ -5,6 +5,7 @@ import {
   DASH,
   getName,
   getNamespace,
+  ListPageFilterWrapper,
   StorageClassModel,
   StorageClassResourceKind,
 } from '@odf/shared';
@@ -20,7 +21,6 @@ import {
   RedExclamationCircleIcon,
   YellowExclamationTriangleIcon,
   RowFilter,
-  ListPageFilter,
   TableColumn,
   TableData,
   RowProps,
@@ -343,7 +343,7 @@ const LUNGroupsTable: React.FC = () => {
           })}
         </Content>
       </Content>
-      <ListPageFilter
+      <ListPageFilterWrapper
         data={data}
         loaded={fileSystemsLoaded && storageClassesLoaded}
         onFilterChange={onFilterChange}

--- a/packages/odf/components/storage-consumers/client-list.tsx
+++ b/packages/odf/components/storage-consumers/client-list.tsx
@@ -8,7 +8,9 @@ import {
   ClusterVersionModel,
   getName,
   Kebab,
+  ListPageFilterWrapper,
   StorageConsumerModel,
+  useModalWrapper,
 } from '@odf/shared';
 import { ODF_OPERATOR } from '@odf/shared/constants/common';
 import { getTimeDifferenceInSeconds } from '@odf/shared/details-page/datetime';
@@ -21,7 +23,6 @@ import { referenceForModel } from '@odf/shared/utils/common';
 import {
   K8sResourceKind,
   ListPageBody,
-  ListPageFilter,
   ListPageHeader,
   RedExclamationCircleIcon,
   RowProps,
@@ -33,7 +34,6 @@ import {
   useActiveColumns,
   useK8sWatchResource,
   useListPageFilter,
-  useModal,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
 import * as _ from 'lodash-es';
@@ -416,7 +416,7 @@ type ClientListPageProps = {
 
 export const ClientListPage: React.FC<ClientListPageProps> = () => {
   const { t } = useCustomTranslation();
-  const launchModal = useModal();
+  const launchModal = useModalWrapper();
   const [storageClients, loaded, loadError] = useK8sWatchResource<
     StorageConsumerKind[]
   >({
@@ -476,7 +476,7 @@ export const ClientListPage: React.FC<ClientListPageProps> = () => {
         </Button>
       </ListPageHeader>
       <ListPageBody>
-        <ListPageFilter
+        <ListPageFilterWrapper
           data={data}
           loaded={loaded && csvLoaded && cvLoaded}
           onFilterChange={onFilterChange}

--- a/packages/odf/components/system-list/external-systems-list.tsx
+++ b/packages/odf/components/system-list/external-systems-list.tsx
@@ -6,9 +6,11 @@ import { storageClusterResource } from '@odf/core/resources';
 import {
   DEFAULT_INFRASTRUCTURE,
   InfrastructureKind,
+  ListPageFilterWrapper,
   StorageClusterKind,
   useFetchCsv,
   useK8sGet,
+  useModalWrapper,
 } from '@odf/shared';
 import {
   useCustomPrometheusPoll,
@@ -45,7 +47,6 @@ import {
 import {
   K8sModel,
   ListPageBody,
-  ListPageFilter,
   ListPageHeader,
   PrometheusEndpoint,
   PrometheusResponse,
@@ -56,7 +57,6 @@ import {
   useFlag,
   useK8sWatchResource,
   useListPageFilter,
-  useModal,
   VirtualizedTable,
 } from '@openshift-console/dynamic-plugin-sdk';
 import classNames from 'classnames';
@@ -521,7 +521,7 @@ const StorageSystemRow: React.FC<RowProps<StorageSystemKind, CustomData>> = ({
 export const StorageSystemListPage: React.FC = () => {
   const { t } = useCustomTranslation();
 
-  const launchModal = useModal();
+  const launchModal = useModalWrapper();
   const isFDF = useFlag(FDF_FLAG);
 
   const { odfNamespace, isODFNsLoaded, odfNsLoadError } =
@@ -704,7 +704,7 @@ export const StorageSystemListPage: React.FC = () => {
         )}
       </ListPageHeader>
       <ListPageBody>
-        <ListPageFilter
+        <ListPageFilterWrapper
           data={data}
           loaded={loaded && isODFNsLoaded}
           onFilterChange={onFilterChange}

--- a/packages/odf/modals/ConfigureDF/StorageClusterCreateModal.tsx
+++ b/packages/odf/modals/ConfigureDF/StorageClusterCreateModal.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { CREATE_SS_PAGE_URL } from '@odf/core/constants';
 import { StartingPoint } from '@odf/core/types/install-ui';
 import { useCustomTranslation } from '@odf/shared';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { useModalWrapper } from '@odf/shared';
 import { Modal } from '@patternfly/react-core/deprecated';
 import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 import {
@@ -28,7 +28,7 @@ export const ConfigureDFSelections: React.FC<ConfigureDFSelectionsProps> = ({
 }) => {
   const { t } = useCustomTranslation();
   const navigate = useNavigate();
-  const launchModal = useModal();
+  const launchModal = useModalWrapper();
   const location = useLocation();
 
   const shouldShowExternalSystems = location.pathname.includes(

--- a/packages/odf/modals/StorageClientDistributionModal/StorageConsumerTable.tsx
+++ b/packages/odf/modals/StorageClientDistributionModal/StorageConsumerTable.tsx
@@ -6,6 +6,7 @@ import {
 import {
   getName,
   getUID,
+  ListPageFilterWrapper,
   StorageConsumerKind,
   ClusterVersionModel,
   ClusterVersionKind,
@@ -14,7 +15,6 @@ import { useK8sGet } from '@odf/shared/hooks';
 import { TableSkeletonLoader } from '@odf/shared/skeletal-loader/TableSkeleton';
 import {
   K8sResourceCommon,
-  ListPageFilter,
   useListPageFilter,
 } from '@openshift-console/dynamic-plugin-sdk';
 import * as _ from 'lodash-es';
@@ -141,7 +141,7 @@ export const StorageConsumerTable: React.FC<ResourceDistributionTableProps> = ({
     <TableSkeletonLoader columns={4} rows={8} />
   ) : (
     <>
-      <ListPageFilter
+      <ListPageFilterWrapper
         data={unfilteredData}
         loaded={loaded && cvLoaded}
         onFilterChange={onFilterChange}

--- a/packages/odf/modals/StorageClientDistributionModal/useStorageClientAttacherAction.ts
+++ b/packages/odf/modals/StorageClientDistributionModal/useStorageClientAttacherAction.ts
@@ -4,15 +4,12 @@ import {
   getProvisioner,
   StorageClassModel,
   StorageClassResourceKind,
+  useModalWrapper,
   VolumeSnapshotClassKind,
   VolumeSnapshotClassModel,
 } from '@odf/shared';
 import { isCephDriver, isCephOrNooBaaProvisioner } from '@odf/shared/utils';
-import {
-  Action,
-  K8sModel,
-  useModal,
-} from '@openshift-console/dynamic-plugin-sdk';
+import { Action, K8sModel } from '@openshift-console/dynamic-plugin-sdk';
 import { LaunchModal } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
 import { StorageClientAttacherModal } from './StorageClientAttacherModal';
 
@@ -29,7 +26,7 @@ const isVolumeSnapshotClass = (
 export const useStorageClientAttacherAction = (
   resource: StorageClassResourceKind | VolumeSnapshotClassKind
 ) => {
-  const launchModal = useModal();
+  const launchModal = useModalWrapper();
   const actions = useMemo(() => {
     const items = [];
     if (

--- a/packages/odf/modals/s3-browser/delete-and-empty-bucket/EmptyBucketModal.tsx
+++ b/packages/odf/modals/s3-browser/delete-and-empty-bucket/EmptyBucketModal.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { DeleteObjectsCommandOutput } from '@aws-sdk/client-s3';
 import { S3Context } from '@odf/core/components/s3-browser/s3-context';
+import { useModalWrapper } from '@odf/shared';
 import { CommonModalProps } from '@odf/shared/modals';
 import { S3Commands } from '@odf/shared/s3';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
 import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
 import { TFunction } from 'react-i18next';
 import { Trans, useTranslation } from 'react-i18next';
@@ -206,7 +206,7 @@ export const EmptyBucketAlerts: React.FC<EmptyBucketAlertProps> = ({
 }) => {
   const { s3Client } = React.useContext(S3Context);
   const { t } = useTranslation();
-  const launcher = useModal();
+  const launcher = useModalWrapper();
 
   if (emptyBucketResponse.response === null) return null;
 

--- a/packages/odf/modals/s3-iam/GenerateAnotherAccessKeyModal.tsx
+++ b/packages/odf/modals/s3-iam/GenerateAnotherAccessKeyModal.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
+import { useModalWrapper } from '@odf/shared';
 import { ButtonBar } from '@odf/shared/generic/ButtonBar';
 import { IamCommands } from '@odf/shared/iam';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
 import { ModalComponent } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
 import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
 import {
@@ -49,7 +49,7 @@ export const GenerateAnotherAccessKeyModal: GenerateAnotherAccessKeyModalProps =
       () => validateDescription(description),
       [description]
     );
-    const launchModal = useModal();
+    const launchModal = useModalWrapper();
 
     const onGenerate = React.useCallback(async () => {
       if (descriptionValidationState === ValidatedOptions.error) {

--- a/packages/shared/src/details-page/DetailsPage.tsx
+++ b/packages/shared/src/details-page/DetailsPage.tsx
@@ -7,7 +7,6 @@ import {
   NavPage,
   ResourceLink,
   useAccessReview,
-  useModal,
 } from '@openshift-console/dynamic-plugin-sdk';
 import classnames from 'classnames';
 import * as _ from 'lodash-es';
@@ -29,6 +28,7 @@ import PageHeading from '../heading/page-heading';
 import { EditLabelModal } from '../modals';
 import AnnotationsModal from '../modals/EditAnnotations';
 import { ResourceIcon } from '../resource-link/resource-link';
+import { useModalWrapper } from '../sdk-wrapper/useModalWrapper';
 import { getName } from '../selectors';
 import { K8sResourceKind } from '../types';
 import { useCustomTranslation } from '../useCustomTranslationHook';
@@ -309,7 +309,7 @@ export const ResourceSummary: React.FC<ResourceSummaryProps> = ({
   });
   const canUpdate = canUpdateAccess && canUpdateResource;
 
-  const launchModal = useModal();
+  const launchModal = useModalWrapper();
 
   return (
     <DescriptionList data-test-id="resource-summary">

--- a/packages/shared/src/error-boundary/ErrorBoundary.tsx
+++ b/packages/shared/src/error-boundary/ErrorBoundary.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+
+type Props = {
+  children?: React.ReactNode;
+};
+
+type State = {
+  hasError: boolean;
+};
+
+export class ErrorBoundary extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(_error: unknown): Partial<State> {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, _info: React.ErrorInfo): void {
+    // eslint-disable-next-line no-console
+    console.error(error);
+  }
+
+  render(): React.ReactNode {
+    if (this.state.hasError) {
+      // hide the error-ed component(s) without breaking the whole page
+      return null;
+    }
+
+    return this.props.children;
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -36,3 +36,5 @@ export * from './file-handling';
 export * from './text-inputs';
 export * from './label-expression-selector';
 export * from './empty-state-page';
+export * from './error-boundary/ErrorBoundary';
+export * from './sdk-wrapper';

--- a/packages/shared/src/kebab/kebab.tsx
+++ b/packages/shared/src/kebab/kebab.tsx
@@ -1,10 +1,7 @@
 import * as React from 'react';
 import { useCallback, useEffect } from 'react';
 import { getName, getNamespace } from '@odf/shared/selectors';
-import {
-  K8sResourceCommon,
-  useModal,
-} from '@openshift-console/dynamic-plugin-sdk';
+import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import { K8sModel } from '@openshift-console/dynamic-plugin-sdk/lib/api/common-types';
 import * as _ from 'lodash-es';
 import { TFunction } from 'react-i18next';
@@ -20,6 +17,7 @@ import {
 import { EllipsisVIcon } from '@patternfly/react-icons';
 import { useAccessReview } from '../hooks/rbac-hook';
 import { ModalKeys, defaultModalMap } from '../modals/types';
+import { useModalWrapper } from '../sdk-wrapper/useModalWrapper';
 import { useCustomTranslation } from '../useCustomTranslationHook';
 import { referenceForModel } from '../utils';
 
@@ -147,7 +145,7 @@ export const Kebab: React.FC<KebabProps> & KebabStaticProperties = ({
   'data-test': dataTestId,
 }) => {
   const { t } = useCustomTranslation();
-  const launchModal = useModal();
+  const launchModal = useModalWrapper();
   const eventRef = React.useRef(undefined);
   const dropdownRef = React.useRef();
   const dropdownToggleRef = React.useRef();

--- a/packages/shared/src/list-page/paginated-list-page.tsx
+++ b/packages/shared/src/list-page/paginated-list-page.tsx
@@ -3,7 +3,6 @@ import {
   K8sResourceCommon,
   ListPageFilterProps,
   ListPageBody,
-  ListPageFilter,
 } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Pagination,
@@ -12,6 +11,7 @@ import {
   Grid,
   GridItem,
 } from '@patternfly/react-core';
+import { ListPageFilterWrapper } from '../sdk-wrapper/ListPageFilterWrapper';
 import { TableProps, ComposableTable } from '../table';
 import { getPageRange, getValidFilteredData } from '../utils';
 
@@ -67,7 +67,7 @@ export const PaginatedListPage: React.FC<PaginatedListPageProps> = ({
             <GridItem md={8} sm={12} className="pf-v6-u-mt-md">
               <div className="pf-v6-u-display-flex pf-v6-u-flex-direction-column pf-v6-u-flex-direction-row-on-md">
                 {!hideFilter && (
-                  <ListPageFilter
+                  <ListPageFilterWrapper
                     {...listPageFilterProps}
                     data={getValidFilteredData(listPageFilterProps.data)}
                   />

--- a/packages/shared/src/sdk-wrapper/ListPageFilterWrapper.tsx
+++ b/packages/shared/src/sdk-wrapper/ListPageFilterWrapper.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import {
+  ListPageFilter,
+  type ListPageFilterProps,
+} from '@openshift-console/dynamic-plugin-sdk';
+import { ErrorBoundary } from '../error-boundary/ErrorBoundary';
+
+export const ListPageFilterWrapper: React.FC<ListPageFilterProps> = (props) => (
+  <ErrorBoundary>
+    <ListPageFilter {...props} />
+  </ErrorBoundary>
+);
+
+ListPageFilterWrapper.displayName = 'ListPageFilterWrapper';

--- a/packages/shared/src/sdk-wrapper/index.ts
+++ b/packages/shared/src/sdk-wrapper/index.ts
@@ -1,0 +1,2 @@
+export * from './ListPageFilterWrapper';
+export * from './useModalWrapper';

--- a/packages/shared/src/sdk-wrapper/useModalWrapper.ts
+++ b/packages/shared/src/sdk-wrapper/useModalWrapper.ts
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { useModal } from '@openshift-console/dynamic-plugin-sdk';
+
+export function useModalWrapper() {
+  const launchModal = useModal();
+  return React.useCallback(
+    (...args: Parameters<typeof launchModal>) => {
+      setTimeout(() => {
+        launchModal(...args);
+      }, 0);
+    },
+    [launchModal]
+  );
+}


### PR DESCRIPTION
https://redhat.atlassian.net/browse/DFBUGS-6713
https://redhat.atlassian.net/browse/DFBUGS-6698
https://redhat.atlassian.net/browse/DFBUGS-6546

```
at ToolbarFilter (http://localhost:9000/static/vendors~vendors-node_modules_octokit_rest_index_js-node_modules_pmmmwh_react-refresh-webpack-plugin_l-f2609e-chunk-ab686b26d24ccf17324f.min.js:49469:5)
    at div
    at ToolbarItem (http://localhost:9000/static/vendors~vendors-node_modules_octokit_rest_index_js-node_modules_pmmmwh_react-refresh-webpack-plugin_l-f2609e-chunk-ab686b26d24ccf17324f.min.js:49672:7)
    at div
    at ToolbarToggleGroup (http://localhost:9000/static/vendors~vendors-node_modules_octokit_rest_index_js-node_modules_pmmmwh_react-refresh-webpack-plugin_l-f2609e-chunk-ab686b26d24ccf17324f.min.js:49860:5)
    at div
    at div
    at ToolbarContent (http://localhost:9000/static/vendors~vendors-node_modules_octokit_rest_index_js-node_modules_pmmmwh_react-refresh-webpack-plugin_l-f2609e-chunk-ab686b26d24ccf17324f.min.js:49254:5)
    at div
    at Toolbar (http://localhost:9000/static/vendors~vendors-node_modules_octokit_rest_index_js-node_modules_pmmmwh_react-refresh-webpack-plugin_l-f2609e-chunk-ab686b26d24ccf17324f.min.js:49103:5)
    at FilterToolbar (http://localhost:9000/static/main-bundle.js:112910:3)
    at ListPageFilter (http://localhost:9000/static/main-bundle.js:109506:3)
    at section
    at PageSection (http://localhost:9000/static/vendors~vendors-node_modules_octokit_rest_index_js-node_modules_pmmmwh_react-refresh-webpack-plugin_l-f2609e-chunk-ab686b26d24ccf17324f.min.js:42833:7)
    at PaneBody (http://localhost:9000/static/main-bundle.js:50797:7)
    at ListPageBody (http://localhost:9000/static/main-bundle.js:20435:3)
    at ClientListPage (webpack-internal:///./packages/odf/components/storage-consumers/client-list.tsx:277:109)
    at LazyRoutePage (http://localhost:9000/static/main-bundle.js:19219:3)
    at RoutePage (http://localhost:9000/static/main-bundle.js:19258:3)
    at RenderedRoute (http://localhost:9000/static/vendor-plugins-shared-node_modules_openshift_dynamic-plugin-sdk_dist_index_esm_js-node_module-9d8b97-bundle.js:16119:26)
    at Routes (http://localhost:9000/static/vendor-plugins-shared-node_modules_openshift_dynamic-plugin-sdk_dist_index_esm_js-node_module-9d8b97-bundle.js:16937:3)
    at Suspense
    at ErrorBoundaryInner (http://localhost:9000/static/main-bundle.js:41636:5)
    at ErrorBoundary (http://localhost:9000/static/main-bundle.js:41681:3)
    at ErrorBoundaryPage
    at section
    at PageSection (http://localhost:9000/static/vendors~vendors-node_modules_octokit_rest_index_js-node_modules_pmmmwh_react-refresh-webpack-plugin_l-f2609e-chunk-ab686b26d24ccf17324f.min.js:42833:7)
    at AppContents (http://localhost:9000/static/main-bundle.js:105372:117)
    at main
    at div
    at div
    at div
    at DrawerMain (http://localhost:9000/static/vendors~vendors-node_modules_octokit_rest_index_js-node_modules_pmmmwh_react-refresh-webpack-plugin_l-f2609e-chunk-ab686b26d24ccf17324f.min.js:32752:7)
    at DrawerContent (http://localhost:9000/static/vendors~vendors-node_modules_octokit_rest_index_js-node_modules_pmmmwh_react-refresh-webpack-plugin_l-f2609e-chunk-ab686b26d24ccf17324f.min.js:32628:7)
    at div
    at Drawer (http://localhost:9000/static/vendors~vendors-node_modules_octokit_rest_index_js-node_modules_pmmmwh_react-refresh-webpack-plugin_l-f2609e-chunk-ab686b26d24ccf17324f.min.js:32468:7)
    at div
    at div
    at Page (http://localhost:9000/static/vendors~vendors-node_modules_octokit_rest_index_js-node_modules_pmmmwh_react-refresh-webpack-plugin_l-f2609e-chunk-ab686b26d24ccf17324f.min.js:42328:5)
    at div
    at Flex (http://localhost:9000/static/vendors~vendors-node_modules_octokit_rest_index_js-node_modules_pmmmwh_react-refresh-webpack-plugin_l-f2609e-chunk-ab686b26d24ccf17324f.min.js:55511:7)
    at CloudShell (http://localhost:9000/static/main-bundle.js:98660:3)
    at div
    at DrawerContentBody (http://localhost:9000/static/vendors~vendors-node_modules_octokit_rest_index_js-node_modules_pmmmwh_react-refresh-webpack-plugin_l-f2609e-chunk-ab686b26d24ccf17324f.min.js:32675:7)
    at div
    at div
    at DrawerMain (http://localhost:9000/static/vendors~vendors-node_modules_octokit_rest_index_js-node_modules_pmmmwh_react-refresh-webpack-plugin_l-f2609e-chunk-ab686b26d24ccf17324f.min.js:32752:7)
    at DrawerContent (http://localhost:9000/static/vendors~vendors-node_modules_octokit_rest_index_js-node_modules_pmmmwh_react-refresh-webpack-plugin_l-f2609e-chunk-ab686b26d24ccf17324f.min.js:32628:7)
    at div
    at Drawer (http://localhost:9000/static/vendors~vendors-node_modules_octokit_rest_index_js-node_modules_pmmmwh_react-refresh-webpack-plugin_l-f2609e-chunk-ab686b26d24ccf17324f.min.js:32468:7)
    at QuickStartDrawer (http://localhost:9000/static/vendors~vendors-node_modules_octokit_rest_index_js-node_modules_pmmmwh_react-refresh-webpack-plugin_l-f2609e-chunk-ab686b26d24ccf17324f.min.js:16690:7)
    at QuickStartsLoader (http://localhost:9000/static/main-bundle.js:16137:3)
    at QuickStartDrawer (http://localhost:9000/static/main-bundle.js:15992:3)
    at Suspense
    at EnhancedProvider (http://localhost:9000/static/main-bundle.js:105977:13)
    at QuickStartContextProvider (http://localhost:9000/static/vendors~vendors-node_modules_octokit_rest_index_js-node_modules_pmmmwh_react-refresh-webpack-plugin_l-f2609e-chunk-ab686b26d24ccf17324f.min.js:14036:3)
    at EnhancedProvider (http://localhost:9000/static/main-bundle.js:105977:13)
    at EnhancedProvider (http://localhost:9000/static/main-bundle.js:105977:13)
    at Suspense
    at OverlayProvider (http://localhost:9000/static/main-bundle.js:23190:3)
    at ModalProvider (http://localhost:9000/static/main-bundle.js:23059:3)
    at DetectNamespace (http://localhost:9000/static/main-bundle.js:12155:3)
    at DetectPerspective (http://localhost:9000/static/main-bundle.js:12632:3)
    at App (http://localhost:9000/static/main-bundle.js:105991:3)
    at AppWithExtensions (http://localhost:9000/static/main-bundle.js:106168:137)
    at RenderedRoute (http://localhost:9000/static/vendor-plugins-shared-node_modules_openshift_dynamic-plugin-sdk_dist_index_esm_js-node_module-9d8b97-bundle.js:16119:26)
    at Routes (http://localhost:9000/static/vendor-plugins-shared-node_modules_openshift_dynamic-plugin-sdk_dist_index_esm_js-node_module-9d8b97-bundle.js:16937:3)
    at Router (http://localhost:9000/static/vendor-plugins-shared-node_modules_openshift_dynamic-plugin-sdk_dist_index_esm_js-node_module-9d8b97-bundle.js:16867:13)
    at BrowserRouter (http://localhost:9000/static/vendor-plugins-shared-node_modules_openshift_dynamic-plugin-sdk_dist_index_esm_js-node_module-9d8b97-bundle.js:20117:3)
    at AppRouter (http://localhost:9000/static/main-bundle.js:106190:126)
    at ToastProvider (http://localhost:9000/static/main-bundle.js:62354:3)
    at _HelmetProvider (http://localhost:9000/static/vendors~vendors-node_modules_octokit_rest_index_js-node_modules_pmmmwh_react-refresh-webpack-plugin_l-f2609e-chunk-ab686b26d24ccf17324f.min.js:339389:5)
    at ThemeProvider (http://localhost:9000/static/main-bundle.js:104728:3)
    at PluginStoreProvider (http://localhost:9000/static/vendor-plugins-shared-node_modules_openshift_dynamic-plugin-sdk_dist_index_esm_js-node_module-9d8b97-bundle.js:1046:32)
    at Provider (http://localhost:9000/static/vendor-plugins-shared-node_modules_openshift_dynamic-plugin-sdk_dist_index_esm_js-node_module-9d8b97-bundle.js:7387:11)
    at Suspense
```
```
TypeError: Cannot read properties of null (reading 'firstElementChild')
    at ToolbarFilter.render (http://localhost:9000/static/vendors~vendors-node_modules_octokit_rest_index_js-node_modules_pmmmwh_react-refresh-webpack-plugin_l-f2609e-chunk-ab686b26d24ccf17324f.min.js:49535:291)
    at finishClassComponent (http://localhost:9000/static/vendors~vendors-node_modules_octokit_rest_index_js-node_modules_pmmmwh_react-refresh-webpack-plugin_l-f2609e-chunk-ab686b26d24ccf17324f.min.js:327141:31)
    at updateClassComponent (http://localhost:9000/static/vendors~vendors-node_modules_octokit_rest_index_js-node_modules_pmmmwh_react-refresh-webpack-plugin_l-f2609e-chunk-ab686b26d24ccf17324f.min.js:327087:24)
    at beginWork (http://localhost:9000/static/vendors~vendors-node_modules_octokit_rest_index_js-node_modules_pmmmwh_react-refresh-webpack-plugin_l-f2609e-chunk-ab686b26d24ccf17324f.min.js:329010:16)
    at beginWork$1 (http://localhost:9000/static/vendors~vendors-node_modules_octokit_rest_index_js-node_modules_pmmmwh_react-refresh-webpack-plugin_l-f2609e-chunk-ab686b26d24ccf17324f.min.js:334825:14)
    at performUnitOfWork (http://localhost:9000/static/vendors~vendors-node_modules_octokit_rest_index_js-node_modules_pmmmwh_react-refresh-webpack-plugin_l-f2609e-chunk-ab686b26d24ccf17324f.min.js:333956:12)
    at workLoopSync (http://localhost:9000/static/vendors~vendors-node_modules_octokit_rest_index_js-node_modules_pmmmwh_react-refresh-webpack-plugin_l-f2609e-chunk-ab686b26d24ccf17324f.min.js:333865:5)
    at renderRootSync (http://localhost:9000/static/vendors~vendors-node_modules_octokit_rest_index_js-node_modules_pmmmwh_react-refresh-webpack-plugin_l-f2609e-chunk-ab686b26d24ccf17324f.min.js:333833:7)
    at recoverFromConcurrentError (http://localhost:9000/static/vendors~vendors-node_modules_octokit_rest_index_js-node_modules_pmmmwh_react-refresh-webpack-plugin_l-f2609e-chunk-ab686b26d24ccf17324f.min.js:333249:20)
    at performConcurrentWorkOnRoot (http://localhost:9000/static/vendors~vendors-node_modules_octokit_rest_index_js-node_modules_pmmmwh_react-refresh-webpack-plugin_l-f2609e-chunk-ab686b26d24ccf17324f.min.js:333149:22)
```

When the modal is launched (issue is prominent when it's lazy-loaded), it's crashing PF's `ToolbarFilter` (we don't use `ToolbarFilter` directly, it's internally used by console's `ListPageFilter` component which we import). Please check: https://github.com/patternfly/patternfly-react/pull/12352 for more details.

As a temporary fix, added a wrapper around the `useModal` `launcher`, a slight delay before opening the modal preventing any interference with the `ToolbarFilter` (or `ListPageFilter`) ongoing lifecycle (eg: unmounting).
Also, added an error boundary around `ListPageFilter` as a safety measure, in rare case if crash still happens it will silently remove the filter instead of displaying error or breaking the page.

More permanent and better fix will be to:
1. Either, open a Jira on OCP console for updating PF to `6.4.3` or newer (https://github.com/openshift/console/blob/release-4.22/frontend/package.json#L158).
2. Or, remove `ListPageFilter` which is now a deprecated component (https://github.com/openshift/console/blob/release-4.22/frontend/packages/console-dynamic-plugin-sdk/release-notes/4.19.md?plain=1#L16).