### PR TITLE
Fix non-functional Show more links in cluster sidebar

### DIFF
--- a/locales/en/plugin__odf-console.json
+++ b/locales/en/plugin__odf-console.json
@@ -1429,7 +1429,6 @@
   "Monitoring offers an enhanced perspective on disaster recovery, providing a more optimized view of the ongoing replication and status of volumes at both cluster and application levels.": "Monitoring offers an enhanced perspective on disaster recovery, providing a more optimized view of the ongoing replication and status of volumes at both cluster and application levels.",
   "Monitoring resources (optional)": "Monitoring resources (optional)",
   "Monthly": "Monthly",
-  "more": "more",
   "more conditions": "more conditions",
   "More information about silence types": "More information about silence types",
   "Move workloads to target cluster": "Move workloads to target cluster",

--- a/packages/mco/components/topology/sidebar/ClusterSidebar.tsx
+++ b/packages/mco/components/topology/sidebar/ClusterSidebar.tsx
@@ -44,6 +44,7 @@ export const ClusterSidebar: React.FC<ClusterSidebarProps> = ({ resource }) => {
   const navigate = useNavigate();
   const { clusterAppsMap } = React.useContext(TopologyDataContext);
   const [activeTabKey, setActiveTabKey] = React.useState<string | number>(0);
+  const [showAllConditions, setShowAllConditions] = React.useState(false);
 
   const resourceName = getName(resource);
   const protectedApps = React.useMemo(
@@ -140,19 +141,12 @@ export const ClusterSidebar: React.FC<ClusterSidebarProps> = ({ resource }) => {
                   <DescriptionListGroup>
                     <DescriptionListTerm>{t('Labels')}</DescriptionListTerm>
                     <DescriptionListDescription>
-                      <LabelGroup>
-                        {Object.entries(labels)
-                          .slice(0, 5)
-                          .map(([key, value]) => (
-                            <Label key={key} isCompact>
-                              {key}: {value as string}
-                            </Label>
-                          ))}
-                        {Object.keys(labels).length > 5 && (
-                          <Label isCompact color="blue">
-                            +{Object.keys(labels).length - 5} {t('more')}
+                      <LabelGroup numLabels={5}>
+                        {Object.entries(labels).map(([key, value]) => (
+                          <Label key={key} isCompact>
+                            {key}: {value as string}
                           </Label>
-                        )}
+                        ))}
                       </LabelGroup>
                     </DescriptionListDescription>
                   </DescriptionListGroup>
@@ -162,7 +156,10 @@ export const ClusterSidebar: React.FC<ClusterSidebarProps> = ({ resource }) => {
                     <DescriptionListTerm>{t('Conditions')}</DescriptionListTerm>
                     <DescriptionListDescription>
                       <List isPlain>
-                        {conditions.slice(0, 3).map((condition, idx) => (
+                        {(showAllConditions
+                          ? conditions
+                          : conditions.slice(0, 3)
+                        ).map((condition, idx) => (
                           <ListItem key={idx}>
                             <Label
                               color={
@@ -176,8 +173,17 @@ export const ClusterSidebar: React.FC<ClusterSidebarProps> = ({ resource }) => {
                         ))}
                         {conditions.length > 3 && (
                           <ListItem>
-                            <Label isCompact color="blue">
-                              +{conditions.length - 3} {t('more conditions')}
+                            <Label
+                              isCompact
+                              color="blue"
+                              onClick={() =>
+                                setShowAllConditions(!showAllConditions)
+                              }
+                              style={{ cursor: 'pointer' }}
+                            >
+                              {showAllConditions
+                                ? t('Show less')
+                                : `+${conditions.length - 3} ${t('more conditions')}`}
                             </Label>
                           </ListItem>
                         )}


### PR DESCRIPTION
- **Labels**: replaced manual `.slice(0, 5)` and static "+N more" label with PatternFly `LabelGroup numLabels={5}` for built-in expand/collapse
- **Conditions**: added `showAllConditions` toggle state so the "+N more conditions" label expands/collapses the full condition list on click

Fixes: https://issues.redhat.com/browse/DFBUGS-6702