### PR TITLE
Fix sidebar DR status not auto-refreshing

### DIFF
--- a/packages/mco/components/topology/Topology.tsx
+++ b/packages/mco/components/topology/Topology.tsx
@@ -126,9 +126,27 @@ const TopologyViewComponent: React.FC = () => {
 
   const controlButtons = useTopologyControls({ controller });
 
-  // Get the selected element's data
+  // Derive sidebar data from the reactive model instead of selectedElement.getData().
+  // getData() reads from the GraphElement which is updated by fromModel() in an
+  // effect — one render behind. The model is computed from context maps and is current.
+  // When the element no longer exists in the model (e.g. operation completed),
+  // return undefined so the sidebar closes rather than showing stale data.
   const selectedElement = React.useContext(TopologyDataContext).selectedElement;
-  const selectedElementData = selectedElement?.getData();
+  const selectedElementId = selectedElement?.getId();
+  const selectedElementData = React.useMemo(() => {
+    if (!selectedElementId) return undefined;
+    const node = model.nodes?.find((n) => n.id === selectedElementId);
+    if (node) return node.data;
+    const edge = model.edges?.find((e) => e.id === selectedElementId);
+    return edge?.data;
+  }, [selectedElementId, model]);
+
+  // Close sidebar when the selected element disappears from the model
+  React.useEffect(() => {
+    if (selectedElementId && selectedElementData === undefined) {
+      onCloseSideBar();
+    }
+  }, [selectedElementId, selectedElementData, onCloseSideBar]);
 
   // Check what type of element is selected
   const isEdgeSelected =


### PR DESCRIPTION
## Summary
- Fixes [DFBUGS-6718](https://redhat.atlassian.net/browse/DFBUGS-6718): Applications sidebar DR Status not auto-refreshing in topology view
- Sidebar was reading data from `selectedElement.getData()` which is updated by `controller.fromModel()` in a post-render effect — always one render behind
- Derives sidebar data directly from the reactive `model` (computed from context maps via `useMemo`) using the selected element's ID as a lookup key
- Closes the sidebar when the selected element disappears from the model (e.g. operation completes and the failover node is removed)