### PR TITLE
Fix sidebar showing DRPC name instead of application name

### DIFF
--- a/packages/mco/components/topology/sidebar/AppSidebar.tsx
+++ b/packages/mco/components/topology/sidebar/AppSidebar.tsx
@@ -142,7 +142,7 @@ export const AppSidebar: React.FC<AppSidebarProps> = ({ edgeData }) => {
     );
     const volumeLastGroupSyncTime = op.drpc?.status?.lastGroupSyncTime;
     return {
-      name: op.drpcName,
+      name: op.applicationName,
       namespace: op.applicationNamespace,
       status: getEffectiveDRStatus(
         op.phase,

--- a/packages/mco/hooks/useActiveDROperations.ts
+++ b/packages/mco/hooks/useActiveDROperations.ts
@@ -11,6 +11,7 @@ import {
 } from '../types';
 import { getProtectedCondition } from '../utils';
 import { shouldShowProtectionError } from '../utils/dr-status';
+import { getApplicationName } from '../utils/pav';
 import {
   getDRPlacementControlResourceObj,
   getProtectedApplicationViewResourceObj,
@@ -115,7 +116,7 @@ export const useActiveDROperations = (): [
 
         // Get associated PAV
         const pav = pavByDRPC.get(drpcName);
-        const applicationName = pav?.metadata?.name || drpcName;
+        const applicationName = pav ? getApplicationName(pav) : drpcName;
         const isDiscoveredApp =
           pav?.status?.applicationInfo?.type === ApplicationType.Discovered;
 

--- a/packages/mco/hooks/useProtectedAppsByCluster.ts
+++ b/packages/mco/hooks/useProtectedAppsByCluster.ts
@@ -10,6 +10,7 @@ import {
   getEffectiveDRStatus,
   shouldShowProtectionError,
 } from '../utils/dr-status';
+import { getApplicationName } from '../utils/pav';
 import {
   getDRPlacementControlResourceObj,
   getProtectedApplicationViewResourceObj,
@@ -64,7 +65,7 @@ export const useProtectedAppsByCluster = (): [
           return;
         }
 
-        const appName = pav.metadata?.name;
+        const appName = getApplicationName(pav);
         const appNamespace = pav.metadata?.namespace;
         const phase = pav.status?.drInfo?.status?.phase;
 


### PR DESCRIPTION
## Summary
- Fixes [DFBUGS-6707](https://redhat.atlassian.net/browse/DFBUGS-6707): Applications sidebar shows DRPC name instead of application name
- Uses existing `getApplicationName(pav)` utility which reads `applicationRef.name` from PAV status, falling back to PAV metadata name