### PR TITLE
Fix policy column showing cluster names instead of policy name

### DIFF
--- a/packages/mco/components/topology/sidebar/AppSidebar.tsx
+++ b/packages/mco/components/topology/sidebar/AppSidebar.tsx
@@ -11,6 +11,7 @@ import {
 import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import { DRPlacementControlConditionType } from '../../../types';
 import { getEffectiveDRStatus } from '../../../utils/dr-status';
+import { getPAVDRPolicyName } from '../../../utils/pav';
 import {
   AppSidebarItem,
   StaticAppsSidebarData,
@@ -151,7 +152,7 @@ export const AppSidebar: React.FC<AppSidebarProps> = ({ edgeData }) => {
         protectedCondition,
         volumeLastGroupSyncTime
       ),
-      drPolicy: `${op.action}: ${op.sourceCluster} → ${op.targetCluster}`,
+      drPolicy: op.pav ? getPAVDRPolicyName(op.pav) : '',
     };
   });
 


### PR DESCRIPTION
## Summary
- Fixes [DFBUGS-6795](https://redhat.atlassian.net/browse/DFBUGS-6795): Policy column in operations sidebar shows failover direction (e.g., `Failover: local-cluster → dr1-may-7-26`) instead of the DR policy name (e.g., `odr-policy-5m`)
- Uses existing `getPAVDRPolicyName()` utility to read the actual policy name from PAV status