### PR TITLE
Update deleting phase of cluster in status card.

### DIFF
--- a/packages/ocs/dashboards/persistent-internal/status-card/status-card.tsx
+++ b/packages/ocs/dashboards/persistent-internal/status-card/status-card.tsx
@@ -1,11 +1,16 @@
 import * as React from 'react';
 import { useGetInternalClusterDetails } from '@odf/core/redux/utils';
-import { getResourceInNs as getCephClusterInNs } from '@odf/core/utils';
+import {
+  getResourceInNs as getCephClusterInNs,
+  getStorageClusterInNs,
+  isClusterDeleting,
+} from '@odf/core/utils';
 import { resiliencyProgressQuery } from '@odf/ocs/queries';
 import {
   getCephHealthChecks,
   getCephHealthState,
   getDataResiliencyState,
+  getStorageClusterHealthState,
 } from '@odf/ocs/utils';
 import { odfDocBasePath } from '@odf/shared/constants/doc';
 import { healthStateMapping } from '@odf/shared/dashboards/status-card/states';
@@ -14,10 +19,14 @@ import {
   useCustomPrometheusPoll,
   usePrometheusBasePath,
 } from '@odf/shared/hooks/custom-prometheus-poll';
-import { CephClusterModel } from '@odf/shared/models';
+import { CephClusterModel, StorageClusterModel } from '@odf/shared/models';
 import useAlerts from '@odf/shared/monitoring/useAlert';
 import { alertURL } from '@odf/shared/monitoring/utils';
-import { CephHealthCheckType, K8sResourceKind } from '@odf/shared/types';
+import {
+  CephHealthCheckType,
+  K8sResourceKind,
+  StorageClusterKind,
+} from '@odf/shared/types';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { filterCephAlerts, referenceForModel } from '@odf/shared/utils';
 import {
@@ -126,10 +135,17 @@ const cephClusterResource = {
   isList: true,
 };
 
+const storageClusterResource = {
+  kind: referenceForModel(StorageClusterModel),
+  isList: true,
+};
+
 export const StatusCard: React.FC = () => {
   const { t } = useCustomTranslation();
   const [data, loaded, loadError] =
     useK8sWatchResource<K8sResourceKind[]>(cephClusterResource);
+  const [storageClusters, storageClustersLoaded, storageClustersLoadError] =
+    useK8sWatchResource<StorageClusterKind[]>(storageClusterResource);
 
   const { clusterNamespace: clusterNs, clusterName: managedByOCS } =
     useGetInternalClusterDetails();
@@ -143,11 +159,22 @@ export const StatusCard: React.FC = () => {
   );
 
   const cephCluster = getCephClusterInNs(data, clusterNs);
+  const storageCluster = getStorageClusterInNs(storageClusters, clusterNs);
 
-  const cephHealthState = getCephHealthState(
-    { ceph: { data: cephCluster, loaded, loadError } },
+  const storageClusterHealth = getStorageClusterHealthState(
+    storageCluster,
+    storageClustersLoaded,
+    storageClustersLoadError,
     t
   );
+
+  const cephHealthState =
+    storageClusterHealth ??
+    getCephHealthState({ ceph: { data: cephCluster, loaded, loadError } }, t);
+
+  const suppressCephHealthChecks =
+    (!storageClustersLoaded && !storageClustersLoadError) ||
+    isClusterDeleting(storageCluster);
   const dataResiliencyState = getDataResiliencyState(
     [{ response: resiliencyProgress, error: resiliencyProgressError }],
     t
@@ -170,15 +197,20 @@ export const StatusCard: React.FC = () => {
               title={t('Storage Cluster')}
               state={cephHealthState.state}
               details={cephHealthState.message}
-              popupTitle={healthChecks ? t('Active health checks') : null}
+              popupTitle={
+                healthChecks && !suppressCephHealthChecks
+                  ? t('Active health checks')
+                  : null
+              }
             >
-              {healthChecks?.map((healthCheck: CephHealthCheckType, i) => (
-                <CephHealthCheck
-                  key={`${i}`}
-                  cephHealthState={cephHealthState}
-                  healthCheck={healthCheck}
-                />
-              ))}
+              {!suppressCephHealthChecks &&
+                healthChecks?.map((healthCheck: CephHealthCheckType, i) => (
+                  <CephHealthCheck
+                    key={`${i}`}
+                    cephHealthState={cephHealthState}
+                    healthCheck={healthCheck}
+                  />
+                ))}
             </HealthItem>
           </GalleryItem>
           <GalleryItem>

--- a/packages/ocs/hooks/useOcsHealth.spec.ts
+++ b/packages/ocs/hooks/useOcsHealth.spec.ts
@@ -98,6 +98,35 @@ describe('useGetOCSHealth', () => {
     jest.clearAllMocks();
   });
 
+  describe('StorageCluster phase overrides', () => {
+    it('returns PROGRESS when StorageCluster is in Deleting phase', () => {
+      const deletingStorageCluster = {
+        ...mockStorageCluster,
+        status: { phase: 'Deleting' },
+      };
+
+      (useK8sWatchResource as jest.Mock)
+        .mockReturnValueOnce([[mockCephCluster], true, null])
+        .mockReturnValueOnce([[mockCephObjectStore], true, null])
+        .mockReturnValueOnce([[mockNoobaaSystem], true, null]);
+
+      (useCustomPrometheusPoll as jest.Mock).mockReturnValue([
+        createPrometheusResponse('0'),
+        null,
+      ]);
+
+      const { result } = renderHook(() =>
+        useGetOCSHealth(deletingStorageCluster as any)
+      );
+
+      expect(result.current.healthState).toBe(HealthState.PROGRESS);
+      expect(result.current.message).toBe('Deleting');
+      expect(utils.getCephHealthState).not.toHaveBeenCalled();
+      expect(utils.getRGWHealthState).not.toHaveBeenCalled();
+      expect(utils.getNooBaaState).not.toHaveBeenCalled();
+    });
+  });
+
   describe('Healthy scenarios', () => {
     it('returns OK when all subsystems are healthy', () => {
       (useK8sWatchResource as jest.Mock)

--- a/packages/ocs/hooks/useOcsHealth.ts
+++ b/packages/ocs/hooks/useOcsHealth.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { isClusterDeleting } from '@odf/core/utils/odf';
 import {
   CephObjectStoreModel,
   NooBaaSystemModel,
@@ -70,6 +71,13 @@ export const useGetOCSHealth: UseGetOCSHealth = (storageCluster) => {
   });
 
   return React.useMemo(() => {
+    if (isClusterDeleting(storageCluster)) {
+      return {
+        healthState: HealthState.PROGRESS,
+        message: t('Deleting'),
+      };
+    }
+
     // Check if any required resources are still loading (not loaded and no error)
     const isLoading =
       (!cephLoaded && !cephLoadError) ||

--- a/packages/ocs/hooks/useOcsHealth.ts
+++ b/packages/ocs/hooks/useOcsHealth.ts
@@ -13,6 +13,7 @@ import { getNamespace } from '@odf/shared/selectors';
 import { K8sResourceKind } from '@odf/shared/types';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { referenceForModel } from '@odf/shared/utils';
+import { isClusterDeleting } from '@odf/shared/utils/storage';
 import {
   HealthState,
   useK8sWatchResource,
@@ -70,6 +71,13 @@ export const useGetOCSHealth: UseGetOCSHealth = (storageCluster) => {
   });
 
   return React.useMemo(() => {
+    if (isClusterDeleting(storageCluster)) {
+      return {
+        healthState: HealthState.PROGRESS,
+        message: t('Deleting'),
+      };
+    }
+
     // Check if any required resources are still loading (not loaded and no error)
     const isLoading =
       (!cephLoaded && !cephLoadError) ||

--- a/packages/ocs/utils/ceph-health.ts
+++ b/packages/ocs/utils/ceph-health.ts
@@ -1,3 +1,4 @@
+import { isClusterDeleting } from '@odf/core/utils/odf';
 import { odfDocBasePath } from '@odf/shared/constants';
 import { STATE_PRIORITY } from '@odf/shared/dashboards/status-card/states';
 import { DOC_VERSION } from '@odf/shared/hooks';
@@ -107,6 +108,24 @@ export const getCephHealthState: ResourceHealthHandler<WatchCephResource> = (
     return { state: HealthState.NOT_AVAILABLE };
   }
   return parseCephHealthStatus(status, t);
+};
+
+export const getStorageClusterHealthState = (
+  data: K8sResourceKind | undefined,
+  loaded: boolean,
+  loadError: unknown,
+  t: TFunction
+): SubsystemHealth | undefined => {
+  if (loadError) {
+    return undefined;
+  }
+  if (!loaded) {
+    return { state: HealthState.LOADING, message: t('Loading') };
+  }
+  if (isClusterDeleting(data)) {
+    return { state: HealthState.PROGRESS, message: t('Deleting') };
+  }
+  return undefined;
 };
 
 export const getCephsHealthState: ResourceHealthHandler<WatchCephResources> = (

--- a/packages/ocs/utils/ceph-health.ts
+++ b/packages/ocs/utils/ceph-health.ts
@@ -9,6 +9,7 @@ import {
   ResourceHealthHandler,
 } from '@odf/shared/types';
 import { getResiliencyProgress } from '@odf/shared/utils';
+import { isClusterDeleting } from '@odf/shared/utils/storage';
 import { HealthState } from '@openshift-console/dynamic-plugin-sdk';
 import { SubsystemHealth } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/dashboard-types';
 import { TFunction } from 'i18next';
@@ -107,6 +108,24 @@ export const getCephHealthState: ResourceHealthHandler<WatchCephResource> = (
     return { state: HealthState.NOT_AVAILABLE };
   }
   return parseCephHealthStatus(status, t);
+};
+
+export const getStorageClusterHealthState = (
+  data: K8sResourceKind | undefined,
+  loaded: boolean,
+  loadError: unknown,
+  t: TFunction
+): SubsystemHealth | undefined => {
+  if (loadError) {
+    return undefined;
+  }
+  if (!loaded) {
+    return { state: HealthState.LOADING, message: t('Loading') };
+  }
+  if (isClusterDeleting(data)) {
+    return { state: HealthState.PROGRESS, message: t('Deleting') };
+  }
+  return undefined;
 };
 
 export const getCephsHealthState: ResourceHealthHandler<WatchCephResources> = (

--- a/packages/odf/components/odf-dashboard/status-card/status-card-popover.tsx
+++ b/packages/odf/components/odf-dashboard/status-card/status-card-popover.tsx
@@ -7,6 +7,7 @@ import {
   CheckCircleIcon,
   ExclamationCircleIcon,
   ExclamationTriangleIcon,
+  InProgressIcon,
 } from '@patternfly/react-icons';
 import './status-card-popover.scss';
 
@@ -23,7 +24,7 @@ type StatusCardPopoverProps = {
   secondColumnName: string;
 };
 
-const healthStateToIcon = {
+const healthStateToIcon: Partial<Record<HealthState, React.ReactNode>> = {
   [HealthState.OK]: (
     <CheckCircleIcon color="var(--pf-t--global--color--brand--default)" />
   ),
@@ -32,6 +33,9 @@ const healthStateToIcon = {
   ),
   [HealthState.ERROR]: (
     <ExclamationCircleIcon color="var(--pf-t--global--color--status--danger--default" />
+  ),
+  [HealthState.PROGRESS]: (
+    <InProgressIcon color="var(--pf-t--global--color--brand--default)" />
   ),
 };
 

--- a/packages/odf/components/odf-dashboard/status-card/status-card.tsx
+++ b/packages/odf/components/odf-dashboard/status-card/status-card.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useSafeK8sWatchResource } from '@odf/core/hooks';
 import { K8sResourceObj } from '@odf/core/types';
 import { useGetOCSHealth } from '@odf/ocs/hooks';
+import { getStorageClusterHealthState } from '@odf/ocs/utils';
 import { StorageConsumerKind } from '@odf/shared';
 import { StorageConsumerModel } from '@odf/shared';
 import { ODF_OPERATOR } from '@odf/shared/constants';
@@ -14,7 +15,10 @@ import {
 import { useWatchStorageSystems } from '@odf/shared/hooks/useWatchStorageSystems';
 import { StorageClusterModel } from '@odf/shared/models';
 import { getName, getNamespace } from '@odf/shared/selectors';
-import { ClusterServiceVersionKind } from '@odf/shared/types';
+import {
+  ClusterServiceVersionKind,
+  StorageClusterKind,
+} from '@odf/shared/types';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import {
   getGVK,
@@ -41,7 +45,11 @@ import { PROVIDER_MODE } from '../../../features';
 import { getVendorDashboardLinkFromMetrics } from '../../utils';
 import { StorageDashboard, STATUS_QUERIES } from '../queries';
 import StatusCardPopover from './status-card-popover';
-import { getAggregateClientHealthState, getClientText } from './utils';
+import {
+  getAggregateClientHealthState,
+  getClientText,
+  getWorstHealthState,
+} from './utils';
 import '../../../style.scss';
 
 const operatorResource: K8sResourceObj = (ns) => ({
@@ -50,11 +58,18 @@ const operatorResource: K8sResourceObj = (ns) => ({
   isList: true,
 });
 
+const storageClusterResource = {
+  kind: referenceForModel(StorageClusterModel),
+  isList: true,
+};
+
 export const StatusCard: React.FC = () => {
   const { t } = useCustomTranslation();
   const [csvData, csvLoaded, csvLoadError] =
     useSafeK8sWatchResource<ClusterServiceVersionKind[]>(operatorResource);
   const [systems, systemsLoaded, systemsLoadError] = useWatchStorageSystems();
+  const [storageClusters, storageClustersLoaded, storageClustersLoadError] =
+    useK8sWatchResource<StorageClusterKind[]>(storageClusterResource);
   const [healthData, healthError, healthLoading] = useCustomPrometheusPoll({
     query: STATUS_QUERIES[StorageDashboard.HEALTH],
     endpoint: 'api/v1/query' as any,
@@ -91,7 +106,7 @@ export const StatusCard: React.FC = () => {
           );
           const systemKind =
             referenceForGroupVersionKind(apiGroup)(apiVersion)(kind);
-          const systemData =
+          let systemData =
             apiGroup === StorageClusterModel.apiGroup
               ? {
                   systemName,
@@ -118,16 +133,42 @@ export const StatusCard: React.FC = () => {
                     systemNamespace
                   ),
                 };
+
+          if (apiGroup === StorageClusterModel.apiGroup) {
+            const storageCluster = storageClusters?.find(
+              (cluster) =>
+                getName(cluster) === systemName &&
+                getNamespace(cluster) === systemNamespace
+            );
+            const storageClusterHealth = getStorageClusterHealthState(
+              storageCluster,
+              storageClustersLoaded,
+              storageClustersLoadError,
+              t
+            );
+
+            if (storageClusterHealth) {
+              systemData = {
+                ...systemData,
+                healthState: storageClusterHealth.state,
+                ...(storageClusterHealth.message
+                  ? { extraTexts: [storageClusterHealth.message] }
+                  : {}),
+              };
+            }
+          }
+
           return [...acc, systemData];
         }, [])
       : [];
 
   const healthySystems = parsedHealthData.filter(
-    (item) => item.rawHealthData === '0'
+    (item) => item.healthState === HealthState.OK
   );
   const unHealthySystems = parsedHealthData.filter(
-    (item) => item.rawHealthData !== '0'
+    (item) => item.healthState !== HealthState.OK
   );
+  const unHealthySystemsAggregateState = getWorstHealthState(unHealthySystems);
 
   const operatorHealthStatus = getOperatorHealthState(
     operatorStatus,
@@ -183,7 +224,7 @@ export const StatusCard: React.FC = () => {
             <GalleryItem>
               <HealthItem
                 title={pluralize(unHealthySystems.length, 'Storage system')}
-                state={HealthState.ERROR}
+                state={unHealthySystemsAggregateState}
                 maxWidth="35rem"
               >
                 <StatusCardPopover

--- a/packages/odf/components/odf-dashboard/status-card/utils.ts
+++ b/packages/odf/components/odf-dashboard/status-card/utils.ts
@@ -1,7 +1,23 @@
 import { StorageConsumerKind, StorageConsumerState } from '@odf/shared';
+import { STATE_PRIORITY } from '@odf/shared/dashboards/status-card/states';
 import { getTimeDifferenceInSeconds } from '@odf/shared/details-page/datetime';
 import { HealthState } from '@openshift-console/dynamic-plugin-sdk';
 import { TFunction } from 'i18next';
+
+type HealthStateItem = {
+  healthState: HealthState;
+};
+
+export const getWorstHealthState = (
+  items: HealthStateItem[] = []
+): HealthState => {
+  for (const state of STATE_PRIORITY) {
+    if (items.some((item) => item.healthState === state)) {
+      return state;
+    }
+  }
+  return HealthState.UNKNOWN;
+};
 
 const getHealthAndTotalClientCounts = (clients: StorageConsumerKind[]) => {
   const connectedClients = clients.filter(

--- a/packages/odf/utils/odf.ts
+++ b/packages/odf/utils/odf.ts
@@ -7,6 +7,7 @@ import { K8sResourceKind } from '@odf/shared/types';
 import {
   StorageClassResourceKind,
   StorageClusterKind,
+  StorageClusterPhase,
 } from '@odf/shared/types';
 import { isDefaultClass } from '@odf/shared/utils';
 import * as _ from 'lodash-es';
@@ -52,6 +53,9 @@ export const isExternalCluster = (storageCluster: StorageClusterKind) =>
 
 export const isClusterIgnored = (storageCluster: StorageClusterKind) =>
   storageCluster?.status?.phase === 'Ignored';
+
+export const isClusterDeleting = (storageCluster?: K8sResourceKind) =>
+  storageCluster?.status?.phase === StorageClusterPhase.Deleting;
 
 export const isNFSEnabled = (storageCluster: StorageClusterKind) =>
   storageCluster?.spec?.nfs?.enable === true;

--- a/packages/odf/utils/odf.ts
+++ b/packages/odf/utils/odf.ts
@@ -1,9 +1,9 @@
 import { getNamespace } from '@odf/shared/selectors';
 import {
   ClusterServiceVersionKind,
+  K8sResourceKind,
   StorageConsumerKind,
 } from '@odf/shared/types';
-import { K8sResourceKind } from '@odf/shared/types';
 import {
   StorageClassResourceKind,
   StorageClusterKind,
@@ -52,6 +52,8 @@ export const isExternalCluster = (storageCluster: StorageClusterKind) =>
 
 export const isClusterIgnored = (storageCluster: StorageClusterKind) =>
   storageCluster?.status?.phase === 'Ignored';
+
+export { isClusterDeleting } from '@odf/shared/utils/storage';
 
 export const isNFSEnabled = (storageCluster: StorageClusterKind) =>
   storageCluster?.spec?.nfs?.enable === true;

--- a/packages/shared/src/types/storage.ts
+++ b/packages/shared/src/types/storage.ts
@@ -22,6 +22,7 @@ export type DataPool = {
 export enum StorageClusterPhase {
   Ready = 'Ready',
   Error = 'Error',
+  Deleting = 'Deleting',
 }
 
 export type ManagedResourcesCephClusterKind = {

--- a/packages/shared/src/utils/storage.ts
+++ b/packages/shared/src/utils/storage.ts
@@ -14,6 +14,7 @@ import {
   ClusterServiceVersionKind,
   PersistentVolumeClaimKind,
   StorageClusterKind,
+  StorageClusterPhase,
   StorageSystemKind,
 } from '@odf/shared/types';
 import { getGVKLabel } from '@odf/shared/utils/common';
@@ -73,6 +74,9 @@ export const getStorageSizeInTiBWithoutUnit = (
 
 export const getStorageAutoScalerName = (storageCluster: StorageClusterKind) =>
   `${getName(storageCluster)}-${DEFAULT_DEVICECLASS}`;
+
+export const isClusterDeleting = (storageCluster?: K8sResourceKind) =>
+  storageCluster?.status?.phase === StorageClusterPhase.Deleting;
 
 export const isOCSStorageSystem = (
   resource: K8sResourceKind


### PR DESCRIPTION
bug link: https://redhat.atlassian.net/browse/DFBUGS-4273

**description :** When storage cluster is stuck in Deleting state, on Storage cluster page it's still green, as if everything is OK and its misleading.

**cause:** When this dashboard was observed, CephCluster was not it deletion phase yet. 

**fix:** Updated the ui to show a spinner and show deleting status in the status card as suggested and approved by UX team

**before fix:**



https://github.com/user-attachments/assets/7bdd6caa-7124-46c8-bcfe-c5df748a8ce8



**after fix:**


https://github.com/user-attachments/assets/cc972ec9-ecd0-4c39-9b6d-590fb953e5a8



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Status cards now include StorageCluster health when determining overall storage health.
  - Added clearer progress reporting while a storage cluster is being deleted.

- **Bug Fixes**
  - Health checks are no longer shown while storage cluster information is loading or during deletion.
  - Deleting storage clusters now display a “Deleting” progress state instead of unrelated health results.
  - Ceph health remains available as a fallback when StorageCluster health cannot be determined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->