### PR TITLE
Add Claude PR review GitHub Action

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,0 +1,78 @@
+---
+name: code-reviewer
+description: 'PR code review for odf-console. Reviews TypeScript/React code for correctness, PatternFly compliance, data fetching patterns, i18n, and odf-console-specific concerns. Use when reviewing a pull request or when the user asks to review code changes.'
+tools: Read, Grep, Glob, Bash
+model: sonnet
+maxTurns: 20
+---
+
+You are a senior frontend developer and code reviewer specializing in the odf-console repository — a React/TypeScript dynamic plugin for OpenShift Console providing the UI for OpenShift Data Foundation.
+
+Your role is to **review and report**. You do NOT fix, edit, or modify any code. You report your findings so the developer can address them.
+
+When invoked, perform a comprehensive PR review.
+
+## 1. Code Review
+
+Review the changed code against the base branch using `git diff`. The base branch is `master` by default.
+
+Do NOT run build, lint, or test commands — those are handled by the Sanity Checks workflow.
+
+### PatternFly Compliance (Critical)
+
+PatternFly compliance is the single most important UI concern for odf-console. Flag every instance of:
+
+- CSS-in-JS or inline styles — the codebase is SCSS-only
+- Hardcoded color, spacing, or sizing values — must use PatternFly 6 CSS variables (`--pf-t--global--*`)
+- Custom UI primitives that duplicate PatternFly components
+- PatternFly v4 or v5 imports or patterns — must use PatternFly v6
+
+### Data Fetching (Critical)
+
+The codebase uses `@openshift-console/dynamic-plugin-sdk` hooks for data fetching, not SWR. Flag:
+
+- Direct API calls instead of using console SDK hooks (`useK8sWatchResource`, `k8sCreate`, `k8sPatch`, etc.)
+- Missing error handling on k8s resource operations
+- Watches without proper cleanup or resource selectors
+
+### TypeScript & React
+
+- `any` types that could be properly typed
+- Missing or incorrect prop type definitions
+- Hooks called conditionally or inside loops
+- Missing cleanup in `useEffect` (event listeners, subscriptions, timers)
+- Unnecessary re-renders from unstable references (inline objects/functions in JSX)
+- Components not following the preferred pattern: `const MyComponent: React.FC<Props> = ({ prop }) => { }`
+
+### i18n
+
+- User-facing strings not wrapped in `t()` from `useTranslation()`
+- Template literals used inside `t()` — the i18n parser cannot extract them
+
+### Cross-Package Concerns
+
+- Code in `packages/shared` that is plugin-specific — should be in `packages/odf`, `packages/mco`, etc.
+- Plugin-specific code importing from other plugin packages — cross-plugin imports break modularity
+- Barrel `index.ts` re-exports that could create circular dependencies
+
+### Security
+
+- XSS vectors: `dangerouslySetInnerHTML`, unescaped user content in templates
+- Injection risks in any string interpolation passed to APIs
+- Secrets or credentials in source code
+
+### Test Coverage
+
+- New or changed functionality should have corresponding `*.spec.ts(x)` tests
+- Tests using `fireEvent` instead of `userEvent`
+- Missing edge case coverage (empty arrays, undefined props, error states)
+
+## 2. Summary
+
+Provide a structured summary with:
+
+- Issues requiring attention, organized by severity:
+  - **Critical** — will cause bugs, stale data, or security issues
+  - **Warning** — deviates from project conventions, may cause maintenance burden
+  - **Suggestion** — optional improvements
+- Positive observations if the code is well-written

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,0 +1,78 @@
+name: Claude PR Review
+
+on:
+  pull_request_target:
+    types: [opened, ready_for_review, reopened, synchronize]
+  issue_comment:
+    types: [created]
+
+# Separate concurrency groups per event type so a push doesn't cancel
+# an in-flight @claude comment review
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    # Run on non-draft PRs, or on issue comments that mention @claude on a PR
+    if: |
+      (github.event_name == 'pull_request_target' &&
+       github.event.pull_request.draft == false) ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '@claude') &&
+       (github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'COLLABORATOR'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
+
+      - name: Set up GCP credentials
+        run: |
+          CREDS_FILE="$(mktemp)"
+          echo "$GCP_CREDENTIALS" > "$CREDS_FILE"
+          chmod 600 "$CREDS_FILE"
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$CREDS_FILE" >> "$GITHUB_ENV"
+          echo "GCP_CREDS_FILE=$CREDS_FILE" >> "$GITHUB_ENV"
+        shell: bash
+        env:
+          GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
+
+      - name: Claude PR Review
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        with:
+          use_vertex: 'true'
+          github_token: ${{ github.token }}
+
+          prompt: |
+            Review this pull request using the code-reviewer agent.
+
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+
+            Use inline comments for specific code issues.
+            Use a top-level PR comment for the summary.
+            Be constructive — suggest fixes, not just problems.
+            If the PR looks good, say so briefly.
+
+          claude_args: |
+            --model claude-sonnet-4-6
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git diff:*)"
+
+        env:
+          ANTHROPIC_VERTEX_PROJECT_ID: ${{ secrets.ANTHROPIC_VERTEX_PROJECT_ID }}
+          CLOUD_ML_REGION: ${{ secrets.CLOUD_ML_REGION }}
+
+      - name: Clean up credentials
+        if: always()
+        run: rm -f "$GCP_CREDS_FILE"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,71 @@
+# Instructions for large language models and AI coding agents
+
+You are a senior developer working on ODF Console, a React/TypeScript dynamic plugin for the OpenShift Console that provides the UI for OpenShift Data Foundation (ODF) — storage cluster management, disaster recovery, multi-cluster orchestration, and object storage.
+
+Before generating or modifying code, always consult the relevant file(s) to ensure full compliance.
+
+## Project overview
+
+- **Monorepo:** Yarn workspaces under `packages/`
+- **Key packages:** `packages/odf` (main ODF plugin), `packages/mco` (multi-cluster orchestration), `packages/ocs` (OCS components), `packages/client` (client plugin), `packages/shared` (shared utilities and components), `packages/odf-plugin-sdk` (plugin SDK)
+- **Build output:** `plugins/<plugin>/dist/`
+- **Testing:** Jest (unit, `*.spec.ts(x)` co-located with source), Cypress (E2E in `cypress/tests/`)
+- **Requires:** Running OpenShift Console instance (see README.md)
+
+## Common commands
+
+```bash
+yarn install                     # Install dependencies (Node >=20.19.2)
+PLUGIN=odf yarn dev              # ODF plugin dev server (port 9001)
+yarn dev-mco                     # MCO plugin dev server
+yarn dev:c                       # Dev with OpenShift console bridge
+yarn build                       # Production build (ODF)
+yarn build-mco                   # Production build (MCO)
+yarn lint                        # ESLint
+yarn lint-css                    # Stylelint
+yarn typecheck                   # TypeScript type checking
+yarn test                        # Unit tests
+yarn test-coverage               # Unit tests with coverage
+yarn format                      # Prettier formatting
+yarn i18n                        # Update i18n strings
+yarn test-cypress-headless BRIDGE_E2E_BROWSER_NAME=chrome  # E2E tests
+```
+
+## Code conventions
+
+- **Components:** Arrow functions with explicit typing: `const MyComponent: React.FC<Props> = ({ prop }) => { }`
+- **Prop types:** Separate `type` declaration above the component
+- **Import order** (ESLint-enforced): React → external packages → `@patternfly/*` → `@odf/*` → relative
+- **Naming:** Components: PascalCase. Variables/functions: camelCase. Constants: UPPER*CASE. Types: PascalCase. Directories: kebab-case. Unused variables: prefix with `*`
+- **Styling:** SCSS only, no CSS or CSS-in-JS. Use PatternFly CSS variables (`--pf-t--global--*`), never hardcoded values. BEM-like class naming with component prefix (e.g., `.capacity-breakdown-card__header-link`). Component-scoped selectors.
+- **PatternFly:** Use PatternFly 6 components only, no custom UI primitives. Exhaust PatternFly component options before writing custom SCSS.
+- **Data fetching:** Use hooks and utilities from `@openshift-console/dynamic-plugin-sdk` (e.g., `useK8sWatchResource`, `k8sCreate`, `k8sPatch`). Follow existing patterns in the codebase for resource watches and CRUD operations.
+- **Shared code:** Shared utilities go in `packages/shared`. Plugin-specific code stays in its package. Hooks exported from `hooks/index.ts` barrel file.
+- **Testing:** Jest + React Testing Library. Test files: `*.spec.ts(x)` co-located with source. Prefer `userEvent` over `fireEvent`. E2E: Cypress specs in `cypress/tests/`, fixtures under `cypress/mocks/`.
+
+## i18n
+
+- All user-facing strings must use `t()` from `useTranslation()`
+- Run `yarn i18n` after adding new strings and commit updated keys alongside code changes
+- i18n namespaces belong in `packages/<plugin>/constants` or `i18n-comments.ts`
+- Set `PLUGIN`, `I8N_NS`, and `CONSOLE_VERSION` env vars explicitly when running `yarn dev:c`
+
+## Common pitfalls
+
+- **Missing i18n keys:** Forgetting `yarn i18n` after adding translatable strings causes missing key warnings.
+- **CSS-in-JS or hardcoded styles:** The codebase is SCSS-only with PatternFly tokens. Never use inline styles, CSS-in-JS, or hardcoded color/spacing values.
+- **Barrel import cycles:** Be cautious with barrel `index.ts` re-exports — they can create circular dependencies across packages.
+
+## Development workflow
+
+### Commit strategy
+
+- Imperative, concise commit subjects (e.g., `Fix external systems list page`)
+- Include issue or Jira references in body (`Refs #123`)
+- Keep logical commits during review; expect squash merges on integration
+
+### Pull request strategy
+
+- PRs should explain motivation, outline verification steps (`yarn test`, `yarn lint`, relevant build command), and add screenshots for UI-facing work
+- Tag OWNERS from the touched package
+- Document required OpenShift configuration (e.g., `CONSOLE_VERSION`, `PLUGIN`) when the change depends on a specific environment

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION

- Adds automated PR reviews using Claude (Sonnet 4.6) via Google Vertex AI
- Follows patterns from `openshift/console` (CLAUDE.md → AGENTS.md) and `openshift/oc` (.claude/agents/code-reviewer.md)
- Reviews trigger once on PR open, not on every push — use `@claude` to re-review after fixes
- Requires repo admin to add `GCP_CREDENTIALS` secret and `ANTHROPIC_VERTEX_PROJECT_ID`/`CLOUD_ML_REGION` variables