### PR TITLE
fix show success decorator for FailedOver on DR topology

### DIFF
--- a/packages/mco/components/topology/utils/decorator-helpers.ts
+++ b/packages/mco/components/topology/utils/decorator-helpers.ts
@@ -28,6 +28,7 @@ export const getDecoratorForStatus = (
     case DRStatus.Healthy:
     case DRStatus.Available:
     case DRStatus.Relocated:
+    case DRStatus.FailedOver:
     case Phase.Deployed:
     case Progression.Completed:
       icon = DecoratorIcon.CheckCircle;
@@ -52,7 +53,6 @@ export const getDecoratorForStatus = (
       tooltip = 'Action required';
       status = NodeStatus.info;
       break;
-    case DRStatus.FailedOver:
     case DRStatus.Warning:
       icon = DecoratorIcon.ExclamationTriangle;
       tooltip = drStatus;


### PR DESCRIPTION
https://redhat.atlassian.net/browse/DFBUGS-6797

getDecoratorForStatus mapped DRStatus.FailedOver to the warning triangle while sidebar-utils and disaster-recovery already treat FailedOver as a successful completed failover. Topology app nodes use getDecoratorForStatus for quadrant decorators, which caused the BZ mismatch on the target cluster.

Align FailedOver with Relocated/Healthy: CheckCircle and NodeStatus.success.