### PR TITLE
hide OBC UI until CRDs and OBC StorageClass exist at client

### DIFF
--- a/packages/client/src/features.ts
+++ b/packages/client/src/features.ts
@@ -1,2 +1,48 @@
+import { SECOND } from '@odf/core/constants';
+import { FeatureDetector } from '@odf/core/features';
+import {
+  CustomResourceDefinitionModel,
+  NooBaaObjectBucketClaimModel,
+  NooBaaObjectBucketModel,
+} from '@odf/shared/models';
+import { CustomResourceDefinitionKind } from '@odf/shared/types';
+import { k8sList, SetFeatureFlag } from '@openshift-console/dynamic-plugin-sdk';
+
 export { default } from '@odf/core/redux';
 export * from '@odf/core/redux';
+
+export const OB_OBC_CRD_EXISTS = 'OB_OBC_CRD_EXISTS';
+
+export const detectObObcCrds: FeatureDetector = async (
+  setFlag: SetFeatureFlag
+) => {
+  let intervalId = null;
+
+  const detector = async () => {
+    try {
+      const crds = (await k8sList({
+        model: CustomResourceDefinitionModel,
+        queryParams: { ns: null },
+      })) as CustomResourceDefinitionKind[];
+
+      const obcCrd = crds?.filter(
+        (crd) => crd.spec.names.kind === NooBaaObjectBucketClaimModel.kind
+      );
+      const obCrd = crds?.filter(
+        (crd) => crd.spec.names.kind === NooBaaObjectBucketModel.kind
+      );
+
+      if (obcCrd?.length > 0 && obCrd?.length > 0) {
+        setFlag(OB_OBC_CRD_EXISTS, true);
+        clearInterval(intervalId);
+      } else {
+        setFlag(OB_OBC_CRD_EXISTS, false);
+      }
+    } catch (_error) {
+      setFlag(OB_OBC_CRD_EXISTS, false);
+    }
+  };
+
+  detector();
+  intervalId = setInterval(detector, 15 * SECOND);
+};

--- a/plugins/client/console-extensions.json
+++ b/plugins/client/console-extensions.json
@@ -173,7 +173,8 @@
       "component": { "$codeRef": "mcg.OBCListPage" }
     },
     "flags": {
-      "disallowed": ["ODF_MODEL"]
+      "disallowed": ["ODF_MODEL"],
+      "required": ["OB_OBC_CRD_EXISTS"]
     }
   },
   {
@@ -184,7 +185,8 @@
       "component": { "$codeRef": "mcg.CreateOBCPage" }
     },
     "flags": {
-      "disallowed": ["ODF_MODEL"]
+      "disallowed": ["ODF_MODEL"],
+      "required": ["OB_OBC_CRD_EXISTS"]
     }
   },
   {
@@ -195,7 +197,8 @@
       "component": { "$codeRef": "mcg.OBCDetailsPage" }
     },
     "flags": {
-      "disallowed": ["ODF_MODEL"]
+      "disallowed": ["ODF_MODEL"],
+      "required": ["OB_OBC_CRD_EXISTS"]
     }
   },
   {
@@ -213,6 +216,17 @@
     "properties": {
       "handler": {
         "$codeRef": "features.useODFNamespace"
+      }
+    },
+    "flags": {
+      "disallowed": ["ODF_MODEL"]
+    }
+  },
+  {
+    "type": "console.flag",
+    "properties": {
+      "handler": {
+        "$codeRef": "features.detectObObcCrds"
       }
     },
     "flags": {


### PR DESCRIPTION
Gate Object Bucket Claims tab and OBC routes on ODF_CLIENT_OBC_UI. Register the flag from the client features module (console exposes features as @odf/client/src/features). Poll every 15s after install so prerequisites are picked up without reload.

Ref: https://redhat.atlassian.net/browse/DFBUGS-6493