### PR TITLE
Display full clustername in topology page kebab menu

### DIFF
--- a/packages/mco/components/topology/components/ClusterContextMenu.scss
+++ b/packages/mco/components/topology/components/ClusterContextMenu.scss
@@ -1,0 +1,35 @@
+.mco-topology__cluster-context-menu {
+  &.pf-v6-c-menu {
+    width: max-content;
+    min-width: max-content;
+  }
+
+  &.pf-m-drilldown.pf-m-drilled-in {
+    > .pf-v6-c-menu__content > .pf-v6-c-menu__list {
+      transform: none !important;
+      visibility: visible;
+    }
+
+    > .pf-v6-c-menu__content > .pf-v6-c-menu__list > .pf-v6-c-menu__list-item.pf-m-current-path {
+      visibility: visible;
+
+      > .pf-v6-c-menu__item {
+        display: none;
+      }
+
+      > .pf-v6-c-menu {
+        position: static;
+        inset: auto;
+        transform: none !important;
+        width: max-content;
+        min-width: 0;
+      }
+    }
+  }
+
+  .pf-v6-c-menu__item-text {
+    overflow: visible;
+    text-overflow: unset;
+    white-space: nowrap;
+  }
+}

--- a/packages/mco/components/topology/components/ClusterContextMenu.tsx
+++ b/packages/mco/components/topology/components/ClusterContextMenu.tsx
@@ -15,6 +15,7 @@ import {
   ClusterContextMenuState,
   ClusterContextMenuHandlers,
 } from '../hooks/useClusterContextMenu';
+import './ClusterContextMenu.scss';
 
 export interface ClusterContextMenuProps {
   state: ClusterContextMenuState;
@@ -63,9 +64,11 @@ export const ClusterContextMenu: React.FC<ClusterContextMenuProps> = ({
         left: menuPosition.x,
         top: menuPosition.y,
         zIndex: 9999,
+        width: 'max-content',
       }}
     >
       <Menu
+        className="mco-topology__cluster-context-menu"
         id={rootMenuId}
         containsDrilldown
         drilldownItemPath={drilldownPath}


### PR DESCRIPTION
https://redhat.atlassian.net/browse/DFBUGS-6867

On the DR Topology View page, when clicking the kebab menu and clicking on the "Pair cluster" submenu, cluster names longer than 12 characters are truncated with ellipsis (...).
**expected results from the bug:** Full cluster name should be displayed regardless of length.

hardcoded a long name "MyStorageClusterWithALongName" instead of the cluster name for testing purpose.
**before fix**

<img width="1728" height="1117" alt="beforefix_bug6867" src="https://github.com/user-attachments/assets/c14c99cf-3102-4701-8f42-1e0922152f3d" />

**after fix**

<img width="1728" height="1117" alt="afterfix_bug6867" src="https://github.com/user-attachments/assets/6096612b-dac3-4a3e-a049-543a6500aa68" />
