### PR TITLE
Make S3 form read-only when DRClusters already exist

### DIFF
--- a/packages/mco/components/create-dr-policy/CreateDRPolicyForm.tsx
+++ b/packages/mco/components/create-dr-policy/CreateDRPolicyForm.tsx
@@ -76,7 +76,10 @@ const areS3DetailsFormatValid = (d: S3Details): boolean =>
   isFilled(d.s3ProfileName) &&
   isValidS3ProfileName(d.s3ProfileName);
 
-export const validateDRPolicyInputs = (state: DRPolicyState): boolean => {
+export const validateDRPolicyInputs = (
+  state: DRPolicyState,
+  allDRClustersExist = false
+): boolean => {
   const {
     policyName,
     replicationType,
@@ -97,6 +100,7 @@ export const validateDRPolicyInputs = (state: DRPolicyState): boolean => {
   if (!baseValid) return false;
 
   if (replicationBackend === BackendType.ThirdParty) {
+    if (allDRClustersExist) return true;
     const c2ProfileValid =
       isFilled(cluster2S3Details.s3ProfileName) &&
       isValidS3ProfileName(cluster2S3Details.s3ProfileName);
@@ -438,8 +442,8 @@ export const CreateDRPolicyForm: React.FC<CreateDRPolicyFormProps> = ({
                         cluster1Details={state.cluster1S3Details}
                         cluster2Details={state.cluster2S3Details}
                         useSameConnection={state.useSameS3Connection}
-                        areDRClustersAlreadyCreated={
-                          selectedDRClusters.length > 0
+                        existingDRClusterNames={
+                          new Set(selectedDRClusters.map(getName))
                         }
                         dispatch={dispatch}
                       />
@@ -484,7 +488,12 @@ export const CreateDRPolicyForm: React.FC<CreateDRPolicyFormProps> = ({
           data-test="create-button"
           variant={ButtonVariant.primary}
           onClick={onCreate}
-          isDisabled={!validateDRPolicyInputs(state) || isLoading}
+          isDisabled={
+            !validateDRPolicyInputs(
+              state,
+              selectedDRClusters.length === MAX_ALLOWED_CLUSTERS
+            ) || isLoading
+          }
           isLoading={isLoading}
         >
           {t('Create')}

--- a/packages/mco/components/create-dr-policy/add-s3-bucket-details/s3-bucket-details-form.tsx
+++ b/packages/mco/components/create-dr-policy/add-s3-bucket-details/s3-bucket-details-form.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { MAX_ALLOWED_CLUSTERS } from '@odf/mco/constants';
 import { getName, useCustomTranslation } from '@odf/shared';
 import {
   Button,
@@ -32,7 +33,7 @@ type ClusterS3BucketDetailsFormProps = {
   cluster2Details: S3Details;
   useSameConnection: boolean;
   dispatch: React.Dispatch<any>;
-  areDRClustersAlreadyCreated?: boolean;
+  existingDRClusterNames: Set<string>;
 };
 
 export const ClusterS3BucketDetailsForm: React.FC<
@@ -42,7 +43,7 @@ export const ClusterS3BucketDetailsForm: React.FC<
   cluster1Details,
   cluster2Details,
   useSameConnection,
-  areDRClustersAlreadyCreated,
+  existingDRClusterNames,
   dispatch,
 }) => {
   const { t } = useCustomTranslation();
@@ -56,6 +57,10 @@ export const ClusterS3BucketDetailsForm: React.FC<
 
   const name1 = getName(selectedClusters[0]) || 'cluster-1';
   const name2 = getName(selectedClusters[1]) || 'cluster-2';
+
+  const cluster1Exists = existingDRClusterNames.has(name1);
+  const cluster2Exists = existingDRClusterNames.has(name2);
+  const allClustersExist = existingDRClusterNames.size === MAX_ALLOWED_CLUSTERS;
 
   // Track cluster2's s3ProfileName via ref so the sync effect can read it
   // without adding it as a dependency (avoids unnecessary re-runs on typing).
@@ -174,7 +179,7 @@ export const ClusterS3BucketDetailsForm: React.FC<
     <div className="pf-v6-u-p-md">
       <ExpandableSection
         toggleText={
-          areDRClustersAlreadyCreated
+          cluster1Exists
             ? t(`Previously used S3 bucket for {{name}}`, { name: name1 })
             : t(`S3 bucket for {{name}}`, { name: name1 })
         }
@@ -202,6 +207,7 @@ export const ClusterS3BucketDetailsForm: React.FC<
                     })}
                     onChange={(_, v) => update(1, key, v)}
                     validated={errors1[key] ? 'error' : 'default'}
+                    isDisabled={cluster1Exists}
                     onBlur={() => handleBlur(1)}
                   />
                 </FlexItem>
@@ -211,6 +217,7 @@ export const ClusterS3BucketDetailsForm: React.FC<
                     variant="plain"
                     onClick={() => setShow1((s) => !s)}
                     aria-label={t('Toggle secret visibility')}
+                    isDisabled={cluster1Exists}
                   />
                 </FlexItem>
               </Flex>
@@ -223,6 +230,7 @@ export const ClusterS3BucketDetailsForm: React.FC<
                 })}
                 onChange={(_, v) => update(1, key, v)}
                 validated={errors1[key] ? 'error' : 'default'}
+                isDisabled={cluster1Exists}
                 onBlur={() => handleBlur(1)}
               />
             )}
@@ -237,7 +245,7 @@ export const ClusterS3BucketDetailsForm: React.FC<
       <Divider className="pf-v6-u-p-md" />
       <ExpandableSection
         toggleText={
-          areDRClustersAlreadyCreated
+          cluster2Exists
             ? t(`Previously used S3 bucket for {{name}}`, { name: name2 })
             : t(`S3 bucket for {{name}}`, { name: name2 })
         }
@@ -245,12 +253,14 @@ export const ClusterS3BucketDetailsForm: React.FC<
         onToggle={(_, exp) => setExpanded2(exp)}
         isIndented
       >
-        <Checkbox
-          id="use-same-conn"
-          label={t('Use the same S3 connection details as the first cluster')}
-          isChecked={useSameConnection}
-          onChange={onToggleSame}
-        />
+        {!allClustersExist && (
+          <Checkbox
+            id="use-same-conn"
+            label={t('Use the same S3 connection details as the first cluster')}
+            isChecked={useSameConnection}
+            onChange={onToggleSame}
+          />
+        )}
         {fields.map(({ key, label }) => (
           <FormGroup
             key={key}
@@ -271,7 +281,7 @@ export const ClusterS3BucketDetailsForm: React.FC<
                     })}
                     onChange={(_, v) => update(2, key, v)}
                     validated={errors2[key] ? 'error' : 'default'}
-                    isDisabled={useSameConnection}
+                    isDisabled={useSameConnection || cluster2Exists}
                     onBlur={() => handleBlur(2)}
                   />
                 </FlexItem>
@@ -281,7 +291,7 @@ export const ClusterS3BucketDetailsForm: React.FC<
                     variant="plain"
                     onClick={() => setShow2((s) => !s)}
                     aria-label={t('Toggle secret visibility')}
-                    isDisabled={useSameConnection}
+                    isDisabled={useSameConnection || cluster2Exists}
                   />
                 </FlexItem>
               </Flex>
@@ -294,7 +304,10 @@ export const ClusterS3BucketDetailsForm: React.FC<
                 })}
                 onChange={(_, v) => update(2, key, v)}
                 validated={errors2[key] ? 'error' : 'default'}
-                isDisabled={useSameConnection && key !== 's3ProfileName'}
+                isDisabled={
+                  cluster2Exists ||
+                  (useSameConnection && key !== 's3ProfileName')
+                }
                 onBlur={() => handleBlur(2)}
               />
             )}

--- a/packages/mco/components/create-dr-policy/utils/k8s-utils.ts
+++ b/packages/mco/components/create-dr-policy/utils/k8s-utils.ts
@@ -1,5 +1,6 @@
 import {
   BackendType,
+  MAX_ALLOWED_CLUSTERS,
   ODFMCO_OPERATOR_NAMESPACE,
   RBD_IMAGE_FLATTEN_LABEL,
   ReplicationType,
@@ -136,22 +137,13 @@ export const createPolicyPromises = async (
   const peerNames = state.selectedClusters.map(getName);
 
   if (state.replicationBackend === BackendType.DataFoundation) {
-    await prepareOdfPeering(state, mirrorPeers, peerNames);
-    await createDRPolicy(
-      state.policyName,
-      state.replicationType,
-      state.syncIntervalTime,
-      state.enableRBDImageFlatten,
-      peerNames
-    );
-  } else {
-    const created: CreatedResources = {
-      secrets: [],
-      profiles: [],
-      drClusters: [],
-    };
+    let createdMirrorPeer: MirrorPeerKind | undefined;
     try {
-      await prepareThirdPartyPeering(state, selectedDRClusters, created);
+      createdMirrorPeer = await prepareOdfPeering(
+        state,
+        mirrorPeers,
+        peerNames
+      );
       await createDRPolicy(
         state.policyName,
         state.replicationType,
@@ -160,9 +152,48 @@ export const createPolicyPromises = async (
         peerNames
       );
     } catch (error) {
-      // Best-effort rollback of any resources created so far.
-      await rollbackThirdPartyResources(created);
+      if (createdMirrorPeer) {
+        await k8sDelete({
+          model: MirrorPeerModel,
+          resource: createdMirrorPeer,
+        }).catch((e) =>
+          // eslint-disable-next-line no-console
+          console.error('Rollback: failed to delete MirrorPeer', e)
+        );
+      }
       throw error;
+    }
+  } else {
+    const allDRClustersExist =
+      selectedDRClusters?.length === MAX_ALLOWED_CLUSTERS;
+
+    if (allDRClustersExist) {
+      await createDRPolicy(
+        state.policyName,
+        state.replicationType,
+        state.syncIntervalTime,
+        state.enableRBDImageFlatten,
+        peerNames
+      );
+    } else {
+      const created: CreatedResources = {
+        secrets: [],
+        profiles: [],
+        drClusters: [],
+      };
+      try {
+        await prepareThirdPartyPeering(state, selectedDRClusters, created);
+        await createDRPolicy(
+          state.policyName,
+          state.replicationType,
+          state.syncIntervalTime,
+          state.enableRBDImageFlatten,
+          peerNames
+        );
+      } catch (error) {
+        await rollbackThirdPartyResources(created);
+        throw error;
+      }
     }
   }
 };
@@ -171,7 +202,7 @@ const prepareOdfPeering = async (
   state: DRPolicyState,
   mirrorPeers: MirrorPeerKind[],
   peerNames: string[]
-): Promise<void> => {
+): Promise<MirrorPeerKind | undefined> => {
   const odfPeerNames: string[] = state.selectedClusters.map(
     (cluster) => getODFPeers(cluster)[0]
   );
@@ -182,8 +213,9 @@ const prepareOdfPeering = async (
   );
 
   if (!mirrorPeer) {
-    await createMirrorPeer(state.selectedClusters, state.replicationType);
+    return createMirrorPeer(state.selectedClusters, state.replicationType);
   }
+  return undefined;
 };
 
 type CreatedResources = {


### PR DESCRIPTION
## Summary
When creating a new DRPolicy for third-party storage where both DRClusters already exist (e.g. offload policy), the S3 bucket detail fields should be read-only since those details are already configured.

- Disable all S3 bucket detail fields and hide "use same connection" checkbox when `areDRClustersAlreadyCreated` is true
- Skip S3 format validation for the Create button when both DRClusters exist
- Skip `prepareThirdPartyPeering()` on submit to avoid overwriting existing secrets/ConfigMap with empty credentials from pre-fill

Fixes: https://issues.redhat.com/browse/DFBUGS-4146