### PR TITLE
Modify the link of third party storage DR page

### DIFF
--- a/packages/shared/src/constants/doc.ts
+++ b/packages/shared/src/constants/doc.ts
@@ -36,7 +36,7 @@ export const multusSetupDoc = (odfDocVersion: string): string =>
   )}/planning_your_deployment/index#multus-networking-setup_odf`;
 
 export const tpsDoc = (odfDocVersion: string): string =>
-  `${odfDRDocHome(odfDocVersion)}#third-party-storage-prerequisites`;
+  `${odfDRDocHome(odfDocVersion)}#storage-agnostic-disaster-recovery-for-third-party-vendors_common`;
 
 export const externalSystemsDoc = (odfDocVersion: string): string =>
   `${odfDocBasePath(


### PR DESCRIPTION
https://redhat.atlassian.net/browse/DFBUGS-3939

**problem:**  The documentation page for using third party storage is showing 404 error
 **fix:** Remove the documentation page link for using third party storage as per the suggestion in jira https://redhat.atlassian.net/browse/DFBUGS-3939?focusedCommentId=17012944

Hard coded the truth value to display the third party storage card in the below picture
**Before fix:**
<img width="1156" height="900" alt="image" src="https://github.com/user-attachments/assets/4b17a7e3-c756-46b2-8f2a-b62b0d952578" />

**After fix**
<img width="1728" height="1117" alt="3939after" src="https://github.com/user-attachments/assets/230eb278-eeef-48c4-a320-6009e9d6ad67" />