### PR TITLE
[release-4.21-compatibility] DFBUGS-6952: updating on-headers package version in 4.21 compat branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "lodash-es": "4.18.0",
     "minimatch": "3.1.4",
     "node-forge": "1.3.3",
+    "on-headers": "1.1.0",
     "qs": "6.14.1",
     "react-router": "6.30.3",
     "schema-utils@npm:4.3.3/ajv": "8.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9925,7 +9925,7 @@ on-finished@^2.4.1, on-finished@~2.4.1:
   dependencies:
     ee-first "1.1.1"
 
-on-headers@~1.1.0:
+on-headers@1.1.0, on-headers@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.1.0.tgz#59da4f91c45f5f989c6e4bcedc5a3b0aed70ff65"
   integrity sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==


### PR DESCRIPTION
This PR fixes the CVE CVE-2025-7339