### PR TITLE
HealthOverview page should list only firing alerts

### DIFF
--- a/packages/odf/components/HealthOverview/hooks.ts
+++ b/packages/odf/components/HealthOverview/hooks.ts
@@ -310,7 +310,7 @@ export const useHealthAlerts = (): [AlertRowData[], boolean, any] => {
     const escapeRegex = (name: string) =>
       name.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
     const regex = Array.from(allowedAlertNames).map(escapeRegex).join('|');
-    return `ALERTS{alertname=~"${regex}"}`;
+    return `ALERTS{alertname=~"${regex}",alertstate="firing"}`;
   }, [allowedAlertNames]);
 
   const [historicalResponse, historicalError, historicalLoading] =
@@ -327,10 +327,12 @@ export const useHealthAlerts = (): [AlertRowData[], boolean, any] => {
     if (!allowedAlertNames.size) {
       return [];
     }
-    const filteredActiveAlerts = (activeAlerts || []).filter((alert) =>
-      allowedAlertNames.has(
-        alert.labels?.alertname || (alert as any)?.rule?.name
-      )
+    const filteredActiveAlerts = (activeAlerts || []).filter(
+      (alert) =>
+        alert.state === 'firing' &&
+        allowedAlertNames.has(
+          alert.labels?.alertname || (alert as any)?.rule?.name
+        )
     );
     const activeAlertKeys = new Set(
       filteredActiveAlerts.map((alert) =>


### PR DESCRIPTION
In HealthOverview main page, we were listing alerts which were in pending state as well (along with other firing state alerts). This change make sure we list only firing alerts.

BZ: https://redhat.atlassian.net/browse/DFBUGS-6732 (failed QA)