### PR TITLE
DFBUGS-6524: [release-4.18] Include NFS to resource profile calculations

### DIFF
--- a/packages/odf/components/create-storage-system/create-steps.tsx
+++ b/packages/odf/components/create-storage-system/create-steps.tsx
@@ -53,6 +53,7 @@ export const createSteps = (
           nodes={nodes}
           systemNamespace={systemNamespace}
           deploymentMode={backingStorage.deployment}
+          enableNFS={backingStorage.enableNFS}
         />
       ),
     },

--- a/packages/odf/components/create-storage-system/create-storage-system-steps/capacity-and-nodes-step/capacity-and-nodes-step.tsx
+++ b/packages/odf/components/create-storage-system/create-storage-system-steps/capacity-and-nodes-step/capacity-and-nodes-step.tsx
@@ -421,6 +421,7 @@ export const CapacityAndNodes: React.FC<CapacityAndNodesProps> = ({
   nodes,
   systemNamespace,
   deploymentMode,
+  enableNFS,
 }) => {
   const {
     capacity,
@@ -454,7 +455,8 @@ export const CapacityAndNodes: React.FC<CapacityAndNodesProps> = ({
     resourceProfile,
     osdAmount,
     deploymentMode,
-    volumeValidationType
+    volumeValidationType,
+    enableNFS
   );
   const onProfileChange = React.useCallback(
     (profile) => onResourceProfileChange(dispatch)(profile),
@@ -495,6 +497,7 @@ export const CapacityAndNodes: React.FC<CapacityAndNodesProps> = ({
               profileRequirementsText={ProfileRequirementsText}
               selectedNodes={nodes}
               osdAmount={osdAmount}
+              enableNFS={enableNFS}
             />
           )}
           <EnableTaintNodes dispatch={dispatch} enableTaint={enableTaint} />
@@ -509,6 +512,7 @@ export const CapacityAndNodes: React.FC<CapacityAndNodesProps> = ({
             osdAmount={osdAmount}
             key={validation}
             validation={validation}
+            enableNFS={enableNFS}
           />
         ))}
     </Form>
@@ -523,4 +527,5 @@ type CapacityAndNodesProps = {
   dispatch: WizardDispatch;
   systemNamespace: WizardState['backingStorage']['systemNamespace'];
   deploymentMode: DeploymentType;
+  enableNFS: boolean;
 };

--- a/packages/odf/components/create-storage-system/create-storage-system-steps/capacity-and-nodes-step/configure-performance.tsx
+++ b/packages/odf/components/create-storage-system/create-storage-system-steps/capacity-and-nodes-step/configure-performance.tsx
@@ -24,13 +24,19 @@ import { TFunction } from 'i18next';
 import { Text, TextVariants, TextContent } from '@patternfly/react-core';
 import './configure-performance.scss';
 
-const selectOptions = (t: TFunction, forceLean: boolean, osdAmount: number) =>
+const selectOptions = (
+  t: TFunction,
+  forceLean: boolean,
+  osdAmount: number,
+  enableNFS?: boolean
+) =>
   Object.entries(ResourceProfile).map((value: [string, ResourceProfile]) => {
     const displayName = t(`${value[0]} mode`);
     let profile = value[1];
     const { minCpu, minMem } = getResourceProfileRequirements(
       profile,
-      osdAmount
+      osdAmount,
+      enableNFS
     );
     const description = `CPUs required: ${minCpu}, Memory required: ${minMem} GiB`;
     const isDisabled =
@@ -61,14 +67,16 @@ export const PerformanceHeaderText: React.FC = () => {
 type ProfileRequirementsTextProps = {
   selectedProfile: ResourceProfile;
   osdAmount: number;
+  enableNFS?: boolean;
 };
 
 export const ProfileRequirementsText: React.FC<ProfileRequirementsTextProps> =
-  ({ selectedProfile, osdAmount }) => {
+  ({ selectedProfile, osdAmount, enableNFS }) => {
     const { t } = useCustomTranslation();
     const { minCpu, minMem } = getResourceProfileRequirements(
       selectedProfile,
-      osdAmount
+      osdAmount,
+      enableNFS
     );
     return (
       <TextContent>
@@ -111,6 +119,7 @@ type ConfigurePerformanceProps = {
   profileRequirementsText?: React.FC<ProfileRequirementsTextProps>;
   selectedNodes: WizardNodeState[];
   osdAmount?: number;
+  enableNFS?: boolean;
 };
 
 const ConfigurePerformance: React.FC<ConfigurePerformanceProps> = ({
@@ -120,6 +129,7 @@ const ConfigurePerformance: React.FC<ConfigurePerformanceProps> = ({
   profileRequirementsText: ProfileRequirementsTextComponent,
   selectedNodes,
   osdAmount,
+  enableNFS,
 }) => {
   const { t } = useCustomTranslation();
   const [availableNodes, availableNodesLoaded, availableNodesLoadError] =
@@ -138,7 +148,8 @@ const ConfigurePerformance: React.FC<ConfigurePerformanceProps> = ({
         ResourceProfile.Balanced,
         allCpu,
         allMem,
-        osdAmount
+        osdAmount,
+        enableNFS
       )
     ) {
       forceLean = true;
@@ -154,7 +165,8 @@ const ConfigurePerformance: React.FC<ConfigurePerformanceProps> = ({
         resourceProfile,
         getTotalCpu(selectedNodes),
         getTotalMemoryInGiB(selectedNodes),
-        osdAmount
+        osdAmount,
+        enableNFS
       )
     : true;
   const validated =
@@ -178,7 +190,7 @@ const ConfigurePerformance: React.FC<ConfigurePerformanceProps> = ({
         selectedKey={resourceProfile}
         id="resource-profile"
         className="odf-configure-performance__selector pf-v5-u-mb-md"
-        selectOptions={selectOptions(t, forceLean, osdAmount)}
+        selectOptions={selectOptions(t, forceLean, osdAmount, enableNFS)}
         onChange={onResourceProfileChange}
         validated={validated}
       />
@@ -186,6 +198,7 @@ const ConfigurePerformance: React.FC<ConfigurePerformanceProps> = ({
         <ProfileRequirementsTextComponent
           selectedProfile={resourceProfile}
           osdAmount={osdAmount}
+          enableNFS={enableNFS}
         />
       )}
     </div>

--- a/packages/odf/components/create-storage-system/footer.tsx
+++ b/packages/odf/components/create-storage-system/footer.tsx
@@ -124,7 +124,7 @@ const canJumpToNextStep = (
     connectionDetails,
     nodes,
   } = state;
-  const { type, externalStorage, deployment } = backingStorage;
+  const { type, externalStorage, deployment, enableNFS } = backingStorage;
   const isExternal: boolean = type === BackingStorageType.EXTERNAL;
   const isRHCS: boolean = externalStorage === StorageClusterModel.kind;
   const {
@@ -189,7 +189,8 @@ const canJumpToNextStep = (
               resourceProfile,
               getTotalCpu(nodes),
               getTotalMemoryInGiB(nodes),
-              osdAmount
+              osdAmount,
+              enableNFS
             )
           : true)
       );

--- a/packages/odf/components/utils/common-odf-install-el.tsx
+++ b/packages/odf/components/utils/common-odf-install-el.tsx
@@ -30,13 +30,15 @@ export const VALIDATIONS = (
   t: TFunction,
   resourceProfile?: ResourceProfile,
   osdAmount?: number,
-  volumeValidationType?: VolumeTypeValidation
+  volumeValidationType?: VolumeTypeValidation,
+  enableNFS?: boolean
 ): Validation => {
   switch (type) {
     case ValidationType.MINIMAL: {
       const { minCpu, minMem } = getResourceProfileRequirements(
         ResourceProfile.Balanced,
-        osdAmount
+        osdAmount,
+        enableNFS
       );
       return {
         variant: AlertVariant.warning,
@@ -205,6 +207,7 @@ export const ValidationMessage: React.FC<ValidationMessageProps> = ({
   volumeValidationType,
   validation,
   osdAmount,
+  enableNFS,
 }) => {
   const { t } = useCustomTranslation();
   const {
@@ -220,7 +223,8 @@ export const ValidationMessage: React.FC<ValidationMessageProps> = ({
     t,
     resourceProfile,
     osdAmount,
-    volumeValidationType
+    volumeValidationType,
+    enableNFS
   );
   return actionLinkStep ? (
     <Alert
@@ -249,6 +253,7 @@ type ValidationMessageProps = {
   validation: keyof typeof ValidationType;
   osdAmount?: number;
   volumeValidationType?: VolumeTypeValidation;
+  enableNFS?: boolean;
 };
 
 export const getEncryptionLevel = (obj: EncryptionType, t: TFunction) => {

--- a/packages/odf/components/utils/common.ts
+++ b/packages/odf/components/utils/common.ts
@@ -148,7 +148,8 @@ export const capacityAndNodesValidate = (
   resourceProfile: ResourceProfile,
   osdAmount: number,
   deploymentType: DeploymentType,
-  volumeValidationType: VolumeTypeValidation
+  volumeValidationType: VolumeTypeValidation,
+  enableNFS?: boolean
 ): ValidationType[] => {
   const validations = [];
 
@@ -170,7 +171,8 @@ export const capacityAndNodesValidate = (
         resourceProfile,
         totalCpu,
         totalMemory,
-        osdAmount
+        osdAmount,
+        enableNFS
       )
     ) {
       validations.push(ValidationType.RESOURCE_PROFILE);
@@ -180,7 +182,8 @@ export const capacityAndNodesValidate = (
         ResourceProfile.Balanced,
         totalCpu,
         totalMemory,
-        osdAmount
+        osdAmount,
+        enableNFS
       )
     ) {
       validations.push(ValidationType.MINIMAL);

--- a/packages/odf/constants/common.ts
+++ b/packages/odf/constants/common.ts
@@ -57,6 +57,14 @@ export const RESOURCE_PROFILE_REQUIREMENTS_MAP: ResourceProfileRequirementsMap =
     },
   };
 
+/**
+ * NFS resource requirements to be added when NFS is enabled
+ */
+export const NFS_RESOURCE_REQUIREMENTS = {
+  minCpu: 6,
+  minMem: 16, // GiB
+};
+
 export enum DefaultRequestSize {
   BAREMETAL = '1',
   NON_BAREMETAL = '2Ti',

--- a/packages/odf/modals/configure-performance/configure-performance-modal.tsx
+++ b/packages/odf/modals/configure-performance/configure-performance-modal.tsx
@@ -43,7 +43,8 @@ import './configure-performance-modal.scss';
 const getValidation = (
   profile: ResourceProfile,
   nodes: WizardNodeState[],
-  osdAmount: number
+  osdAmount: number,
+  enableNFS?: boolean
 ): ValidationType => {
   if (!profile) {
     return null;
@@ -53,7 +54,8 @@ const getValidation = (
     profile,
     getTotalCpu(nodes),
     getTotalMemoryInGiB(nodes),
-    osdAmount
+    osdAmount,
+    enableNFS
   )
     ? null
     : ValidationType.RESOURCE_PROFILE;
@@ -62,14 +64,16 @@ const getValidation = (
 type ProfileRequirementsModalTextProps = {
   selectedProfile: ResourceProfile;
   osdAmount: number;
+  enableNFS?: boolean;
 };
 
 const ProfileRequirementsModalText: React.FC<ProfileRequirementsModalTextProps> =
-  ({ selectedProfile, osdAmount }) => {
+  ({ selectedProfile, osdAmount, enableNFS }) => {
     const { t } = useCustomTranslation();
     const { minCpu, minMem } = getResourceProfileRequirements(
       selectedProfile,
-      osdAmount
+      osdAmount,
+      enableNFS
     );
     return (
       <TextContent>
@@ -125,20 +129,25 @@ const ConfigurePerformanceModal: React.FC<ConfigurePerformanceModalProps> = ({
     )
     .reduce((accumulator: number, current: number) => accumulator + current);
 
+  const enableNFS = storageCluster?.spec?.nfs?.enable || false;
   const onProfileChange = React.useCallback(
     (newProfile: ResourceProfile): void => {
       setResourceProfile(newProfile);
-      setValidation(getValidation(newProfile, selectedNodes, osdAmount));
+      setValidation(
+        getValidation(newProfile, selectedNodes, osdAmount, enableNFS)
+      );
     },
-    [selectedNodes, osdAmount]
+    [selectedNodes, osdAmount, enableNFS]
   );
   const onRowSelected = React.useCallback(
     (newNodes: NodeData[]) => {
       const nodes = createWizardNodeState(newNodes);
       setSelectedNodes(nodes);
-      setValidation(getValidation(resourceProfile, nodes, osdAmount));
+      setValidation(
+        getValidation(resourceProfile, nodes, osdAmount, enableNFS)
+      );
     },
-    [resourceProfile, osdAmount]
+    [resourceProfile, osdAmount, enableNFS]
   );
 
   const submit = async (event: React.FormEvent<EventTarget>): Promise<void> => {
@@ -189,6 +198,7 @@ const ConfigurePerformanceModal: React.FC<ConfigurePerformanceModalProps> = ({
           profileRequirementsText={ProfileRequirementsModalText}
           selectedNodes={selectedNodes}
           osdAmount={osdAmount}
+          enableNFS={enableNFS}
         />
         <SelectNodesTable
           nodes={selectedNodes}
@@ -203,6 +213,7 @@ const ConfigurePerformanceModal: React.FC<ConfigurePerformanceModalProps> = ({
             key={validation}
             validation={validation}
             className="pf-v5-u-mt-md"
+            enableNFS={enableNFS}
           />
         )}
         {errorMessage && (

--- a/packages/odf/utils/ocs.ts
+++ b/packages/odf/utils/ocs.ts
@@ -24,6 +24,7 @@ import {
   HOSTNAME_LABEL_KEY,
   LABEL_OPERATOR,
   MINIMUM_NODES,
+  NFS_RESOURCE_REQUIREMENTS,
   ocsTaint,
   RESOURCE_PROFILE_REQUIREMENTS_MAP,
   OCS_PROVISIONERS,
@@ -118,7 +119,8 @@ export const isFlexibleScaling = (
  */
 export const getResourceProfileRequirements = (
   profile: ResourceProfile,
-  osdAmount: number
+  osdAmount: number,
+  enableNFS?: boolean
 ): { minCpu: number; minMem: number } => {
   const { minCpu, minMem, osd } = RESOURCE_PROFILE_REQUIREMENTS_MAP[profile];
   const extraOsds = osdAmount - 3;
@@ -128,6 +130,10 @@ export const getResourceProfileRequirements = (
     cpu += Math.ceil(extraOsds * osd.cpu);
     mem += Math.ceil(extraOsds * osd.mem);
   }
+  if (enableNFS) {
+    cpu += NFS_RESOURCE_REQUIREMENTS.minCpu;
+    mem += NFS_RESOURCE_REQUIREMENTS.minMem;
+  }
   return { minCpu: cpu, minMem: mem };
 };
 
@@ -136,16 +142,22 @@ export const getResourceProfileRequirements = (
  * @param profile A resource profile.
  * @param cpu The amount CPUs.
  * @param memory The amount of selected nodes' memory in GiB.
- * @param memory The amount of OSD pods.
+ * @param osdAmount The amount of OSD pods.
+ * @param enableNFS Whether NFS is enabled.
  * @returns boolean
  */
 export const isResourceProfileAllowed = (
   profile: ResourceProfile,
   cpu: number,
   memory: number,
-  osdAmount: number
+  osdAmount: number,
+  enableNFS?: boolean
 ): boolean => {
-  const { minCpu, minMem } = getResourceProfileRequirements(profile, osdAmount);
+  const { minCpu, minMem } = getResourceProfileRequirements(
+    profile,
+    osdAmount,
+    enableNFS
+  );
 
   return cpu >= minCpu && memory >= minMem;
 };


### PR DESCRIPTION
https://redhat.atlassian.net/browse/DFBUGS-6524

before
<img width="1722" height="956" alt="Screenshot 2026-06-19 at 13 07 29" src="https://github.com/user-attachments/assets/996bace9-5fa1-4372-9a92-b89ca36f6cf5" />

after enableNFS
<img width="1726" height="963" alt="Screenshot 2026-06-19 at 13 07 40" src="https://github.com/user-attachments/assets/3ba448fb-f954-424f-9f88-36db9bb8624c" />

<img width="1725" height="966" alt="Screenshot 2026-06-19 at 13 07 50" src="https://github.com/user-attachments/assets/0b961d84-c1de-4db8-bb74-dec5b5da012a" />

before nfs
<img width="1728" height="952" alt="Screenshot 2026-06-19 at 13 22 38" src="https://github.com/user-attachments/assets/8f069919-bbdc-4334-bd07-b502af8b69b9" />

after nfs
<img width="1721" height="960" alt="Screenshot 2026-06-19 at 13 23 46" src="https://github.com/user-attachments/assets/9f859d11-3ea1-42bf-a398-c403d5485706" />
