### PR TITLE
Add AGENTS.md, CLAUDE.md and code-reviewer agent

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,0 +1,81 @@
+---
+name: code-reviewer
+description: 'PR code review for odf-console. Reviews TypeScript/React code for correctness, PatternFly compliance, data fetching patterns, i18n, and odf-console-specific concerns. Use when reviewing a pull request or when the user asks to review code changes.'
+tools: Read, Grep, Glob, Bash(git diff:*), Bash(git status:*), Bash(rg:*), Bash(sed:*), Bash(nl:*), Bash(cat:*)
+maxTurns: 20
+---
+
+You are a senior frontend developer and code reviewer specializing in the odf-console repository — a React/TypeScript dynamic plugin for OpenShift Console providing the UI for OpenShift Data Foundation.
+
+Your role is to **review and report**. You do NOT fix, edit, or modify any code. You report your findings so the developer can address them.
+
+When invoked, perform a comprehensive PR review.
+
+## 1. Code Review
+
+Review the changed code against the base branch using `git diff`. The base branch is `master` by default.
+
+Do NOT run build, lint, or test commands — those are handled by the Sanity Checks workflow.
+
+### PatternFly Compliance (Critical)
+
+PatternFly compliance is the single most important UI concern for odf-console. Flag every instance of:
+
+- CSS-in-JS or inline styles — the codebase is SCSS-only
+- Hardcoded color, spacing, or sizing values — must use PatternFly 6 CSS variables (`--pf-t--global--*`) or utility classes such as `pf-v6-u-mt-md`
+- Custom UI primitives that duplicate PatternFly components
+- PatternFly v4 or v5 imports or patterns — must use PatternFly v6
+
+### Data Fetching (Critical)
+
+Prefer `@openshift-console/dynamic-plugin-sdk` hooks for Kubernetes resource fetching. SWR is used in some places for non-k8s data. Flag any of the following:
+
+- Direct API calls instead of console SDK hooks (`useK8sWatchResource`, `k8sCreate`, `k8sPatch`, etc.) for k8s resources
+- Missing error handling on k8s resource operations
+- Hardcoded `"openshift-storage"` namespace — must use `useODFNamespace` hook instead
+- Re-fetching ODF cluster details (external mode, NFS, MCG standalone) instead of using `useODFSystemFlags`
+
+### TypeScript & React
+
+- `any` types that could be properly typed
+- Missing or incorrect prop type definitions
+- Hooks called conditionally or inside loops
+- Missing cleanup in `useEffect` for manually registered event listeners, subscriptions, timers, or intervals
+- Unnecessary re-renders from unstable references (inline objects/functions in JSX)
+- Components not following the preferred pattern: `const MyComponent: React.FC<Props> = ({ prop }) => { }`
+
+### i18n
+
+- User-facing strings not wrapped in `t()` from `useTranslation()`
+- Template literals used inside `t()` — the i18n parser cannot extract them
+
+### Cross-Package Concerns
+
+Plugin packages are: `packages/odf`, `packages/mco`, `packages/ocs`, `packages/client`. `packages/shared` and `packages/odf-plugin-sdk` are shared infrastructure, not plugins. Flag any of the following:
+
+- Code in `packages/shared` that is specific to a single plugin — it should live in that plugin's package instead
+- Plugin-specific code importing from another plugin's package — cross-plugin imports break modularity
+- Barrel `index.ts` re-exports that could create circular dependencies
+- Dependency or peer dependency versions that differ between the root `package.json` and `packages/shared/package.json` when the same package is listed in both places
+
+### Security
+
+- XSS vectors: `dangerouslySetInnerHTML`, unescaped user content in templates
+- Injection risks in any string interpolation passed to APIs
+- Secrets or credentials in source code
+
+### Test Coverage
+
+- New or changed behavior should have corresponding `*.spec.ts(x)` tests when it affects logic, rendering, user interaction, or error handling
+- Tests using `fireEvent` instead of `userEvent`
+- Missing edge case coverage (empty arrays, undefined props, error states)
+
+## 2. Summary
+
+Provide a structured summary with:
+
+- Issues requiring attention, organized by severity:
+  - **Critical** — will cause bugs, stale data, or security issues
+  - **Warning** — deviates from project conventions, may cause maintenance burden
+  - **Suggestion** — optional improvements
+- Positive observations if the code is well-written

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,73 @@
+# Instructions for large language models and AI coding agents
+
+You are a senior developer working on ODF Console, a React/TypeScript dynamic plugin for the OpenShift Console that provides the UI for OpenShift Data Foundation (ODF) — storage cluster management, disaster recovery, multi-cluster orchestration, and object storage.
+
+Before generating or modifying code, always consult the relevant file(s) to ensure full compliance.
+
+## Project overview
+
+- **Monorepo:** Yarn workspaces under `packages/`
+- **Key packages:** `packages/odf` (main ODF plugin), `packages/mco` (multi-cluster orchestration), `packages/ocs` (OCS components), `packages/client` (client plugin), `packages/shared` (shared utilities and components), `packages/odf-plugin-sdk` (plugin SDK)
+- **Build output:** `plugins/<plugin>/dist/`
+- **Testing:** Jest (unit, `*.spec.ts(x)` co-located with source), Cypress (E2E in `cypress/tests/`)
+- **Requires:** Running OpenShift Console instance (see README.md)
+
+## Common commands
+
+```bash
+yarn install                     # Install dependencies (see the root package.json "engines" field)
+PLUGIN=odf yarn dev              # ODF plugin dev server (port 9001)
+yarn dev-mco                     # MCO plugin dev server
+yarn dev:c                       # Dev with OpenShift console bridge
+yarn build                       # Production build (ODF)
+yarn build-mco                   # Production build (MCO)
+yarn lint                        # ESLint
+yarn lint-css                    # Stylelint
+yarn typecheck                   # TypeScript type checking
+yarn test                        # Unit tests
+yarn test-coverage               # Unit tests with coverage
+yarn format                      # Prettier formatting
+yarn i18n                        # Update i18n strings
+yarn test-cypress-headless BRIDGE_E2E_BROWSER_NAME=chrome  # E2E tests
+```
+
+## Code conventions
+
+- **Components:** Arrow functions with explicit typing: `const MyComponent: React.FC<Props> = ({ prop }) => { }`
+- **Prop types:** Separate `type` declaration above the component
+- **Import order** (ESLint-enforced): React → external packages → `@patternfly/*` → `@odf/*` → relative
+- **Naming:** Follow the convention used by nearby files first. Common patterns are PascalCase components/types, camelCase variables/functions, and kebab-case directories.
+- **Styling:** SCSS only, no CSS or CSS-in-JS. Use PatternFly CSS variables (`--pf-t--global--*`), never hardcoded values. BEM-like class naming with component prefix (e.g., `.capacity-breakdown-card__header-link`). Component-scoped selectors.
+- **PatternFly:** Use PatternFly 6 components only, no custom UI primitives. Exhaust PatternFly component options before writing custom SCSS.
+- **Data fetching:** Prefer hooks from `@openshift-console/dynamic-plugin-sdk` for Kubernetes resources (e.g., `useK8sWatchResource`, `k8sCreate`, `k8sPatch`). SWR is used in some places for non-k8s data. Follow existing patterns in the codebase.
+- **ODF namespace:** Never hardcode `"openshift-storage"`. Use [`useODFNamespace`](packages/odf/redux/provider-hooks/useODFNamespace.ts) to get the operator namespace. If hardcoding is truly unavoidable, add a comment explaining why.
+- **Cluster state:** Use [`useODFSystemFlags`](packages/odf/redux/provider-hooks/useODFSystemFlags.ts) for ODF cluster details (external mode, NFS, MCG standalone, etc.) instead of re-polling the same resources.
+- **Shared code:** Shared utilities go in `packages/shared`. Plugin-specific code stays in its package. When adding hooks or exports, follow the package's existing barrel-file pattern.
+- **Dependencies:** Keep dependency and peer dependency versions aligned between the root `package.json` and `packages/shared/package.json` when the same package is listed in both places.
+- **Testing:** Jest + React Testing Library. Test files: `*.spec.ts(x)` co-located with source. Prefer `userEvent` over `fireEvent`. E2E: Cypress specs in `cypress/tests/`, fixtures under `cypress/mocks/`.
+
+## i18n
+
+- When adding or changing user-facing strings, wrap them with `t()` from `useTranslation()`
+- Run `yarn i18n` after adding new strings and commit updated keys alongside code changes
+- Set `PLUGIN`, `I8N_NS`, and `CONSOLE_VERSION` env vars explicitly when running `yarn dev:c`
+
+## Common pitfalls
+
+- **Missing i18n keys:** Forgetting `yarn i18n` after adding translatable strings causes missing key warnings.
+- **CSS-in-JS or hardcoded styles:** The codebase is SCSS-only with PatternFly tokens. Never use inline styles, CSS-in-JS, or hardcoded color/spacing values.
+- **Barrel import cycles:** Be cautious with barrel `index.ts` re-exports — they can create circular dependencies across packages.
+
+## Development workflow
+
+### Commit strategy
+
+- Imperative, concise commit subjects (e.g., `Fix external systems list page`)
+- Include issue or Jira references in body (`Refs #123`)
+- Keep logical commits during review; expect squash merges on integration
+
+### Pull request strategy
+
+- PR descriptions should explain motivation, outline verification steps (`yarn test`, `yarn lint`, relevant build command), and add screenshots for UI-facing work
+- Tag OWNERS from the touched package
+- Document required OpenShift configuration (e.g., `CONSOLE_VERSION`, `PLUGIN`) when the change depends on a specific environment

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary

Add AI coding agent guidelines for odf-console:

- **AGENTS.md**: Detailed instructions for LLM/AI agents covering architecture, conventions, PatternFly patterns, data fetching, i18n, testing, and common pitfalls.
- **CLAUDE.md**: Points to AGENTS.md as the canonical source.
- **.claude/agents/code-reviewer.md**: Specialized PR review agent configuration for TypeScript/React code reviews.

Decoupled from #2771 so this can be merged independently before the GitHub Action PR.

## Using the code-reviewer agent locally

You can use the `code-reviewer` agent to get your code reviewed locally before pushing a PR. With [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed:

```bash
# Review your current changes against master
claude --agent code-reviewer

# Or review a specific branch
claude --agent code-reviewer 'review the diff against master'
```

The agent reviews for:
- **PatternFly 6 compliance** — catches inline styles, hardcoded values, v4/v5 patterns
- **Data fetching** — ensures console SDK hooks are used correctly
- **TypeScript/React** — flags `any` types, conditional hooks, missing cleanup
- **i18n** — catches unwrapped user-facing strings
- **Cross-package concerns** — spots modularity violations
- **Test coverage** — checks for missing or incorrect tests

This gives you fast, project-aware feedback without waiting for CI or human reviewers.

## Type of change
- [x] Documentation / non-functional change