### PR TITLE
Fix topology view showing "Unknown" DR status during relocate after failover

### DIFF
--- a/packages/mco/components/dr-status-popover/dr-status-popover.spec.tsx
+++ b/packages/mco/components/dr-status-popover/dr-status-popover.spec.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import React from 'react';
 import { describe, expect, it } from '@jest/globals';
-import { VolumeReplicationHealth } from '@odf/mco/constants';
+import { DRActionType, VolumeReplicationHealth } from '@odf/mco/constants';
 import { DRPlacementControlConditionReason, Phase } from '@odf/mco/types';
 import { K8sResourceConditionStatus } from '@odf/shared/types';
 import { render, screen } from '@testing-library/react';
@@ -856,6 +856,42 @@ describe('DRStatusPopover Component', () => {
             status: K8sResourceConditionStatus.False,
             reason: DRPlacementControlConditionReason.Error,
           },
+        },
+      },
+      {
+        label: 'Initiating with action=Relocate -> Relocating',
+        expectedStatus: 'Relocating',
+        overrides: {
+          phase: Phase.Initiating,
+          progression: 'Initial',
+          action: DRActionType.RELOCATE,
+        },
+      },
+      {
+        label: 'Initiating with action=Failover -> FailingOver',
+        expectedStatus: 'FailingOver',
+        overrides: {
+          phase: Phase.Initiating,
+          progression: 'Initial',
+          action: DRActionType.FAILOVER,
+        },
+      },
+      {
+        label: 'Deploying with action=Relocate -> Relocating',
+        expectedStatus: 'Relocating',
+        overrides: {
+          phase: Phase.Deploying,
+          progression: 'Deploying',
+          action: DRActionType.RELOCATE,
+        },
+      },
+      {
+        label: 'Deploying with action=Failover -> FailingOver',
+        expectedStatus: 'FailingOver',
+        overrides: {
+          phase: Phase.Deploying,
+          progression: 'Deploying',
+          action: DRActionType.FAILOVER,
         },
       },
       {

--- a/packages/mco/components/dr-status-popover/dr-status-popover.tsx
+++ b/packages/mco/components/dr-status-popover/dr-status-popover.tsx
@@ -388,6 +388,7 @@ type GetDRStatusDetailsParams = {
   availableCondition?: K8sResourceCondition;
   schedulingInterval?: string;
   actionStartTime?: string;
+  action?: DRActionType;
 };
 
 const getDRStatusDetails = ({
@@ -404,6 +405,7 @@ const getDRStatusDetails = ({
   availableCondition,
   schedulingInterval,
   actionStartTime,
+  action,
 }: GetDRStatusDetailsParams): StatusContent => {
   const drStatus = getDRStatus({
     isCleanupRequired,
@@ -415,6 +417,7 @@ const getDRStatusDetails = ({
     protectedCondition,
     schedulingInterval,
     actionStartTime,
+    action,
   });
 
   switch (drStatus) {
@@ -733,6 +736,7 @@ const DRStatusPopover: React.FC<DRStatusPopoverProps> = ({
         availableCondition: disasterRecoveryStatus.availableCondition,
         schedulingInterval: disasterRecoveryStatus.schedulingInterval,
         actionStartTime: disasterRecoveryStatus.actionStartTime,
+        action: disasterRecoveryStatus.action,
       }),
     [disasterRecoveryStatus, t]
   );

--- a/packages/mco/components/topology/factory/MCOFailoverNode.tsx
+++ b/packages/mco/components/topology/factory/MCOFailoverNode.tsx
@@ -15,11 +15,8 @@ import {
   ScaleDetailsLevel,
   WithSelectionProps,
 } from '@patternfly/react-topology';
-import { DRPlacementControlConditionType } from '../../../types';
-import {
-  getEffectiveDRStatus,
-  isUserActionRequired,
-} from '../../../utils/dr-status';
+import { getProtectedCondition } from '../../../utils';
+import { getDRStatus, isUserActionRequired } from '../../../utils/dr-status';
 import { FailoverNodeData } from '../types';
 import { getDRNodeStatus } from '../utils/sidebar-utils';
 import '../utils/decorator-utils.scss';
@@ -43,17 +40,14 @@ const getFailoverNodeStatus = (data: FailoverNodeData): NodeStatus => {
   let allSuccess = true;
 
   for (const op of operations) {
-    const protectedCondition = op.drpc?.status?.conditions?.find(
-      (c) => c.type === DRPlacementControlConditionType.Protected
-    );
-    const volumeLastGroupSyncTime = op.drpc?.status?.lastGroupSyncTime;
-    const effectiveStatus = getEffectiveDRStatus(
-      op.phase,
-      op.progression,
-      op.hasProtectionError,
+    const protectedCondition = getProtectedCondition(op.drpc);
+    const effectiveStatus = getDRStatus({
+      phase: op.phase,
+      progression: op.progression,
       protectedCondition,
-      volumeLastGroupSyncTime
-    );
+      volumeLastGroupSyncTime: op.drpc?.status?.lastGroupSyncTime,
+      action: op.action,
+    });
     const nodeStatus = getDRNodeStatus(effectiveStatus);
 
     // Priority: danger > info > success
@@ -122,18 +116,15 @@ const MCOFailoverNodeComponent: React.FC<MCOFailoverNodeProps> = ({
   const nodeStatus = getFailoverNodeStatus(data);
   const action = data.action || 'Failover';
   const needsUserAction = operations.some((op) => {
-    const protectedCondition = op.drpc?.status?.conditions?.find(
-      (c) => c.type === DRPlacementControlConditionType.Protected
-    );
-    const volumeLastGroupSyncTime = op.drpc?.status?.lastGroupSyncTime;
+    const protectedCondition = getProtectedCondition(op.drpc);
     return isUserActionRequired(
-      getEffectiveDRStatus(
-        op.phase,
-        op.progression,
-        op.hasProtectionError,
+      getDRStatus({
+        phase: op.phase,
+        progression: op.progression,
         protectedCondition,
-        volumeLastGroupSyncTime
-      )
+        volumeLastGroupSyncTime: op.drpc?.status?.lastGroupSyncTime,
+        action: op.action,
+      })
     );
   });
   const label = needsUserAction ? 'Action required' : action;

--- a/packages/mco/components/topology/factory/MCOStyleAppNode.tsx
+++ b/packages/mco/components/topology/factory/MCOStyleAppNode.tsx
@@ -14,7 +14,6 @@ import {
   ScaleDetailsLevel,
   WithSelectionProps,
 } from '@patternfly/react-topology';
-import { getEffectiveDRStatus } from '../../../utils/dr-status';
 import { AppNodeData } from '../types';
 import { renderDecorators } from '../utils/decorator-utils';
 import { getDRNodeStatus } from '../utils/sidebar-utils';
@@ -69,12 +68,8 @@ const MCOStyleAppNodeComponent: React.FC<MCOStyleAppNodeProps> = ({
 
   const showLabel = rest.hover || detailsLevel !== ScaleDetailsLevel.low;
 
-  // For static apps, appStatus is already a computed DRStatus - use it directly
-  // For operation nodes, compute from phase/progression
-  const effectiveStatus =
-    data.isStatic && data.appStatus
-      ? data.appStatus
-      : getEffectiveDRStatus(data?.phase, data?.progression);
+  // appStatus is pre-computed by the node-generator (for both static and operation nodes)
+  const effectiveStatus = data.appStatus;
   const nodeStatus = getDRNodeStatus(effectiveStatus);
   const isOperation = !data?.isStatic && data?.isSource !== undefined;
   const animationClass = isOperation

--- a/packages/mco/components/topology/sidebar/AppSidebar.tsx
+++ b/packages/mco/components/topology/sidebar/AppSidebar.tsx
@@ -9,8 +9,8 @@ import {
   EmptyStateBody,
 } from '@patternfly/react-core';
 import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
-import { DRPlacementControlConditionType } from '../../../types';
-import { getEffectiveDRStatus } from '../../../utils/dr-status';
+import { getProtectedCondition } from '../../../utils';
+import { getDRStatus } from '../../../utils/dr-status';
 import { getPAVDRPolicyName } from '../../../utils/pav';
 import {
   AppSidebarItem,
@@ -138,20 +138,17 @@ export const AppSidebar: React.FC<AppSidebarProps> = ({ edgeData }) => {
     operationData.operations ||
     (operationData.operation ? [operationData.operation] : []);
   const appsFromOperations = operations.map((op) => {
-    const protectedCondition = op.drpc?.status?.conditions?.find(
-      (c) => c.type === DRPlacementControlConditionType.Protected
-    );
-    const volumeLastGroupSyncTime = op.drpc?.status?.lastGroupSyncTime;
+    const protectedCondition = getProtectedCondition(op.drpc);
     return {
       name: op.applicationName,
       namespace: op.applicationNamespace,
-      status: getEffectiveDRStatus(
-        op.phase,
-        op.progression,
-        op.hasProtectionError,
+      status: getDRStatus({
+        phase: op.phase,
+        progression: op.progression,
         protectedCondition,
-        volumeLastGroupSyncTime
-      ),
+        volumeLastGroupSyncTime: op.drpc?.status?.lastGroupSyncTime,
+        action: op.action,
+      }),
       drPolicy: op.pav ? getPAVDRPolicyName(op.pav) : '',
     };
   });

--- a/packages/mco/components/topology/sidebar/OperationSidebar.tsx
+++ b/packages/mco/components/topology/sidebar/OperationSidebar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getEffectiveDRStatus } from '@odf/mco/utils/dr-status';
+import { getDRStatus } from '@odf/mco/utils/dr-status';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import {
@@ -23,7 +23,11 @@ import { DRPCFilterToolbar } from './DRPCFilterToolbar';
 import './TopologySidebar.scss';
 
 const getOperationStatus = (op: DROperationInfo) =>
-  getEffectiveDRStatus(op.phase, op.progression, op.hasProtectionError);
+  getDRStatus({
+    phase: op.phase,
+    progression: op.progression,
+    action: op.action,
+  });
 
 type OperationSidebarProps = {
   edgeData: OperationEdgeSidebarData;

--- a/packages/mco/components/topology/utils/decorator-helpers.ts
+++ b/packages/mco/components/topology/utils/decorator-helpers.ts
@@ -21,8 +21,6 @@ export const getDecoratorForStatus = (
     case DRStatus.Unknown:
     case DRStatus.WaitOnUserToCleanUp:
     case DRStatus.WaitForUser:
-    case Progression.FailedToFailover:
-    case Progression.FailedToRelocate:
     case Progression.WaitForUserAction:
       icon = DecoratorIcon.ExclamationCircle;
       tooltip =

--- a/packages/mco/components/topology/utils/node-generator.ts
+++ b/packages/mco/components/topology/utils/node-generator.ts
@@ -87,6 +87,7 @@ const computeOperationDRStatus = (
     protectedCondition,
     schedulingInterval,
     actionStartTime: drpc?.status?.actionStartTime,
+    action: drpc?.spec?.action,
   });
 };
 
@@ -138,6 +139,7 @@ const createGroupedOperationNodes = (
       clusterName,
       isGrouped: count > 1,
       appCount: count,
+      appStatus: effectiveStatus,
       action,
       phase,
       progression,

--- a/packages/mco/hooks/useProtectedAppsByCluster.ts
+++ b/packages/mco/hooks/useProtectedAppsByCluster.ts
@@ -117,6 +117,7 @@ export const useProtectedAppsByCluster = (): [
           protectedCondition,
           schedulingInterval,
           actionStartTime: drpc?.status?.actionStartTime,
+          action: drpc?.spec?.action,
         });
 
         // Get the list of clusters this app is deployed to

--- a/packages/mco/types/ramen.ts
+++ b/packages/mco/types/ramen.ts
@@ -145,10 +145,8 @@ export enum Progression {
   FailingOver = 'FailingOver',
   Relocating = 'Relocating',
   FailedOver = 'FailedOver',
-  FailedToFailover = 'FailedToFailover',
   WaitOnUserToCleanUp = 'WaitOnUserToCleanUp',
   CleaningUp = 'CleaningUp',
-  FailedToRelocate = 'FailedToRelocate',
   WaitForUserAction = 'WaitForUserAction',
 }
 
@@ -160,9 +158,7 @@ export enum Phase {
   FailingOver = 'FailingOver',
   Relocating = 'Relocating',
   FailedOver = 'FailedOver',
-  FailedToFailover = 'FailedToFailover',
   Relocated = 'Relocated',
-  FailedToRelocate = 'FailedToRelocate',
   Deleting = 'Deleting',
   WaitForUser = 'WaitForUser',
 }
@@ -178,6 +174,7 @@ export enum DRPlacementControlConditionReason {
   Progressing = 'Progressing',
   Error = 'Error',
   Unknown = 'Unknown',
+  Success = 'Success',
 }
 
 // VRG condition reasons (for resourceConditions)

--- a/packages/mco/utils/dr-status.ts
+++ b/packages/mco/utils/dr-status.ts
@@ -6,6 +6,7 @@ import {
 import {
   VolumeReplicationHealth,
   DRProtectionStatus,
+  DRActionType,
   THRESHOLD,
 } from '../constants';
 import {
@@ -177,19 +178,24 @@ export const getDRStatus = ({
   protectedCondition,
   schedulingInterval,
   actionStartTime,
+  action,
 }: {
-  isCleanupRequired: boolean;
+  isCleanupRequired?: boolean;
   phase: Phase;
-  volumeReplicationHealth: VolumeReplicationHealth;
+  volumeReplicationHealth?: VolumeReplicationHealth;
   kubeObjectReplicationHealth?: VolumeReplicationHealth;
   progression?: string;
   volumeLastGroupSyncTime?: string;
   protectedCondition?: K8sResourceCondition;
   schedulingInterval?: string;
   actionStartTime?: string;
+  action?: DRActionType;
 }): DRStatus => {
-  // Check if cleanup is required — this has the highest priority
-  if (isCleanupRequired) return DRStatus.WaitOnUserToCleanUp;
+  // Check if cleanup is required — this has the highest priority.
+  // If not explicitly provided, derive from progression.
+  const cleanupRequired =
+    isCleanupRequired ?? progression === Progression.WaitOnUserToCleanUp;
+  if (cleanupRequired) return DRStatus.WaitOnUserToCleanUp;
 
   // WaitForUser is always treated as action required
   if (phase === Phase.WaitForUser) return DRStatus.WaitForUser;
@@ -201,9 +207,16 @@ export const getDRStatus = ({
   if (phase === Phase.FailingOver) return DRStatus.FailingOver;
   if (phase === Phase.Relocating) return DRStatus.Relocating;
 
+  // Map transitional phases to action-specific status when action is known.
+  // During initial enrollment (no action), fall through to Protecting/health logic.
+  if ((phase === Phase.Initiating || phase === Phase.Deploying) && action) {
+    if (action === DRActionType.FAILOVER) return DRStatus.FailingOver;
+    if (action === DRActionType.RELOCATE) return DRStatus.Relocating;
+  }
+
   // Combine health statuses into an array for easier checks (filter out undefined)
-  const replicationHealths = [
-    volumeReplicationHealth,
+  const replicationHealths: VolumeReplicationHealth[] = [
+    ...(volumeReplicationHealth ? [volumeReplicationHealth] : []),
     ...(kubeObjectReplicationHealth ? [kubeObjectReplicationHealth] : []),
   ];
   const isProgressionCompleted = !isProgressionActive(progression);
@@ -238,7 +251,7 @@ export const getDRStatus = ({
   }
 
   const shouldProtect = shouldShowProtecting(
-    isCleanupRequired,
+    cleanupRequired,
     phase,
     protectedCondition,
     volumeLastGroupSyncTime,
@@ -276,85 +289,11 @@ export const getDRStatus = ({
   if (replicationHealths.includes(VolumeReplicationHealth.HEALTHY))
     return DRStatus.Healthy;
 
+  // No health data available — cannot determine status
+  if (replicationHealths.length === 0) return DRStatus.Unknown;
+
   // Fallback — assume Critical if no health statuses matched
   return DRStatus.Critical;
-};
-
-/**
- * Simplified DR status for topology view.
- * Returns effective status based on phase, progression, and protection state.
- * Enhanced to detect "Protecting" status without requiring volume health data.
- */
-export const getEffectiveDRStatus = (
-  phase?: string,
-  progression?: string,
-  hasProtectionError?: boolean,
-  protectedCondition?: K8sResourceCondition,
-  volumeLastGroupSyncTime?: string
-): DRStatus => {
-  if (progression === Progression.WaitOnUserToCleanUp) {
-    return DRStatus.WaitOnUserToCleanUp;
-  }
-
-  if (progression === Progression.WaitForUserAction) {
-    return DRStatus.WaitForUser;
-  }
-
-  if (progression === Progression.CleaningUp && phase !== Phase.Deployed) {
-    return DRStatus.Deleting;
-  }
-
-  if (
-    progression === Progression.FailedToFailover ||
-    progression === Progression.FailedToRelocate
-  ) {
-    return DRStatus.Critical;
-  }
-
-  if (hasProtectionError) {
-    return DRStatus.ProtectionError;
-  }
-
-  // Check if protection is in progress (before sync has started)
-  // This detects the initial protection setup phase
-  if (
-    phase === Phase.Deployed &&
-    protectedCondition &&
-    !volumeLastGroupSyncTime
-  ) {
-    const { status, reason } = protectedCondition;
-    // Show "Protecting" during initial setup before sync starts
-    const isStatusUnknown = status === K8sResourceConditionStatus.Unknown;
-    const isReasonUnknown =
-      reason === DRPlacementControlConditionReason.Unknown;
-    const isProgressingWithoutSync =
-      status === K8sResourceConditionStatus.False &&
-      reason === DRPlacementControlConditionReason.Progressing;
-
-    if (isStatusUnknown || isReasonUnknown || isProgressingWithoutSync) {
-      return DRStatus.Protecting;
-    }
-  }
-
-  // Map phase to DRStatus
-  switch (phase) {
-    case Phase.WaitForUser:
-      return DRStatus.WaitForUser;
-    case Phase.Deleting:
-      return DRStatus.Deleting;
-    case Phase.FailingOver:
-      return DRStatus.FailingOver;
-    case Phase.Relocating:
-      return DRStatus.Relocating;
-    case Phase.FailedOver:
-      return DRStatus.FailedOver;
-    case Phase.Relocated:
-      return DRStatus.Relocated;
-    case Phase.Deployed:
-      return DRStatus.Healthy;
-    default:
-      return DRStatus.Unknown;
-  }
 };
 
 /**


### PR DESCRIPTION
Fixes https://redhat.atlassian.net/browse/DFBUGS-7001

## SUMMARY
 - Fixes DR status displaying "Unknown" instead of "Relocating" on the topology view when performing a relocate operation after a completed failover
 - Unifies DR status handling across both the topology view and the protected-applications list by adding an action parameter to getDRStatus(), ensuring both views show consistent status during transitional phases (Initiating/Deploying)
 - Maps transitional DRPC phases (Initiating/Deploying) to the correct action-specific status using spec.action

## RCA
When a relocate is initiated after a completed failover, the Ramen controller transitions the DRPC's status.phase through Initiating → Relocating. The useActiveDROperations hook correctly detects these as active operations (they're in ACTIVE_PHASES), but:

getEffectiveDRStatus (used by node rendering + sidebar) had no case for Phase.Initiating/Phase.Deploying in its switch — falling to default: return DRStatus.Unknown.
getDRStatus (used by protected-applications list and topology node labels) also doesn't explicitly handle these transitional phases, causing it to fall through to health-based evaluation instead of showing the in-progress operation status.
This resulted in the topology showing "Unknown" and the protected-applications list showing "Healthy" during the transitional window before the phase advances to Relocating.

## FIX
 - Added an optional action parameter to getEffectiveDRStatus and mapped Phase.Initiating/Phase.Deploying → FailingOver/Relocating based on spec.action
 - Added an optional action parameter to getDRStatus with the same transitional phase mapping, ensuring the protected-applications list also shows the correct in-progress status
 - Simplified computeOperationDRStatus in node-generator.ts — removed the manual effectivePhase mapping and instead passes action directly to getDRStatus
 - Updated useProtectedAppsByCluster.ts to pass drpc?.spec?.action to getDRStatus
 - Updated dr-status-popover.tsx to pass action through getDRStatusDetails to getDRStatus
 - Updated all topology callers to pass the action field
 - Added test cases for Initiating/Deploying + action=Relocate/Failover scenarios
 - When action is undefined (e.g., initial enrollment), existing behavior is preserved — no change to Protecting/health logic paths


