### PR TITLE
DFBUGS-7355: [release-4.22] Fix all CVES

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,18 +65,23 @@
     "**/package.json": "npx --yes sort-package-json@3.0.0"
   },
   "resolutions": {
-    "@eslint/eslintrc/ajv": "6.14.0",
+    "@openshift-console/dynamic-plugin-sdk-webpack/ajv": "^6.15.0",
+    "@eslint/eslintrc/ajv": "^6.15.0",
+    "eslint/ajv": "^6.15.0",
+    "schema-utils/ajv": "^8.20.0",
+    "table/ajv": "^8.20.0",
+    "ajv-formats/ajv": "^8.20.0",
+    "ajv-keywords/ajv": "^8.20.0",
     "@types/react": "^17",
     "@types/react-dom": "^17",
-    "ajv-formats": "2.1.1",
-    "ajv-keywords": "5.1.0",
-    "fast-xml-parser": "5.5.8",
-    "fork-ts-checker-webpack-plugin/ajv": "8.18.0",
+    "ajv-formats": "^3.0.1",
+    "ajv-keywords": "^5.1.0",
+    "fast-xml-parser": "^5.5.8",
     "fork-ts-checker-webpack-plugin/schema-utils": "4.3.3",
-    "immutable": "5.1.5",
-    "qs": "6.14.1",
-    "react-router": "6.30.3",
-    "schema-utils@npm:4.3.3/ajv": "8.18.0"
+    "minimatch": "^3.1.5",
+    "immutable": "^5.1.6",
+    "qs": "^6.15.2",
+    "react-router": "6.30.4"
   },
   "dependencies": {
     "@aws-sdk/client-iam": "^3.1011.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3214,6 +3214,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nodable/entities@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@nodable/entities@npm:2.2.0"
+  checksum: 10/7f44743adb5947ea6e0c276fecc927eb47ff1a6526256aeb03098d98086c906b2ab98663330c049a55758644b1fd23478222cbc8d4f773ac737c979ff2c1c769
+  languageName: node
+  linkType: hard
+
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
@@ -3959,6 +3966,13 @@ __metadata:
   version: 1.23.2
   resolution: "@remix-run/router@npm:1.23.2"
   checksum: 10/50eb497854881bbd2e1016d4eb83c935ecd618e1c3888b74718851317e3b04edbaae9fe1baa49ec08c5c52cfe7118f4664e37144813d9500f45f922d6602a782
+  languageName: node
+  linkType: hard
+
+"@remix-run/router@npm:1.23.3":
+  version: 1.23.3
+  resolution: "@remix-run/router@npm:1.23.3"
+  checksum: 10/a12ae9994bf017d47392ce2be24252b4e2281f4b27eac78f0e9b48afa5f522be9c0ec64b85db013ded1fff140d9512b97ac8ea5dd182138dcd6d3ded3136cbf6
   languageName: node
   linkType: hard
 
@@ -6667,9 +6681,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv-formats@npm:2.1.1":
-  version: 2.1.1
-  resolution: "ajv-formats@npm:2.1.1"
+"ajv-formats@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "ajv-formats@npm:3.0.1"
   dependencies:
     ajv: "npm:^8.0.0"
   peerDependencies:
@@ -6677,11 +6691,11 @@ __metadata:
   peerDependenciesMeta:
     ajv:
       optional: true
-  checksum: 10/70c263ded219bf277ffd9127f793b625f10a46113b2e901e150da41931fcfd7f5592da6d66862f4449bb157ffe65867c3294a7df1d661cc232c4163d5a1718ed
+  checksum: 10/5679b9f9ced9d0213a202a37f3aa91efcffe59a6de1a6e3da5c873344d3c161820a1f11cc29899661fee36271fd2895dd3851b6461c902a752ad661d1c1e8722
   languageName: node
   linkType: hard
 
-"ajv-keywords@npm:5.1.0":
+"ajv-keywords@npm:^5.1.0":
   version: 5.1.0
   resolution: "ajv-keywords@npm:5.1.0"
   dependencies:
@@ -6692,75 +6706,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:6.14.0":
-  version: 6.14.0
-  resolution: "ajv@npm:6.14.0"
+"ajv@npm:^6.15.0":
+  version: 6.15.0
+  resolution: "ajv@npm:6.15.0"
   dependencies:
     fast-deep-equal: "npm:^3.1.1"
     fast-json-stable-stringify: "npm:^2.0.0"
     json-schema-traverse: "npm:^0.4.1"
     uri-js: "npm:^4.2.2"
-  checksum: 10/c71f14dd2b6f2535d043f74019c8169f7aeb1106bafbb741af96f34fdbf932255c919ddd46344043d03b62ea0ccb319f83667ec5eedf612393f29054fe5ce4a5
+  checksum: 10/0916dda09c152fb5857bc1cc7ce61718e9cec5b7faeff44a74f5e324eed8a556e1a84856724ea322a067b436ecad9f74ac8295fd395449788cca52f0c25bd5fb
   languageName: node
   linkType: hard
 
-"ajv@npm:8.18.0":
-  version: 8.18.0
-  resolution: "ajv@npm:8.18.0"
+"ajv@npm:^8.20.0":
+  version: 8.20.0
+  resolution: "ajv@npm:8.20.0"
   dependencies:
     fast-deep-equal: "npm:^3.1.3"
     fast-uri: "npm:^3.0.1"
     json-schema-traverse: "npm:^1.0.0"
     require-from-string: "npm:^2.0.2"
-  checksum: 10/bfed9de827a2b27c6d4084324eda76a4e32bdde27410b3e9b81d06e6f8f5c78370fc6b93fe1d869f1939ff1d7c4ae8896960995acb8425e3e9288c8884247c48
-  languageName: node
-  linkType: hard
-
-"ajv@npm:^6.12.3, ajv@npm:^6.12.4":
-  version: 6.12.6
-  resolution: "ajv@npm:6.12.6"
-  dependencies:
-    fast-deep-equal: "npm:^3.1.1"
-    fast-json-stable-stringify: "npm:^2.0.0"
-    json-schema-traverse: "npm:^0.4.1"
-    uri-js: "npm:^4.2.2"
-  checksum: 10/48d6ad21138d12eb4d16d878d630079a2bda25a04e745c07846a4ad768319533031e28872a9b3c5790fa1ec41aabdf2abed30a56e5a03ebc2cf92184b8ee306c
-  languageName: node
-  linkType: hard
-
-"ajv@npm:^8.0.0, ajv@npm:^8.8.0":
-  version: 8.11.0
-  resolution: "ajv@npm:8.11.0"
-  dependencies:
-    fast-deep-equal: "npm:^3.1.1"
-    json-schema-traverse: "npm:^1.0.0"
-    require-from-string: "npm:^2.0.2"
-    uri-js: "npm:^4.2.2"
-  checksum: 10/aa0dfd6cebdedde8e77747e84e7b7c55921930974b8547f54b4156164ff70445819398face32dafda4bd4c61bbc7513d308d4c2bf769f8ea6cb9c8449f9faf54
-  languageName: node
-  linkType: hard
-
-"ajv@npm:^8.0.1":
-  version: 8.6.2
-  resolution: "ajv@npm:8.6.2"
-  dependencies:
-    fast-deep-equal: "npm:^3.1.1"
-    json-schema-traverse: "npm:^1.0.0"
-    require-from-string: "npm:^2.0.2"
-    uri-js: "npm:^4.2.2"
-  checksum: 10/f4f06654c89599b3cdb53b7eb7e84eb1066772ccb9f300b4df53bcbef015a26d7ec9e3cb4c73791ef4880d7c056759face5c283d3cebff090d5d877e19ba612b
-  languageName: node
-  linkType: hard
-
-"ajv@npm:^8.9.0":
-  version: 8.17.1
-  resolution: "ajv@npm:8.17.1"
-  dependencies:
-    fast-deep-equal: "npm:^3.1.3"
-    fast-uri: "npm:^3.0.1"
-    json-schema-traverse: "npm:^1.0.0"
-    require-from-string: "npm:^2.0.2"
-  checksum: 10/ee3c62162c953e91986c838f004132b6a253d700f1e51253b99791e2dbfdb39161bc950ebdc2f156f8568035bb5ed8be7bd78289cd9ecbf3381fe8f5b82e3f33
+  checksum: 10/5ce59c0537f4c2aca9a758b412659ec70acb4d5dde971c10ecf21d2e3d799f99acdb4a08e1f5fb2e067c8542930398aae793bb996bb07d3feb81dae22fe2ada9
   languageName: node
   linkType: hard
 
@@ -6859,6 +6825,13 @@ __metadata:
     normalize-path: "npm:^3.0.0"
     picomatch: "npm:^2.0.4"
   checksum: 10/985163db2292fac9e5a1e072bf99f1b5baccf196e4de25a0b0b81865ebddeb3b3eb4480734ef0a2ac8c002845396b91aa89121f5b84f93981a4658164a9ec6e9
+  languageName: node
+  linkType: hard
+
+"anynum@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "anynum@npm:1.0.0"
+  checksum: 10/5f7921dfa10fc80cc88442d6c9681203281cb68a2a7b69d2ba9c5977ef31cf0044209006eea59b22ad44ab172b2ccea38d6cab9f41e66570c76fc2470ba15c23
   languageName: node
   linkType: hard
 
@@ -7317,13 +7290,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"balanced-match@npm:^4.0.2":
-  version: 4.0.4
-  resolution: "balanced-match@npm:4.0.4"
-  checksum: 10/fb07bb66a0959c2843fc055838047e2a95ccebb837c519614afb067ebfdf2fa967ca8d712c35ced07f2cd26fc6f07964230b094891315ad74f11eba3d53178a0
-  languageName: node
-  linkType: hard
-
 "bare-events@npm:^2.2.0":
   version: 2.5.0
   resolution: "bare-events@npm:2.5.0"
@@ -7469,24 +7435,6 @@ __metadata:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
   checksum: 10/12cb6d6310629e3048cadb003e1aca4d8c9bb5c67c3c321bafdd7e7a50155de081f78ea3e0ed92ecc75a9015e784f301efc8132383132f4f7904ad1ac529c562
-  languageName: node
-  linkType: hard
-
-"brace-expansion@npm:^2.0.1":
-  version: 2.0.2
-  resolution: "brace-expansion@npm:2.0.2"
-  dependencies:
-    balanced-match: "npm:^1.0.0"
-  checksum: 10/01dff195e3646bc4b0d27b63d9bab84d2ebc06121ff5013ad6e5356daa5a9d6b60fa26cf73c74797f2dc3fbec112af13578d51f75228c1112b26c790a87b0488
-  languageName: node
-  linkType: hard
-
-"brace-expansion@npm:^5.0.2":
-  version: 5.0.4
-  resolution: "brace-expansion@npm:5.0.4"
-  dependencies:
-    balanced-match: "npm:^4.0.2"
-  checksum: 10/cfd57e20d8ded9578149e47ae4d3fff2b2f78d06b54a32a73057bddff65c8e9b930613f0cbcfefedf12dd117151e19d4da16367d5127c54f3bff02d8a4479bb2
   languageName: node
   linkType: hard
 
@@ -10799,25 +10747,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-builder@npm:^1.1.4":
-  version: 1.1.4
-  resolution: "fast-xml-builder@npm:1.1.4"
+"fast-xml-builder@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "fast-xml-builder@npm:1.2.0"
   dependencies:
-    path-expression-matcher: "npm:^1.1.3"
-  checksum: 10/32937866aaf5a90e69d1f4ee6e15e875248d5b5d2afd70277e9e8323074de4980cef24575a591b8e43c29f405d5f12377b3bad3842dc412b0c5c17a3eaee4b6b
+    path-expression-matcher: "npm:^1.5.0"
+    xml-naming: "npm:^0.1.0"
+  checksum: 10/5948add7796879d03b6c779cbb17f2f203a41cdf23dfaaa4789c65078a36376cd0709a6586701e980e3d244ebd5fdb35db1235ccb5e4fb9e9abfd8c51e7b8813
   languageName: node
   linkType: hard
 
-"fast-xml-parser@npm:5.5.8":
-  version: 5.5.8
-  resolution: "fast-xml-parser@npm:5.5.8"
+"fast-xml-parser@npm:^5.5.8":
+  version: 5.9.2
+  resolution: "fast-xml-parser@npm:5.9.2"
   dependencies:
-    fast-xml-builder: "npm:^1.1.4"
-    path-expression-matcher: "npm:^1.2.0"
-    strnum: "npm:^2.2.0"
+    "@nodable/entities": "npm:^2.2.0"
+    fast-xml-builder: "npm:^1.2.0"
+    is-unsafe: "npm:^1.0.1"
+    path-expression-matcher: "npm:^1.5.0"
+    strnum: "npm:^2.4.0"
+    xml-naming: "npm:^0.1.0"
   bin:
     fxparser: src/cli/cli.js
-  checksum: 10/888f9a5d345e65e34b70d394798a1542603a216f06c140a9671d031b80b42c01ef2e68f2a0ceea45e7703fa80549f0e06da710f5a2faafdc910d1b6b354f0fa0
+  checksum: 10/c2ef301453d9db188469615c90bb552aab628c1b5b564e02db17e0295781bcc449cb174bad8638f5760cfb673e0f2df875495838b08f78ed5c0c5c6f51175ade
   languageName: node
   linkType: hard
 
@@ -12400,10 +12352,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immutable@npm:5.1.5":
-  version: 5.1.5
-  resolution: "immutable@npm:5.1.5"
-  checksum: 10/7aec2740239772ec8e92e793c991bd809203a97694f4ff3a18e50e28f9a6b02393ad033d87b458037bdf8c0ea37d4446d640e825f6171df3405cf6cf300ce028
+"immutable@npm:^5.1.6":
+  version: 5.1.6
+  resolution: "immutable@npm:5.1.6"
+  checksum: 10/4ba416dac4cc9d1cab4155bd6aefa54d5ca25e56bfee8a1d4edc3f23115b599486edafe76e91f83d22961bd065754fd705b04f052809ec967ccd71817c8dac2a
   languageName: node
   linkType: hard
 
@@ -13149,6 +13101,13 @@ __metadata:
   version: 0.1.0
   resolution: "is-unicode-supported@npm:0.1.0"
   checksum: 10/a2aab86ee7712f5c2f999180daaba5f361bdad1efadc9610ff5b8ab5495b86e4f627839d085c6530363c6d6d4ecbde340fb8e54bdb83da4ba8e0865ed5513c52
+  languageName: node
+  linkType: hard
+
+"is-unsafe@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "is-unsafe@npm:1.0.1"
+  checksum: 10/971d05c69a742f866e4f257e4008ee3a9fb84ebf81141352211698416e1cf52aa03bcda54e3a5c2f25547f4b4cbb6d9e02c048a4daef5e7baea51f33089ddc9e
   languageName: node
   linkType: hard
 
@@ -14687,30 +14646,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^10.2.2":
-  version: 10.2.4
-  resolution: "minimatch@npm:10.2.4"
-  dependencies:
-    brace-expansion: "npm:^5.0.2"
-  checksum: 10/aea4874e521c55bb60744685bbffe3d152e5460f84efac3ea936e6bbe2ceba7deb93345fec3f9bb17f7b6946776073a64d40ae32bf5f298ad690308121068a1f
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:^3.0.2, minimatch@npm:^3.0.4, minimatch@npm:^3.0.5, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
-  version: 3.1.2
-  resolution: "minimatch@npm:3.1.2"
+"minimatch@npm:^3.1.5":
+  version: 3.1.5
+  resolution: "minimatch@npm:3.1.5"
   dependencies:
     brace-expansion: "npm:^1.1.7"
-  checksum: 10/e0b25b04cd4ec6732830344e5739b13f8690f8a012d73445a4a19fbc623f5dd481ef7a5827fde25954cd6026fede7574cc54dc4643c99d6c6b653d6203f94634
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:^9.0.4":
-  version: 9.0.5
-  resolution: "minimatch@npm:9.0.5"
-  dependencies:
-    brace-expansion: "npm:^2.0.1"
-  checksum: 10/dd6a8927b063aca6d910b119e1f2df6d2ce7d36eab91de83167dd136bb85e1ebff97b0d3de1cb08bd1f7e018ca170b4962479fefab5b2a69e2ae12cb2edc8348
+  checksum: 10/b11a7ee5773cd34c1a0c8436cdbe910901018fb4b6cb47aa508a18d567f6efd2148507959e35fba798389b161b8604a2d704ccef751ea36bd4582f9852b7d63f
   languageName: node
   linkType: hard
 
@@ -15770,7 +15711,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-expression-matcher@npm:^1.1.3, path-expression-matcher@npm:^1.2.0":
+"path-expression-matcher@npm:^1.5.0":
   version: 1.5.0
   resolution: "path-expression-matcher@npm:1.5.0"
   checksum: 10/28303bb9ee6831e6df14c10cd3f3f7b2d7c8d7f788d8bdb7440136fd696064c82a3e264999a0764d28e39f698275fc03a5493bec93c57ef4a22566280367dd64
@@ -16298,12 +16239,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:6.14.1":
-  version: 6.14.1
-  resolution: "qs@npm:6.14.1"
+"qs@npm:^6.15.2":
+  version: 6.15.2
+  resolution: "qs@npm:6.15.2"
   dependencies:
     side-channel: "npm:^1.1.0"
-  checksum: 10/34b5ab00a910df432d55180ef39c1d1375e550f098b5ec153b41787f1a6a6d7e5f9495593c3b112b77dbc6709d0ae18e55b82847a4c2bbbb0de1e8ccbb1794c5
+  checksum: 10/7a934b2dba40654cf9878dab7c1e7ad56c6186265509727fbece67dadc38fd5d67715b61b6ef938e5a0475faeee701d18ec0a7ce420ad64367caad7f1bdb66e2
   languageName: node
   linkType: hard
 
@@ -16614,14 +16555,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router@npm:6.30.3":
-  version: 6.30.3
-  resolution: "react-router@npm:6.30.3"
+"react-router@npm:6.30.4":
+  version: 6.30.4
+  resolution: "react-router@npm:6.30.4"
   dependencies:
-    "@remix-run/router": "npm:1.23.2"
+    "@remix-run/router": "npm:1.23.3"
   peerDependencies:
     react: ">=16.8"
-  checksum: 10/1a51bdcc42b8d7979228dea8b5c44a28a4add9b681781f75b74f5f920d20058a92ffe5f1d0ba0621f03abe1384b36025b53b402515ecb35f27a6a2f2f25d6fbe
+  checksum: 10/59c1b64a210cde2f1d069ffc47dce2d58991bd4d81bb0743e22ba7c6b742e63ebbdc976c42c3a3ebd90bf38a2f05258bd0efa82c162b259be000d39787716043
   languageName: node
   linkType: hard
 
@@ -18236,10 +18177,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strnum@npm:^2.2.0":
-  version: 2.2.3
-  resolution: "strnum@npm:2.2.3"
-  checksum: 10/fb70206301858c319f59ed34fecedf90ac3b821692c2accd403d9d4a3384223a09df8fd92b130bbd4e885b67b7790715c003405ce5f959d9cabbf07d41d62aa8
+"strnum@npm:^2.4.0":
+  version: 2.4.0
+  resolution: "strnum@npm:2.4.0"
+  dependencies:
+    anynum: "npm:^1.0.0"
+  checksum: 10/ce603543f8c8a8f0497ab554ea99bf7c8d6bef1eeb3d73feced8a291212dc675014b160e25f527c01e8b88106cc10b102094f0b9feb3e4527a84ad446b8cbf06
   languageName: node
   linkType: hard
 
@@ -20522,6 +20465,13 @@ __metadata:
   version: 5.0.0
   resolution: "xml-name-validator@npm:5.0.0"
   checksum: 10/43f30f3f6786e406dd665acf08cd742d5f8a46486bd72517edb04b27d1bcd1599664c2a4a99fc3f1e56a3194bff588b12f178b7972bc45c8047bdc4c3ac8d4a1
+  languageName: node
+  linkType: hard
+
+"xml-naming@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "xml-naming@npm:0.1.0"
+  checksum: 10/45abd94ba64a508bda3f4d0b70e49811a3c3542596252c213caf47c858bbe9bba365ebba8eeff68e2a876e22a1bf6855d90cd2019b2f28012cebb167a4df2293
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**observation:**

There are total 17 uniques CVE numbers in all release branches

**fixes**

<google-sheets-html-origin><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->
Tab | CVE | Package | Recommended fix (CVE) | Before fix version in repo | After fix version in repo (current branch)
-- | -- | -- | -- | -- | --
1 | CVE-2026-27942 | fast-xml-parser | ≥ 5.3.8 | 5.5.8 | 5.5.8
2 | CVE-2026-27904 | minimatch | ≥ 3.1.4 / 9.0.7 / 10.2.3 | 3.1.2, 9.0.5, 10.2.4 | 3.1.5, 9.0.9, 10.2.5
3 | CVE-2026-26996 | minimatch | ≥ 10.2.1 | 10.2.4 | 10.2.5
4 | CVE-2026-26278 | fast-xml-parser | ≥ 5.3.6 | 5.5.8 | 5.5.8
5 | CVE-2026-25896 | fast-xml-parser | ≥ 5.3.5 | 5.5.8 | 5.5.8
6 | CVE-2026-25128 | fast-xml-parser | ≥ 5.3.4 | 5.5.8 | 5.5.8
7 | CVE-2026-22029 | react-router / @remix-run/router | @remix-run/router ≥ 1.23.2 | react-router 6.30.3, @remix-run/router 1.23.2 | react-router 6.30.4, @remix-run/router 1.23.3
8 | CVE-2025-69873 | ajv | > 8.17.1 | 8.17.1 (also 8.18.0, 6.14.0, 6.12.6, 8.11.0, 8.6.2) | 8.20.0, 6.15.0, 6.14.0
9 | CVE-2025-68458 | webpack | ≥ 5.104.1 | 5.106.0 | 5.106.0
10 | CVE-2025-68157 | webpack | ≥ 5.104.0 | 5.106.0 | 5.106.0
11 | CVE-2025-66031 | node-forge | ≥ 1.3.2 | Not in dependency tree | Not in dependency tree
12 | CVE-2025-15284 | qs | ≥ 6.14.1 | 6.14.1 | 6.15.2
13 | CVE-2025-13465 | lodash / lodash-es | ≥ 4.17.23 | 4.18.1 | 4.18.1
14 | CVE-2025-12816 | node-forge | ≥ 1.3.2 | Not in dependency tree | Not in dependency tree
15 | CVE-2026-4800 | lodash / lodash-es | ≥ 4.18.0 | 4.18.1 | 4.18.1
16 | CVE-2026-29063 | immutable | ≥ 5.1.5 | 5.1.5 | 5.1.6
17 | CVE-2026-33036 | fast-xml-parser | ≥ 5.5.6 | 5.5.8 | 5.5.8


<img width="1728" height="1117" alt="Screenshot 2026-06-11 at 7 16 19 PM" src="https://github.com/user-attachments/assets/00f1945f-613d-47a0-9eaa-de7c01f6bdc9" />

vaddempudinikhitha@VADDEMPUDIs-MacBook-Pro odf-console % for pkg in fast-xml-parser minimatch react-router @remix-run/router ajv webpack node-forge qs lodash lodash-es immutable; do echo "========== $pkg =========="; yarn why "$pkg" 2>/dev/null || echo "not in tree"; done
========== fast-xml-parser ==========
├─ @aws-sdk/xml-builder@npm:3.972.16
│  └─ fast-xml-parser@npm:5.5.8 (via npm:5.5.8)
│
└─ @aws-sdk/xml-builder@npm:3.972.17
   └─ fast-xml-parser@npm:5.5.8 (via npm:5.5.8)
========== minimatch ==========
├─ @eslint/eslintrc@npm:2.1.4
│  └─ minimatch@npm:3.1.5 (via npm:3.1.5)
│
├─ @humanwhocodes/config-array@npm:0.13.0
│  └─ minimatch@npm:3.1.5 (via npm:3.1.5)
│
├─ @typescript-eslint/typescript-estree@npm:8.58.1
│  └─ minimatch@npm:10.2.5 (via npm:10.2.5)
│
├─ @typescript-eslint/typescript-estree@npm:8.58.1 [1a0dd]
│  └─ minimatch@npm:10.2.5 (via npm:10.2.5)
│
├─ @typescript-eslint/typescript-estree@npm:8.58.1 [b8fc2]
│  └─ minimatch@npm:10.2.5 (via npm:10.2.5)
│
├─ eslint-plugin-import@npm:2.32.0
│  └─ minimatch@npm:3.1.5 (via npm:3.1.5)
│
├─ eslint-plugin-import@npm:2.32.0 [df149]
│  └─ minimatch@npm:3.1.5 (via npm:3.1.5)
│
├─ eslint-plugin-jsx-a11y@npm:6.10.2
│  └─ minimatch@npm:3.1.5 (via npm:3.1.5)
│
├─ eslint-plugin-jsx-a11y@npm:6.10.2 [df149]
│  └─ minimatch@npm:3.1.5 (via npm:3.1.5)
│
├─ eslint-plugin-react@npm:7.37.5
│  └─ minimatch@npm:3.1.5 (via npm:3.1.5)
│
├─ eslint-plugin-react@npm:7.37.5 [df149]
│  └─ minimatch@npm:3.1.5 (via npm:3.1.5)
│
├─ eslint@npm:8.57.1
│  └─ minimatch@npm:3.1.5 (via npm:3.1.5)
│
├─ fork-ts-checker-webpack-plugin@npm:9.1.0
│  └─ minimatch@npm:3.1.5 (via npm:3.1.5)
│
├─ fork-ts-checker-webpack-plugin@npm:9.1.0 [df149]
│  └─ minimatch@npm:3.1.5 (via npm:3.1.5)
│
├─ glob@npm:10.4.5
│  └─ minimatch@npm:9.0.9 (via npm:9.0.9)
│
├─ glob@npm:10.5.0
│  └─ minimatch@npm:9.0.9 (via npm:9.0.9)
│
├─ glob@npm:13.0.6
│  └─ minimatch@npm:10.2.5 (via npm:10.2.5)
│
├─ glob@npm:7.1.7
│  └─ minimatch@npm:3.1.5 (via npm:3.1.5)
│
├─ glob@npm:7.2.3
│  └─ minimatch@npm:3.1.5 (via npm:3.1.5)
│
├─ matcher-collection@npm:2.0.1
│  └─ minimatch@npm:3.1.5 (via npm:3.1.5)
│
├─ test-exclude@npm:6.0.0
│  └─ minimatch@npm:3.1.5 (via npm:3.1.5)
│
└─ walk-sync@npm:2.2.0
   └─ minimatch@npm:3.1.5 (via npm:3.1.5)
========== react-router ==========
├─ @openshift-console/dynamic-plugin-sdk@npm:4.21.0
│  └─ react-router@npm:6.30.4 [333df] (via npm:6.30.4 [333df])
│
├─ react-router-dom-v5-compat@npm:6.15.0
│  └─ react-router@npm:6.30.4 (via npm:6.30.4)
│
├─ react-router-dom-v5-compat@npm:6.30.3
│  └─ react-router@npm:6.30.4 (via npm:6.30.4)
│
├─ react-router-dom-v5-compat@npm:6.15.0 [333df]
│  └─ react-router@npm:6.30.4 [333df] (via npm:6.30.4 [c6c5f])
│
├─ react-router-dom-v5-compat@npm:6.30.3 [df149]
│  └─ react-router@npm:6.30.4 [70315] (via npm:6.30.4 [70315])
│
├─ react-router-dom@npm:5.3.4
│  └─ react-router@npm:6.30.4 (via npm:6.30.4)
│
└─ react-router-dom@npm:5.3.4 [333df]
   └─ react-router@npm:6.30.4 [333df] (via npm:6.30.4 [fc992])
========== @remix-run/router ==========
├─ react-router-dom-v5-compat@npm:6.30.3
│  └─ @remix-run/router@npm:1.23.2 (via npm:1.23.2)
│
├─ react-router-dom-v5-compat@npm:6.30.3 [df149]
│  └─ @remix-run/router@npm:1.23.2 (via npm:1.23.2)
│
├─ react-router@npm:6.30.4
│  └─ @remix-run/router@npm:1.23.3 (via npm:1.23.3)
│
├─ react-router@npm:6.30.4 [333df]
│  └─ @remix-run/router@npm:1.23.3 (via npm:1.23.3)
│
└─ react-router@npm:6.30.4 [70315]
   └─ @remix-run/router@npm:1.23.3 (via npm:1.23.3)
========== ajv ==========
├─ @eslint/eslintrc@npm:2.1.4
│  └─ ajv@npm:6.14.0 (via npm:6.14.0)
│
├─ @openshift-console/dynamic-plugin-sdk-webpack@npm:4.21.0
│  └─ ajv@npm:6.15.0 (via npm:^6.15.0)
│
├─ @openshift-console/dynamic-plugin-sdk-webpack@npm:4.21.0 [df149]
│  └─ ajv@npm:6.15.0 (via npm:^6.15.0)
│
├─ eslint@npm:8.57.1
│  └─ ajv@npm:6.15.0 (via npm:^6.15.0)
│
├─ schema-utils@npm:4.0.0
│  └─ ajv@npm:8.20.0 (via npm:^8.20.0)
│
├─ schema-utils@npm:4.2.0
│  └─ ajv@npm:8.20.0 (via npm:^8.20.0)
│
├─ schema-utils@npm:4.3.2
│  └─ ajv@npm:8.20.0 (via npm:^8.20.0)
│
├─ schema-utils@npm:4.3.3
│  └─ ajv@npm:8.20.0 (via npm:^8.20.0)
│
└─ table@npm:6.9.0
   └─ ajv@npm:8.20.0 (via npm:^8.20.0)
========== webpack ==========
├─ @openshift-console/dynamic-plugin-sdk-webpack@npm:4.21.0
│  └─ webpack@npm:5.106.0 (via npm:^5.75.0)
│
├─ @openshift-console/dynamic-plugin-sdk-webpack@npm:4.21.0 [df149]
│  └─ webpack@npm:5.106.0 [642a1] (via npm:^5.75.0 [642a1])
│
└─ odf-plugin@workspace:.
   └─ webpack@npm:5.106.0 [df149] (via npm:^5.105.4 [df149])
========== node-forge ==========
========== qs ==========
├─ @cypress/request@npm:3.0.10
│  └─ qs@npm:6.15.2 (via npm:^6.15.2)
│
├─ body-parser@npm:1.20.4
│  └─ qs@npm:6.15.2 (via npm:^6.15.2)
│
├─ express@npm:4.22.1
│  └─ qs@npm:6.15.2 (via npm:^6.15.2)
│
└─ union@npm:0.5.0
   └─ qs@npm:6.15.2 (via npm:^6.15.2)
========== lodash ==========
├─ @cypress/webpack-preprocessor@npm:7.0.2
│  └─ lodash@npm:4.18.1 (via npm:^4.17.20)
│
├─ @cypress/webpack-preprocessor@npm:7.0.2 [df149]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.20)
│
├─ @openshift-console/dynamic-plugin-sdk-webpack@npm:4.21.0
│  └─ lodash@npm:4.18.1 (via npm:^4.17.23)
│
├─ @openshift-console/dynamic-plugin-sdk-webpack@npm:4.21.0 [df149]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.23)
│
├─ @openshift-console/dynamic-plugin-sdk@npm:4.21.0
│  └─ lodash@npm:4.18.1 (via npm:^4.17.23)
│
├─ @openshift/dynamic-plugin-sdk-webpack@npm:4.1.0
│  └─ lodash@npm:4.18.1 (via npm:^4.17.21)
│
├─ @openshift/dynamic-plugin-sdk-webpack@npm:4.1.0 [642a1]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.21)
│
├─ @openshift/dynamic-plugin-sdk@npm:5.0.1
│  └─ lodash@npm:4.18.1 (via npm:^4.17.21)
│
├─ @openshift/dynamic-plugin-sdk@npm:8.2.0
│  └─ lodash@npm:4.18.1 (via npm:^4.17.23)
│
├─ @openshift/dynamic-plugin-sdk@npm:5.0.1 [333df]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.21)
│
├─ @openshift/dynamic-plugin-sdk@npm:8.2.0 [bb7ba]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.23)
│
├─ @patternfly/react-charts@npm:8.4.0
│  └─ lodash@npm:4.18.1 (via npm:^4.17.21)
│
├─ @patternfly/react-charts@npm:8.4.0 [5a509]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.21)
│
├─ @patternfly/react-charts@npm:8.4.0 [df149]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.21)
│
├─ @patternfly/react-table@npm:6.4.0
│  └─ lodash@npm:4.18.1 (via npm:^4.17.21)
│
├─ @patternfly/react-table@npm:6.4.0 [5a509]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.21)
│
├─ @patternfly/react-table@npm:6.4.0 [df149]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.21)
│
├─ async@npm:2.6.4
│  └─ lodash@npm:4.18.1 (via npm:^4.17.14)
│
├─ cypress-multi-reporters@npm:2.0.5
│  └─ lodash@npm:4.18.1 (via npm:^4.17.21)
│
├─ cypress-multi-reporters@npm:2.0.5 [df149]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.21)
│
├─ cypress@npm:15.13.1
│  └─ lodash@npm:4.18.1 (via npm:^4.17.23)
│
├─ victory-area@npm:37.3.6
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-area@npm:37.3.6 [69de8]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-area@npm:37.3.6 [83c14]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-axis@npm:37.3.6
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-axis@npm:37.3.6 [69de8]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-axis@npm:37.3.6 [83c14]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-bar@npm:37.3.6
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-bar@npm:37.3.6 [69de8]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-bar@npm:37.3.6 [83c14]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-box-plot@npm:37.3.6
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-box-plot@npm:37.3.6 [69de8]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-box-plot@npm:37.3.6 [83c14]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-brush-container@npm:37.3.6
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-brush-container@npm:37.3.6 [69de8]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-brush-container@npm:37.3.6 [83c14]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-brush-line@npm:37.3.6
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-brush-line@npm:37.3.6 [69de8]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-brush-line@npm:37.3.6 [83c14]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-candlestick@npm:37.3.6
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-candlestick@npm:37.3.6 [69de8]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-candlestick@npm:37.3.6 [83c14]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-canvas@npm:37.3.6
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-canvas@npm:37.3.6 [69de8]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-canvas@npm:37.3.6 [83c14]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-chart@npm:37.3.6
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-chart@npm:37.3.6 [69de8]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-chart@npm:37.3.6 [83c14]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-core@npm:37.3.6
│  └─ lodash@npm:4.18.1 (via npm:^4.17.21)
│
├─ victory-core@npm:37.3.6 [5a509]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.21)
│
├─ victory-core@npm:37.3.6 [df149]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.21)
│
├─ victory-create-container@npm:37.3.6
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-create-container@npm:37.3.6 [69de8]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-create-container@npm:37.3.6 [83c14]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-cursor-container@npm:37.3.6
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-cursor-container@npm:37.3.6 [69de8]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-cursor-container@npm:37.3.6 [83c14]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-errorbar@npm:37.3.6
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-errorbar@npm:37.3.6 [69de8]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-errorbar@npm:37.3.6 [83c14]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-group@npm:37.3.6
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-group@npm:37.3.6 [69de8]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-group@npm:37.3.6 [83c14]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-histogram@npm:37.3.6
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-histogram@npm:37.3.6 [69de8]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-histogram@npm:37.3.6 [83c14]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-legend@npm:37.3.6
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-legend@npm:37.3.6 [69de8]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-legend@npm:37.3.6 [83c14]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-line@npm:37.3.6
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-line@npm:37.3.6 [69de8]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-line@npm:37.3.6 [83c14]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-pie@npm:37.3.6
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-pie@npm:37.3.6 [69de8]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-pie@npm:37.3.6 [83c14]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-polar-axis@npm:37.3.6
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-polar-axis@npm:37.3.6 [69de8]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-polar-axis@npm:37.3.6 [83c14]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-scatter@npm:37.3.6
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-scatter@npm:37.3.6 [69de8]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-scatter@npm:37.3.6 [83c14]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-selection-container@npm:37.3.6
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-selection-container@npm:37.3.6 [69de8]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-selection-container@npm:37.3.6 [83c14]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-shared-events@npm:37.3.6
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-shared-events@npm:37.3.6 [69de8]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-shared-events@npm:37.3.6 [83c14]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-stack@npm:37.3.6
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-stack@npm:37.3.6 [69de8]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-stack@npm:37.3.6 [83c14]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-tooltip@npm:37.3.6
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-tooltip@npm:37.3.6 [69de8]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-tooltip@npm:37.3.6 [83c14]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-voronoi-container@npm:37.3.6
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-voronoi-container@npm:37.3.6 [69de8]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-voronoi-container@npm:37.3.6 [83c14]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-voronoi@npm:37.3.6
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-voronoi@npm:37.3.6 [69de8]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-voronoi@npm:37.3.6 [83c14]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-zoom-container@npm:37.3.6
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-zoom-container@npm:37.3.6 [69de8]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
├─ victory-zoom-container@npm:37.3.6 [83c14]
│  └─ lodash@npm:4.18.1 (via npm:^4.17.19)
│
└─ yup@npm:0.32.11
   └─ lodash@npm:4.18.1 (via npm:^4.17.21)
========== lodash-es ==========
├─ @odf-console/shared@workspace:packages/shared [848a8]
│  └─ lodash-es@npm:4.18.1 (via npm:^4.17.23)
│
├─ @odf-console/shared@workspace:packages/shared
│  └─ lodash-es@npm:4.18.1 (via npm:^4.17.23)
│
├─ odf-plugin@workspace:.
│  └─ lodash-es@npm:4.18.1 (via npm:^4.17.23)
│
└─ yup@npm:0.32.11
   └─ lodash-es@npm:4.18.1 (via npm:^4.17.21)
========== immutable ==========
├─ @openshift-console/dynamic-plugin-sdk-internal@npm:4.22.0-prerelease.3
│  └─ immutable@npm:5.1.6 (via npm:^5.1.6)
│
├─ @openshift-console/dynamic-plugin-sdk@npm:4.21.0
│  └─ immutable@npm:5.1.6 (via npm:^5.1.6)
│
└─ sass@npm:1.99.0
   └─ immutable@npm:5.1.6 (via npm:^5.1.6)
vaddempudinikhitha@VADDEMPUDIs-MacBook-Pro odf-console % 
