### PR TITLE
Fix SAN vs CNSA detection on Overview external systems card

### DIFF
--- a/packages/odf/components/overview/external-systems-card/ExternalSystemsCard.spec.tsx
+++ b/packages/odf/components/overview/external-systems-card/ExternalSystemsCard.spec.tsx
@@ -199,15 +199,10 @@ describe('ExternalSystemsCard', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders SAN row with LUN group status counts when SAN cluster exists', () => {
+  it('renders SAN row with LUN group status counts when only SAN cluster exists', () => {
     mockWatchClusters({
       sanClusters: {
         data: [{ metadata: { name: 'san-cluster' } }],
-        loaded: true,
-        loadError: null,
-      },
-      remoteClusters: {
-        data: [{ metadata: { name: 'remote-cluster-1' } }],
         loaded: true,
         loadError: null,
       },
@@ -231,6 +226,54 @@ describe('ExternalSystemsCard', () => {
       .closest('dt');
     const description = sanRow?.nextElementSibling as HTMLElement;
     expect(within(description).getAllByText('1')).toHaveLength(2);
+  });
+
+  it('renders SAN row when Cluster exists without RemoteCluster', () => {
+    mockWatchClusters({
+      sanClusters: {
+        data: [{ metadata: { name: 'san-cluster' } }],
+        loaded: true,
+        loadError: null,
+      },
+    });
+    mockFileSystems([]);
+
+    renderCard();
+
+    expect(
+      screen.getByText('Storage Area Network LUN groups')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('IBM Scale (CNSA) file systems')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders CNSA row when both RemoteCluster and Cluster CRs exist', () => {
+    mockWatchClusters({
+      sanClusters: {
+        data: [{ metadata: { name: 'local-scale-cluster' } }],
+        loaded: true,
+        loadError: null,
+      },
+      remoteClusters: {
+        data: [{ metadata: { name: 'remote-cluster-1' } }],
+        loaded: true,
+        loadError: null,
+      },
+    });
+    mockFileSystems([
+      cnsaFilesystem('fs-healthy', 'connected'),
+      cnsaFilesystem('fs-error', 'error'),
+    ]);
+
+    renderCard();
+
+    expect(
+      screen.getByText('IBM Scale (CNSA) file systems')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('Storage Area Network LUN groups')
+    ).not.toBeInTheDocument();
   });
 
   it('renders CNSA row with filesystem status counts when remote cluster exists', () => {

--- a/packages/odf/components/overview/external-systems-card/ExternalSystemsCard.tsx
+++ b/packages/odf/components/overview/external-systems-card/ExternalSystemsCard.tsx
@@ -5,7 +5,10 @@ import { isClusterIgnored, isExternalCluster } from '@odf/core/utils/odf';
 import { useWatchStorageClusters } from '@odf/shared/hooks/useWatchStorageClusters';
 import { FileSystemModel } from '@odf/shared/models/scale';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
-import { referenceForModel } from '@odf/shared/utils';
+import {
+  getValidWatchK8sResourceObj,
+  referenceForModel,
+} from '@odf/shared/utils';
 import {
   K8sResourceKind,
   useFlag,
@@ -95,13 +98,14 @@ export const ExternalSystemsCard: React.FC<CardProps> = ({ className }) => {
 
   const [fileSystems, fileSystemsLoaded, fileSystemsLoadError] =
     useK8sWatchResource<FileSystemKind[]>(
-      isFDF
-        ? {
-            kind: referenceForModel(FileSystemModel),
-            isList: true,
-            namespaced: false,
-          }
-        : null
+      getValidWatchK8sResourceObj(
+        {
+          kind: referenceForModel(FileSystemModel),
+          isList: true,
+          namespaced: false,
+        },
+        isFDF
+      )
     );
 
   const externalCephClusters =
@@ -128,9 +132,9 @@ export const ExternalSystemsCard: React.FC<CardProps> = ({ className }) => {
       fileSystemsLoaded &&
       !fileSystemsLoadError);
 
-  const isSanConnected = isFDF && sanClustersData.length > 0;
-  const isCnsaConnected =
-    isFDF && !isSanConnected && remoteClustersData.length > 0;
+  const isCnsaConnected = isFDF && remoteClustersData.length > 0;
+  const isSanConnected =
+    isFDF && !isCnsaConnected && sanClustersData.length > 0;
 
   const cnsaFileSystems = filterCnsaFileSystems(fileSystems ?? []);
   const sanLunGroups = filterSANFileSystems(fileSystems ?? []);
@@ -138,17 +142,17 @@ export const ExternalSystemsCard: React.FC<CardProps> = ({ className }) => {
   const connectedRows: ExternalSystemRow[] = [];
 
   if (isFDF && scaleResourcesLoaded) {
-    if (isSanConnected) {
-      connectedRows.push({
-        id: 'san',
-        label: t('Storage Area Network LUN groups'),
-        counts: getSanLunGroupStatusCounts(sanLunGroups),
-      });
-    } else if (isCnsaConnected) {
+    if (isCnsaConnected) {
       connectedRows.push({
         id: 'cnsa',
         label: t('IBM Scale (CNSA) file systems'),
         counts: getCnsaFilesystemStatusCounts(cnsaFileSystems),
+      });
+    } else if (isSanConnected) {
+      connectedRows.push({
+        id: 'san',
+        label: t('Storage Area Network LUN groups'),
+        counts: getSanLunGroupStatusCounts(sanLunGroups),
       });
     }
   }


### PR DESCRIPTION
https://redhat.atlassian.net/browse/DFBUGS-5324

Aligns Overview External systems card with storage systems list logic. RemoteCluster indicates CNSA, otherwise Cluster indicates SAN.

Replaces useK8sWatchResource with useSafeK8sWatchResource for the FileSystem watch. SAN row visibility does not require LUN groups to be present. Related to #2798.