### PR TITLE
Add NooBaa health management and status types

### DIFF
--- a/locales/en/plugin__odf-console.json
+++ b/locales/en/plugin__odf-console.json
@@ -1589,6 +1589,8 @@
   "None (no device class)": "None (no device class)",
   "NooBaa Bucket": "NooBaa Bucket",
   "NooBaa does not automatically delete the OBC if a bucket is deleted. Make sure you delete the corresponding OBC": "NooBaa does not automatically delete the OBC if a bucket is deleted. Make sure you delete the corresponding OBC",
+  "NooBaa is {{phase}}": "NooBaa is {{phase}}",
+  "NooBaa spec rejected": "NooBaa spec rejected",
   "Normal": "Normal",
   "Not Authorized": "Not Authorized",
   "Not available": "Not available",

--- a/locales/en/plugin__odf-console.json
+++ b/locales/en/plugin__odf-console.json
@@ -1709,6 +1709,8 @@
   "None (no device class)": "None (no device class)",
   "NooBaa Bucket": "NooBaa Bucket",
   "NooBaa does not automatically delete the OBC if a bucket is deleted. Make sure you delete the corresponding OBC": "NooBaa does not automatically delete the OBC if a bucket is deleted. Make sure you delete the corresponding OBC",
+  "NooBaa is {{phase}}": "NooBaa is {{phase}}",
+  "NooBaa spec rejected": "NooBaa spec rejected",
   "Normal": "Normal",
   "Not Authorized": "Not Authorized",
   "Not available": "Not available",

--- a/packages/ocs/dashboards/object-service/status-card/status-card.tsx
+++ b/packages/ocs/dashboards/object-service/status-card/status-card.tsx
@@ -3,14 +3,18 @@ import { useODFSystemFlagsSelector } from '@odf/core/redux';
 import { useGetClusterDetails } from '@odf/core/redux/utils';
 import { secretResource } from '@odf/core/resources';
 import { getResourceInNs } from '@odf/core/utils';
-import { decodeRGWPrefix, getDataResiliencyState } from '@odf/ocs/utils';
+import {
+  decodeRGWPrefix,
+  getDataResiliencyState,
+  getNooBaaHealthFromCR,
+} from '@odf/ocs/utils';
 import { CephObjectStoreModel, NooBaaSystemModel } from '@odf/shared';
 import {
   useCustomPrometheusPoll,
   usePrometheusBasePath,
 } from '@odf/shared/hooks/custom-prometheus-poll';
 import useAlerts from '@odf/shared/monitoring/useAlert';
-import { K8sResourceKind } from '@odf/shared/types';
+import { K8sResourceKind, NooBaaKind } from '@odf/shared/types';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import {
   alertURL,
@@ -40,7 +44,7 @@ import {
   ObjectServiceDashboardQuery,
 } from '../../../queries';
 import { ObjectServiceStatus } from './object-service-health';
-import { getNooBaaState, getRGWHealthState } from './statuses';
+import { getRGWHealthState } from './statuses';
 import '../../../style.scss';
 
 const noobaaResource = {
@@ -88,7 +92,7 @@ const StatusCard: React.FC<{}> = () => {
   const [secretData, secretLoaded, secretLoadError] =
     useK8sWatchResource<K8sResourceKind>(secretResource(clusterNs));
   const [noobaas, noobaaLoaded, noobaaLoadError] =
-    useK8sWatchResource<K8sResourceKind[]>(noobaaResource);
+    useK8sWatchResource<NooBaaKind[]>(noobaaResource);
   const [rgws, rgwLoaded, rgwLoadError] = useK8sWatchResource<
     K8sResourceKind[]
   >(cephObjectStoreResource);
@@ -108,11 +112,6 @@ const StatusCard: React.FC<{}> = () => {
     ObjectServiceDashboardQuery.RGW_REBUILD_PROGRESS_QUERY
   ](rgwPrefix, managedByOCS);
 
-  const [healthStatusResult, healthStatusError] = useCustomPrometheusPoll({
-    query: StatusCardQueries.HEALTH_QUERY,
-    endpoint: 'api/v1/query' as any,
-    basePath: usePrometheusBasePath(),
-  });
   const [progressResult, progressError] = useCustomPrometheusPoll({
     query: StatusCardQueries.MCG_REBUILD_PROGRESS_QUERY,
     endpoint: 'api/v1/query' as any,
@@ -124,15 +123,10 @@ const StatusCard: React.FC<{}> = () => {
     basePath: usePrometheusBasePath(),
   });
 
-  const MCGState = getNooBaaState(
-    [{ response: healthStatusResult, error: healthStatusError }],
-    t,
-    {
-      loaded: noobaaLoaded,
-      loadError: noobaaLoadError,
-      data: noobaa,
-    }
-  );
+  const MCGState =
+    !noobaaLoadError && noobaaLoaded
+      ? getNooBaaHealthFromCR(noobaa as NooBaaKind, t)
+      : undefined;
 
   const RGWState =
     !rgwLoadError && rgwLoaded ? getRGWHealthState(rgw) : undefined;

--- a/packages/ocs/hooks/useOcsHealth.spec.ts
+++ b/packages/ocs/hooks/useOcsHealth.spec.ts
@@ -28,7 +28,7 @@ jest.mock('@odf/shared/useCustomTranslationHook', () => ({
 jest.mock('../utils', () => ({
   getCephHealthState: jest.fn(),
   getRGWHealthState: jest.fn(),
-  getNooBaaState: jest.fn(),
+  getNooBaaHealthFromCR: jest.fn(),
 }));
 
 const mockStorageCluster = {
@@ -118,7 +118,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
@@ -149,7 +149,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
@@ -180,7 +180,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.NOT_AVAILABLE,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
@@ -211,7 +211,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.UPDATING,
       });
 
@@ -244,7 +244,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
@@ -275,7 +275,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.ERROR,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
@@ -306,7 +306,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.ERROR,
       });
 
@@ -337,7 +337,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.ERROR,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.ERROR,
       });
 
@@ -368,7 +368,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.ERROR,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.ERROR,
       });
 
@@ -399,7 +399,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
@@ -430,7 +430,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.WARNING,
       });
 
@@ -472,7 +472,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
@@ -519,7 +519,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
@@ -559,18 +559,15 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
       renderHook(() => useGetOCSHealth(mockStorageCluster as any));
 
-      expect(utils.getNooBaaState).toHaveBeenCalledWith(
-        expect.any(Array),
-        expect.any(Function),
-        expect.objectContaining({
-          data: [mockNoobaaSystem, otherNamespaceNoobaa],
-        })
+      expect(utils.getNooBaaHealthFromCR).toHaveBeenCalledWith(
+        mockNoobaaSystem,
+        expect.any(Function)
       );
     });
   });
@@ -595,7 +592,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.NOT_AVAILABLE,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
@@ -632,7 +629,7 @@ describe('useGetOCSHealth', () => {
 
       expect(result.current.healthState).toBe(HealthState.OK);
       expect(result.current.message).toBe('Healthy');
-      expect(utils.getNooBaaState).not.toHaveBeenCalled();
+      expect(utils.getNooBaaHealthFromCR).not.toHaveBeenCalled();
     });
 
     it('handles CephObjectStore not found in namespace (undefined)', () => {
@@ -666,7 +663,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.NOT_AVAILABLE,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
@@ -713,7 +710,7 @@ describe('useGetOCSHealth', () => {
         useGetOCSHealth(mockStorageCluster as any)
       );
 
-      expect(utils.getNooBaaState).not.toHaveBeenCalled();
+      expect(utils.getNooBaaHealthFromCR).not.toHaveBeenCalled();
       expect(result.current.healthState).toBe(HealthState.OK);
     });
   });
@@ -738,7 +735,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
@@ -764,7 +761,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
@@ -795,7 +792,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.NOT_AVAILABLE,
       });
 
@@ -825,7 +822,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.NOT_AVAILABLE,
       });
 
@@ -855,7 +852,7 @@ describe('useGetOCSHealth', () => {
       expect(result.current.message).toBe('Unknown');
       expect(utils.getCephHealthState).not.toHaveBeenCalled();
       expect(utils.getRGWHealthState).not.toHaveBeenCalled();
-      expect(utils.getNooBaaState).not.toHaveBeenCalled();
+      expect(utils.getNooBaaHealthFromCR).not.toHaveBeenCalled();
     });
 
     it('returns UNKNOWN when some resources have network errors and others not loaded', () => {
@@ -937,7 +934,7 @@ describe('useGetOCSHealth', () => {
 
       expect(result.current.healthState).toBe(HealthState.LOADING);
       expect(result.current.message).toBe('Loading');
-      expect(utils.getNooBaaState).not.toHaveBeenCalled();
+      expect(utils.getNooBaaHealthFromCR).not.toHaveBeenCalled();
     });
 
     it('returns LOADING when all resources are not loaded yet', () => {
@@ -959,7 +956,7 @@ describe('useGetOCSHealth', () => {
       expect(result.current.message).toBe('Loading');
       expect(utils.getCephHealthState).not.toHaveBeenCalled();
       expect(utils.getRGWHealthState).not.toHaveBeenCalled();
-      expect(utils.getNooBaaState).not.toHaveBeenCalled();
+      expect(utils.getNooBaaHealthFromCR).not.toHaveBeenCalled();
     });
   });
 
@@ -983,7 +980,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
@@ -1018,7 +1015,7 @@ describe('useGetOCSHealth', () => {
       );
 
       expect(result.current.healthState).toBe(HealthState.OK);
-      expect(utils.getNooBaaState).not.toHaveBeenCalled();
+      expect(utils.getNooBaaHealthFromCR).not.toHaveBeenCalled();
     });
 
     it('handles undefined CephCluster in namespace', () => {
@@ -1040,7 +1037,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
@@ -1073,7 +1070,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.ERROR,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.ERROR,
       });
 
@@ -1104,7 +1101,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
@@ -1135,7 +1132,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.PROGRESS,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
@@ -1166,7 +1163,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.UNKNOWN,
       });
 
@@ -1199,7 +1196,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
@@ -1230,7 +1227,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
@@ -1249,19 +1246,9 @@ describe('useGetOCSHealth', () => {
 
       expect(utils.getRGWHealthState).toHaveBeenCalledWith(mockCephObjectStore);
 
-      expect(utils.getNooBaaState).toHaveBeenCalledWith(
-        [
-          {
-            response: promResponse,
-            error: promError,
-          },
-        ],
-        expect.any(Function),
-        {
-          loaded: true,
-          loadError: null,
-          data: [mockNoobaaSystem],
-        }
+      expect(utils.getNooBaaHealthFromCR).toHaveBeenCalledWith(
+        mockNoobaaSystem,
+        expect.any(Function)
       );
     });
   });
@@ -1302,7 +1289,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
@@ -1347,7 +1334,7 @@ describe('useGetOCSHealth', () => {
           state,
         });
 
-        (utils.getNooBaaState as jest.Mock).mockReturnValue({
+        (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
           state,
         });
 

--- a/packages/ocs/hooks/useOcsHealth.spec.ts
+++ b/packages/ocs/hooks/useOcsHealth.spec.ts
@@ -28,7 +28,7 @@ jest.mock('@odf/shared/useCustomTranslationHook', () => ({
 jest.mock('../utils', () => ({
   getCephHealthState: jest.fn(),
   getRGWHealthState: jest.fn(),
-  getNooBaaState: jest.fn(),
+  getNooBaaHealthFromCR: jest.fn(),
 }));
 
 const mockStorageCluster = {
@@ -118,7 +118,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
@@ -149,7 +149,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
@@ -180,7 +180,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.NOT_AVAILABLE,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
@@ -211,7 +211,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.UPDATING,
       });
 
@@ -244,7 +244,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
@@ -275,7 +275,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.ERROR,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
@@ -306,7 +306,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.ERROR,
       });
 
@@ -337,7 +337,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.ERROR,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.ERROR,
       });
 
@@ -368,7 +368,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.ERROR,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.ERROR,
       });
 
@@ -399,7 +399,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
@@ -430,7 +430,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.WARNING,
       });
 
@@ -472,7 +472,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
@@ -519,7 +519,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
@@ -559,18 +559,15 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
       renderHook(() => useGetOCSHealth(mockStorageCluster as any));
 
-      expect(utils.getNooBaaState).toHaveBeenCalledWith(
-        expect.any(Array),
-        expect.any(Function),
-        expect.objectContaining({
-          data: [mockNoobaaSystem, otherNamespaceNoobaa],
-        })
+      expect(utils.getNooBaaHealthFromCR).toHaveBeenCalledWith(
+        mockNoobaaSystem,
+        expect.any(Function)
       );
     });
   });
@@ -595,7 +592,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.NOT_AVAILABLE,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
@@ -632,7 +629,7 @@ describe('useGetOCSHealth', () => {
 
       expect(result.current.healthState).toBe(HealthState.OK);
       expect(result.current.message).toBe('Healthy');
-      expect(utils.getNooBaaState).not.toHaveBeenCalled();
+      expect(utils.getNooBaaHealthFromCR).not.toHaveBeenCalled();
     });
 
     it('handles CephObjectStore not found in namespace (undefined)', () => {
@@ -666,7 +663,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.NOT_AVAILABLE,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
@@ -713,7 +710,7 @@ describe('useGetOCSHealth', () => {
         useGetOCSHealth(mockStorageCluster as any)
       );
 
-      expect(utils.getNooBaaState).not.toHaveBeenCalled();
+      expect(utils.getNooBaaHealthFromCR).not.toHaveBeenCalled();
       expect(result.current.healthState).toBe(HealthState.OK);
     });
   });
@@ -738,7 +735,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
@@ -764,7 +761,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
@@ -795,7 +792,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.NOT_AVAILABLE,
       });
 
@@ -825,7 +822,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.NOT_AVAILABLE,
       });
 
@@ -855,7 +852,7 @@ describe('useGetOCSHealth', () => {
       expect(result.current.message).toBe('Unknown');
       expect(utils.getCephHealthState).not.toHaveBeenCalled();
       expect(utils.getRGWHealthState).not.toHaveBeenCalled();
-      expect(utils.getNooBaaState).not.toHaveBeenCalled();
+      expect(utils.getNooBaaHealthFromCR).not.toHaveBeenCalled();
     });
 
     it('returns UNKNOWN when some resources have network errors and others not loaded', () => {
@@ -937,7 +934,7 @@ describe('useGetOCSHealth', () => {
 
       expect(result.current.healthState).toBe(HealthState.LOADING);
       expect(result.current.message).toBe('Loading');
-      expect(utils.getNooBaaState).not.toHaveBeenCalled();
+      expect(utils.getNooBaaHealthFromCR).not.toHaveBeenCalled();
     });
 
     it('returns LOADING when all resources are not loaded yet', () => {
@@ -959,7 +956,7 @@ describe('useGetOCSHealth', () => {
       expect(result.current.message).toBe('Loading');
       expect(utils.getCephHealthState).not.toHaveBeenCalled();
       expect(utils.getRGWHealthState).not.toHaveBeenCalled();
-      expect(utils.getNooBaaState).not.toHaveBeenCalled();
+      expect(utils.getNooBaaHealthFromCR).not.toHaveBeenCalled();
     });
   });
 
@@ -983,7 +980,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
@@ -1018,7 +1015,7 @@ describe('useGetOCSHealth', () => {
       );
 
       expect(result.current.healthState).toBe(HealthState.OK);
-      expect(utils.getNooBaaState).not.toHaveBeenCalled();
+      expect(utils.getNooBaaHealthFromCR).not.toHaveBeenCalled();
     });
 
     it('handles undefined CephCluster in namespace', () => {
@@ -1040,7 +1037,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
@@ -1073,7 +1070,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.ERROR,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.ERROR,
       });
 
@@ -1104,7 +1101,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
@@ -1116,7 +1113,7 @@ describe('useGetOCSHealth', () => {
       expect(result.current.message).toBe('Unhealthy');
     });
 
-    it('handles PROGRESS state for RGW (unacceptable)', () => {
+    it('handles PROGRESS state for RGW (acceptable)', () => {
       (useK8sWatchResource as jest.Mock)
         .mockReturnValueOnce([[mockCephCluster], true, null])
         .mockReturnValueOnce([[mockCephObjectStore], true, null])
@@ -1135,7 +1132,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.PROGRESS,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
@@ -1143,8 +1140,8 @@ describe('useGetOCSHealth', () => {
         useGetOCSHealth(mockStorageCluster as any)
       );
 
-      expect(result.current.healthState).toBe(HealthState.ERROR);
-      expect(result.current.message).toBe('Unhealthy');
+      expect(result.current.healthState).toBe(HealthState.OK);
+      expect(result.current.message).toBe('Healthy');
     });
 
     it('handles UNKNOWN state for MCG (unacceptable)', () => {
@@ -1166,7 +1163,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.UNKNOWN,
       });
 
@@ -1199,7 +1196,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
@@ -1230,7 +1227,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
@@ -1249,19 +1246,9 @@ describe('useGetOCSHealth', () => {
 
       expect(utils.getRGWHealthState).toHaveBeenCalledWith(mockCephObjectStore);
 
-      expect(utils.getNooBaaState).toHaveBeenCalledWith(
-        [
-          {
-            response: promResponse,
-            error: promError,
-          },
-        ],
-        expect.any(Function),
-        {
-          loaded: true,
-          loadError: null,
-          data: [mockNoobaaSystem],
-        }
+      expect(utils.getNooBaaHealthFromCR).toHaveBeenCalledWith(
+        mockNoobaaSystem,
+        expect.any(Function)
       );
     });
   });
@@ -1302,7 +1289,7 @@ describe('useGetOCSHealth', () => {
         state: HealthState.OK,
       });
 
-      (utils.getNooBaaState as jest.Mock).mockReturnValue({
+      (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
         state: HealthState.OK,
       });
 
@@ -1324,6 +1311,7 @@ describe('useGetOCSHealth', () => {
       HealthState.OK,
       HealthState.LOADING,
       HealthState.UPDATING,
+      HealthState.PROGRESS,
       HealthState.NOT_AVAILABLE,
     ];
 
@@ -1347,7 +1335,7 @@ describe('useGetOCSHealth', () => {
           state,
         });
 
-        (utils.getNooBaaState as jest.Mock).mockReturnValue({
+        (utils.getNooBaaHealthFromCR as jest.Mock).mockReturnValue({
           state,
         });
 

--- a/packages/ocs/hooks/useOcsHealth.ts
+++ b/packages/ocs/hooks/useOcsHealth.ts
@@ -4,10 +4,6 @@ import {
   NooBaaSystemModel,
   StorageClusterKind,
 } from '@odf/shared';
-import {
-  useCustomPrometheusPoll,
-  usePrometheusBasePath,
-} from '@odf/shared/hooks/custom-prometheus-poll';
 import { CephClusterModel } from '@odf/shared/models';
 import { getNamespace } from '@odf/shared/selectors';
 import { K8sResourceKind } from '@odf/shared/types';
@@ -19,10 +15,10 @@ import {
   WatchK8sResource,
 } from '@openshift-console/dynamic-plugin-sdk';
 import * as _ from 'lodash-es';
-import { Health, HEALTH_QUERY } from '../queries';
+import { NooBaaKind } from '../types';
 import {
   getCephHealthState,
-  getNooBaaState,
+  getNooBaaHealthFromCR,
   getRGWHealthState,
 } from '../utils';
 
@@ -61,13 +57,7 @@ export const useGetOCSHealth: UseGetOCSHealth = (storageCluster) => {
     K8sResourceKind[]
   >(cephObjectStoreResource);
   const [noobaaData, noobaaLoaded, noobaaLoadError] =
-    useK8sWatchResource<K8sResourceKind[]>(noobaaResource);
-
-  const [noobaaHealthStatus, noobaaQueryLoadError] = useCustomPrometheusPoll({
-    query: HEALTH_QUERY[Health.NOOBAA],
-    endpoint: 'api/v1/query' as any,
-    basePath: usePrometheusBasePath(),
-  });
+    useK8sWatchResource<NooBaaKind[]>(noobaaResource);
 
   return React.useMemo(() => {
     // Check if any required resources are still loading (not loaded and no error)
@@ -116,7 +106,7 @@ export const useGetOCSHealth: UseGetOCSHealth = (storageCluster) => {
     const cephObjectStore = cephObjData?.find(
       (cephObj) => getNamespace(cephObj) === systemNamespace
     );
-    const noobaaCluster = noobaaData?.find(
+    const noobaaCluster: NooBaaKind | undefined = noobaaData?.find(
       (noobaa) => getNamespace(noobaa) === systemNamespace
     );
 
@@ -138,21 +128,9 @@ export const useGetOCSHealth: UseGetOCSHealth = (storageCluster) => {
 
     // there will only be single NooBaa instance (even for multiple StorageSystems)
     // and its status should only be linked with the corresponding StorageSystem/StorageCluster.
+    // Use NooBaa CR status.phase field instead of Prometheus metrics for accurate health state
     const interimMCGState = !_.isEmpty(noobaaCluster)
-      ? getNooBaaState(
-          [
-            {
-              response: noobaaHealthStatus,
-              error: noobaaQueryLoadError,
-            },
-          ],
-          t,
-          {
-            loaded: noobaaLoaded,
-            loadError: noobaaLoadError,
-            data: noobaaData,
-          }
-        ).state
+      ? getNooBaaHealthFromCR(noobaaCluster, t).state
       : NA;
 
     const mcgState = AcceptableHealthStates.includes(interimMCGState)
@@ -206,10 +184,8 @@ export const useGetOCSHealth: UseGetOCSHealth = (storageCluster) => {
     cephObjLoadError,
     cephObjLoaded,
     noobaaData,
-    noobaaHealthStatus,
     noobaaLoadError,
     noobaaLoaded,
-    noobaaQueryLoadError,
     storageCluster,
     t,
   ]);

--- a/packages/ocs/hooks/useOcsHealth.ts
+++ b/packages/ocs/hooks/useOcsHealth.ts
@@ -4,13 +4,9 @@ import {
   NooBaaSystemModel,
   StorageClusterKind,
 } from '@odf/shared';
-import {
-  useCustomPrometheusPoll,
-  usePrometheusBasePath,
-} from '@odf/shared/hooks/custom-prometheus-poll';
 import { CephClusterModel } from '@odf/shared/models';
 import { getNamespace } from '@odf/shared/selectors';
-import { K8sResourceKind } from '@odf/shared/types';
+import { K8sResourceKind, NooBaaKind } from '@odf/shared/types';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { referenceForModel } from '@odf/shared/utils';
 import {
@@ -18,11 +14,12 @@ import {
   useK8sWatchResource,
   WatchK8sResource,
 } from '@openshift-console/dynamic-plugin-sdk';
+import { SubsystemHealth } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/dashboard-types';
+import { TFunction } from 'i18next';
 import * as _ from 'lodash-es';
-import { Health, HEALTH_QUERY } from '../queries';
 import {
   getCephHealthState,
-  getNooBaaState,
+  getNooBaaHealthFromCR,
   getRGWHealthState,
 } from '../utils';
 
@@ -41,18 +38,115 @@ const noobaaResource: WatchK8sResource = {
   isList: true,
 };
 
-// Not applicable
-const NA = 'N/A';
-
 const AcceptableHealthStates = [
   HealthState.OK,
   HealthState.LOADING,
   HealthState.UPDATING,
+  HealthState.PROGRESS,
   HealthState.NOT_AVAILABLE,
-  NA,
 ];
 
-export const useGetOCSHealth: UseGetOCSHealth = (storageCluster) => {
+export type OCSHealthResult = {
+  healthState: HealthState;
+  message: string;
+  mcgHealth: SubsystemHealth;
+};
+
+type ResourceData<T> = {
+  data: T[];
+  loaded: boolean;
+  loadError: unknown;
+};
+
+export const computeOCSHealth = (
+  storageCluster: StorageClusterKind,
+  ceph: ResourceData<K8sResourceKind>,
+  cephObj: ResourceData<K8sResourceKind>,
+  noobaa: ResourceData<NooBaaKind>,
+  t: TFunction
+): OCSHealthResult => {
+  const isLoading =
+    (!ceph.loaded && !ceph.loadError) ||
+    (!cephObj.loaded && !cephObj.loadError) ||
+    (!noobaa.loaded && !noobaa.loadError);
+
+  if (isLoading) {
+    return {
+      healthState: HealthState.LOADING,
+      message: t('Loading'),
+      mcgHealth: { state: HealthState.LOADING },
+    };
+  }
+
+  const allResourcesErrored =
+    (ceph.loadError || !ceph.loaded) &&
+    (cephObj.loadError || !cephObj.loaded) &&
+    (noobaa.loadError || !noobaa.loaded);
+
+  if (
+    allResourcesErrored &&
+    (ceph.loadError || cephObj.loadError || noobaa.loadError)
+  ) {
+    return {
+      healthState: HealthState.UNKNOWN,
+      message: t('Unknown'),
+      mcgHealth: { state: HealthState.UNKNOWN },
+    };
+  }
+
+  const systemNamespace = getNamespace(storageCluster);
+  const cephCluster = ceph.data?.find(
+    (c) => getNamespace(c) === systemNamespace
+  );
+  const cephObjectStore = cephObj.data?.find(
+    (o) => getNamespace(o) === systemNamespace
+  );
+  const noobaaCluster = noobaa.data?.find(
+    (n) => getNamespace(n) === systemNamespace
+  );
+
+  const cephHealthState = getCephHealthState(
+    {
+      ceph: {
+        data: cephCluster,
+        loaded: ceph.loaded,
+        loadError: ceph.loadError,
+      },
+    },
+    t
+  ).state;
+
+  const interimRGWState =
+    !cephObj.loadError && cephObj.loaded
+      ? getRGWHealthState(cephObjectStore).state
+      : HealthState.NOT_AVAILABLE;
+
+  const mcgSubsystemHealth: SubsystemHealth = !_.isEmpty(noobaaCluster)
+    ? getNooBaaHealthFromCR(noobaaCluster, t)
+    : { state: HealthState.NOT_AVAILABLE };
+
+  const mcgState = AcceptableHealthStates.includes(mcgSubsystemHealth.state)
+    ? HealthState.OK
+    : HealthState.ERROR;
+
+  const rgwState = AcceptableHealthStates.includes(interimRGWState)
+    ? HealthState.OK
+    : HealthState.ERROR;
+
+  const blockFileOk = AcceptableHealthStates.includes(cephHealthState);
+  const objectOk =
+    mcgState !== HealthState.ERROR && rgwState !== HealthState.ERROR;
+
+  return {
+    healthState: blockFileOk && objectOk ? HealthState.OK : HealthState.ERROR,
+    message: blockFileOk && objectOk ? t('Healthy') : t('Unhealthy'),
+    mcgHealth: mcgSubsystemHealth,
+  };
+};
+
+export const useGetOCSHealth = (
+  storageCluster: StorageClusterKind
+): OCSHealthResult => {
   const { t } = useCustomTranslation();
 
   const [cephData, cephLoaded, cephLoadError] =
@@ -61,163 +155,33 @@ export const useGetOCSHealth: UseGetOCSHealth = (storageCluster) => {
     K8sResourceKind[]
   >(cephObjectStoreResource);
   const [noobaaData, noobaaLoaded, noobaaLoadError] =
-    useK8sWatchResource<K8sResourceKind[]>(noobaaResource);
+    useK8sWatchResource<NooBaaKind[]>(noobaaResource);
 
-  const [noobaaHealthStatus, noobaaQueryLoadError] = useCustomPrometheusPoll({
-    query: HEALTH_QUERY[Health.NOOBAA],
-    endpoint: 'api/v1/query' as any,
-    basePath: usePrometheusBasePath(),
-  });
-
-  return React.useMemo(() => {
-    // Check if any required resources are still loading (not loaded and no error)
-    const isLoading =
-      (!cephLoaded && !cephLoadError) ||
-      (!cephObjLoaded && !cephObjLoadError) ||
-      (!noobaaLoaded && !noobaaLoadError);
-
-    if (isLoading) {
-      return {
-        healthState: HealthState.LOADING,
-        message: t('Loading'),
-      };
-    }
-
-    // Check if all resources failed to load (network errors)
-    const allResourcesErrored =
-      (cephLoadError || !cephLoaded) &&
-      (cephObjLoadError || !cephObjLoaded) &&
-      (noobaaLoadError || !noobaaLoaded);
-
-    if (
-      allResourcesErrored &&
-      (cephLoadError || cephObjLoadError || noobaaLoadError)
-    ) {
-      return {
-        healthState: HealthState.UNKNOWN,
-        message: t('Unknown'),
-      };
-    }
-
-    let blockFileHealthState: SubsystemHealth = {
-      healthState: HealthState.UNKNOWN,
-      message: t('Unknown'),
-    };
-
-    let objectHealthState: SubsystemHealth = {
-      healthState: HealthState.UNKNOWN,
-      message: t('Unknown'),
-    };
-
-    const systemNamespace = getNamespace(storageCluster);
-    const cephCluster = cephData?.find(
-      (ceph) => getNamespace(ceph) === systemNamespace
-    );
-    const cephObjectStore = cephObjData?.find(
-      (cephObj) => getNamespace(cephObj) === systemNamespace
-    );
-    const noobaaCluster = noobaaData?.find(
-      (noobaa) => getNamespace(noobaa) === systemNamespace
-    );
-
-    const cephHealthState = getCephHealthState(
-      {
-        ceph: {
-          data: cephCluster,
-          loaded: cephLoaded,
-          loadError: cephLoadError,
+  return React.useMemo(
+    () =>
+      computeOCSHealth(
+        storageCluster,
+        { data: cephData, loaded: cephLoaded, loadError: cephLoadError },
+        {
+          data: cephObjData,
+          loaded: cephObjLoaded,
+          loadError: cephObjLoadError,
         },
-      },
-      t
-    ).state;
-
-    const interimRGWState =
-      !cephObjLoadError && cephObjLoaded
-        ? getRGWHealthState(cephObjectStore).state
-        : NA;
-
-    // there will only be single NooBaa instance (even for multiple StorageSystems)
-    // and its status should only be linked with the corresponding StorageSystem/StorageCluster.
-    const interimMCGState = !_.isEmpty(noobaaCluster)
-      ? getNooBaaState(
-          [
-            {
-              response: noobaaHealthStatus,
-              error: noobaaQueryLoadError,
-            },
-          ],
-          t,
-          {
-            loaded: noobaaLoaded,
-            loadError: noobaaLoadError,
-            data: noobaaData,
-          }
-        ).state
-      : NA;
-
-    const mcgState = AcceptableHealthStates.includes(interimMCGState)
-      ? HealthState.OK
-      : HealthState.ERROR;
-
-    const rgwState = AcceptableHealthStates.includes(interimRGWState)
-      ? HealthState.OK
-      : HealthState.ERROR;
-
-    blockFileHealthState.healthState = AcceptableHealthStates.includes(
-      cephHealthState
-    )
-      ? HealthState.OK
-      : HealthState.ERROR;
-    blockFileHealthState.message = AcceptableHealthStates.includes(
-      cephHealthState
-    )
-      ? t('Healthy')
-      : t('Unhealthy');
-
-    objectHealthState.healthState =
-      mcgState === HealthState.ERROR || rgwState === HealthState.ERROR
-        ? HealthState.ERROR
-        : HealthState.OK;
-    objectHealthState.message =
-      mcgState === HealthState.ERROR || rgwState === HealthState.ERROR
-        ? t('Unhealthy')
-        : t('Healthy');
-
-    const unifiedHealthMessage =
-      blockFileHealthState.healthState === HealthState.OK &&
-      objectHealthState.healthState === HealthState.OK
-        ? t('Healthy')
-        : t('Unhealthy');
-
-    const unifiedHealthStates = {
-      healthState:
-        blockFileHealthState.healthState === HealthState.OK &&
-        objectHealthState.healthState === HealthState.OK
-          ? HealthState.OK
-          : HealthState.ERROR,
-      message: unifiedHealthMessage,
-    };
-    return unifiedHealthStates;
-  }, [
-    cephData,
-    cephLoadError,
-    cephLoaded,
-    cephObjData,
-    cephObjLoadError,
-    cephObjLoaded,
-    noobaaData,
-    noobaaHealthStatus,
-    noobaaLoadError,
-    noobaaLoaded,
-    noobaaQueryLoadError,
-    storageCluster,
-    t,
-  ]);
+        { data: noobaaData, loaded: noobaaLoaded, loadError: noobaaLoadError },
+        t
+      ),
+    [
+      cephData,
+      cephLoadError,
+      cephLoaded,
+      cephObjData,
+      cephObjLoadError,
+      cephObjLoaded,
+      noobaaData,
+      noobaaLoadError,
+      noobaaLoaded,
+      storageCluster,
+      t,
+    ]
+  );
 };
-
-type SubsystemHealth = {
-  healthState: HealthState;
-  message: string;
-};
-
-type UseGetOCSHealth = (system: StorageClusterKind) => SubsystemHealth;

--- a/packages/ocs/types.ts
+++ b/packages/ocs/types.ts
@@ -77,3 +77,50 @@ export type CephBlockPoolRadosNamespaceKind = K8sResourceCommon & {
 
 // Pool utilization metrics - mapping of pool name to value
 export type PoolMetrics = { [poolName: string]: string };
+
+export enum NooBaaSystemPhase {
+  Rejected = 'Rejected',
+  Verifying = 'Verifying',
+  Creating = 'Creating',
+  Connecting = 'Connecting',
+  Configuring = 'Configuring',
+  Ready = 'Ready',
+}
+
+export type NooBaaStatus = {
+  observedGeneration?: number;
+  phase?: NooBaaSystemPhase;
+  conditions?: Array<{
+    type: string;
+    status: string;
+    reason?: string;
+    message?: string;
+    lastTransitionTime?: string;
+  }>;
+  relatedObjects?: K8sResourceCommon[];
+  actualImage?: string;
+  upgradePhase?: string;
+  postgresUpdatePhase?: string;
+  readme?: string;
+  lastKeyRotateTime?: string;
+  beforeUpgradeDbImage?: string;
+  accounts?: {
+    admin: {
+      secretRef: {
+        name: string;
+        namespace: string;
+      };
+    };
+  };
+  services?: Record<string, unknown>;
+  endpoints?: {
+    readyCount: number;
+    virtualHosts: string[];
+  };
+  dbStatus?: Record<string, unknown>;
+};
+
+export type NooBaaKind = K8sResourceCommon & {
+  spec?: Record<string, unknown>;
+  status?: NooBaaStatus;
+};

--- a/packages/ocs/utils/noobaa-health.ts
+++ b/packages/ocs/utils/noobaa-health.ts
@@ -6,6 +6,7 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import { SubsystemHealth } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/dashboard-types';
 import { TFunction } from 'react-i18next';
+import { NooBaaKind, NooBaaSystemPhase } from '../types';
 
 const parseNoobaaStatus = (status: string, t: TFunction): SubsystemHealth => {
   switch (status) {
@@ -30,6 +31,44 @@ const parseNoobaaStatus = (status: string, t: TFunction): SubsystemHealth => {
       return {
         state: HealthState.WARNING,
         message: t('plugin__odf-console~Some buckets have issues'),
+      };
+    default:
+      return { state: HealthState.UNKNOWN };
+  }
+};
+
+/**
+ * Get NooBaa health state from CR status.phase field
+ * Maps NooBaa SystemPhase to HealthState according to:
+ * - Rejected → ERROR (red)
+ * - Verifying, Creating, Connecting, Configuring → PROGRESS (yellow)
+ * - Ready → OK (green)
+ */
+export const getNooBaaHealthFromCR = (
+  noobaa: NooBaaKind | undefined,
+  t: TFunction
+): SubsystemHealth => {
+  const phase = noobaa?.status?.phase;
+
+  if (!phase) {
+    return { state: HealthState.UNKNOWN };
+  }
+
+  switch (phase) {
+    case NooBaaSystemPhase.Ready:
+      return { state: HealthState.OK };
+    case NooBaaSystemPhase.Rejected:
+      return {
+        state: HealthState.ERROR,
+        message: t('plugin__odf-console~NooBaa spec rejected'),
+      };
+    case NooBaaSystemPhase.Verifying:
+    case NooBaaSystemPhase.Creating:
+    case NooBaaSystemPhase.Connecting:
+    case NooBaaSystemPhase.Configuring:
+      return {
+        state: HealthState.PROGRESS,
+        message: t('plugin__odf-console~NooBaa is {{phase}}', { phase }),
       };
     default:
       return { state: HealthState.UNKNOWN };

--- a/packages/ocs/utils/noobaa-health.ts
+++ b/packages/ocs/utils/noobaa-health.ts
@@ -1,4 +1,8 @@
-import { PrometheusHealthHandler } from '@odf/shared/types';
+import {
+  NooBaaKind,
+  NooBaaSystemPhase,
+  PrometheusHealthHandler,
+} from '@odf/shared/types';
 import { getGaugeValue } from '@odf/shared/utils';
 import {
   HealthState,
@@ -30,6 +34,44 @@ const parseNoobaaStatus = (status: string, t: TFunction): SubsystemHealth => {
       return {
         state: HealthState.WARNING,
         message: t('plugin__odf-console~Some buckets have issues'),
+      };
+    default:
+      return { state: HealthState.UNKNOWN };
+  }
+};
+
+/**
+ * Get NooBaa health state from CR status.phase field
+ * Maps NooBaa SystemPhase to HealthState according to:
+ * - Rejected → ERROR (red)
+ * - Verifying, Creating, Connecting, Configuring → PROGRESS (yellow)
+ * - Ready → OK (green)
+ */
+export const getNooBaaHealthFromCR = (
+  noobaa: NooBaaKind | undefined,
+  t: TFunction
+): SubsystemHealth => {
+  const phase = noobaa?.status?.phase;
+
+  if (!phase) {
+    return { state: HealthState.UNKNOWN };
+  }
+
+  switch (phase) {
+    case NooBaaSystemPhase.Ready:
+      return { state: HealthState.OK };
+    case NooBaaSystemPhase.Rejected:
+      return {
+        state: HealthState.ERROR,
+        message: t('plugin__odf-console~NooBaa spec rejected'),
+      };
+    case NooBaaSystemPhase.Verifying:
+    case NooBaaSystemPhase.Creating:
+    case NooBaaSystemPhase.Connecting:
+    case NooBaaSystemPhase.Configuring:
+      return {
+        state: HealthState.PROGRESS,
+        message: t('plugin__odf-console~NooBaa is {{phase}}', { phase }),
       };
     default:
       return { state: HealthState.UNKNOWN };

--- a/packages/odf/components/cluster-overview-extensions/HealthOverview.tsx
+++ b/packages/odf/components/cluster-overview-extensions/HealthOverview.tsx
@@ -1,76 +1,88 @@
 import * as React from 'react';
-import { getNooBaaState } from '@odf/ocs/dashboards/object-service/status-card/statuses';
-import { getCephsHealthState } from '@odf/ocs/utils';
+import { useODFNamespaceSelector } from '@odf/core/redux/selectors';
+import { storageClusterResource } from '@odf/core/resources';
+import { getStorageClusterInNs, isClusterIgnored } from '@odf/core/utils';
+import { computeOCSHealth, useGetOCSHealth } from '@odf/ocs/hooks/useOcsHealth';
 import { healthStateMapping } from '@odf/shared/dashboards';
-import { CephClusterModel } from '@odf/shared/models';
-import { PrometheusHealthHandler } from '@odf/shared/types';
+import {
+  CephClusterModel,
+  CephObjectStoreModel,
+  NooBaaSystemModel,
+  StorageClusterModel,
+} from '@odf/shared/models';
+import {
+  K8sResourceKind,
+  NooBaaKind,
+  StorageClusterKind,
+} from '@odf/shared/types';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { referenceForModel } from '@odf/shared/utils';
 import {
   StatusPopupSection,
-  HealthState,
-  SubsystemHealth,
-  PrometheusHealthPopupProps,
-  FirehoseResource,
-  K8sResourceCommon,
+  useK8sWatchResource,
+  WatchK8sResource,
 } from '@openshift-console/dynamic-plugin-sdk';
-import * as _ from 'lodash-es';
+import { ResourceHealthHandler } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/dashboard-types';
 import { Link } from 'react-router';
 import { Stack, StackItem } from '@patternfly/react-core';
 import '@odf/shared/popup/status-popup.scss';
 
-export const getStorageSystemHealthState: PrometheusHealthHandler = (
-  promMetrics,
-  t,
-  ceph
-) => {
-  const isNoobaaOnly = _.isEmpty(ceph?.data);
-  if (!isNoobaaOnly) {
-    return getCephsHealthState(
-      {
-        ceph: {
-          data: ceph.data as K8sResourceCommon[],
-          loaded: ceph.loaded,
-          loadError: ceph.loadError,
-        },
-      },
-      t
-    );
-  } else {
-    return getNooBaaState(promMetrics, t, {
-      loaded: true,
-      loadError: '',
-      data: {},
-    });
-  }
+type StorageHealthResources = {
+  storageClusters: StorageClusterKind[];
+  ceph: K8sResourceKind[];
+  noobaa: NooBaaKind[];
+  cephObjectStore: K8sResourceKind[];
 };
 
-export const StoragePopover: React.FC<PrometheusHealthPopupProps> = ({
-  responses,
-  k8sResult,
-}) => {
-  const { t } = useCustomTranslation();
+export const healthResources: {
+  [k in keyof StorageHealthResources]: WatchK8sResource;
+} = {
+  storageClusters: {
+    kind: referenceForModel(StorageClusterModel),
+    isList: true,
+  },
+  ceph: {
+    kind: referenceForModel(CephClusterModel),
+    isList: true,
+  },
+  noobaa: {
+    kind: referenceForModel(NooBaaSystemModel),
+    isList: true,
+  },
+  cephObjectStore: {
+    kind: referenceForModel(CephObjectStoreModel),
+    isList: true,
+  },
+};
 
-  const noobaaHealth = getNooBaaState(responses, t, {
-    loaded: true,
-    loadError: '',
-    data: {},
-  });
-  const cephData = k8sResult?.data;
-  const isNoobaaOnly = _.isEmpty(cephData);
-  const cephHealthState: SubsystemHealth = getCephsHealthState(
-    {
-      ceph: {
-        data: cephData as K8sResourceCommon[],
-        loaded: k8sResult?.loaded,
-        loadError: k8sResult?.loadError,
-      },
-    },
+export const getStorageSystemHealthState: ResourceHealthHandler<
+  StorageHealthResources
+> = (resourcesResult, t) => {
+  const storageCluster = (
+    resourcesResult.storageClusters?.data as StorageClusterKind[]
+  )?.find((sc) => !isClusterIgnored(sc));
+
+  const { healthState, message } = computeOCSHealth(
+    storageCluster,
+    resourcesResult.ceph,
+    resourcesResult.cephObjectStore,
+    resourcesResult.noobaa,
     t
   );
-  const healthStatus: HealthState = isNoobaaOnly
-    ? noobaaHealth?.state
-    : cephHealthState?.state;
+
+  return { state: healthState, message };
+};
+
+export const StoragePopover: React.FC = () => {
+  const { t } = useCustomTranslation();
+  const { odfNamespace } = useODFNamespaceSelector();
+
+  const [storageClusters] = useK8sWatchResource<StorageClusterKind[]>(
+    storageClusterResource
+  );
+  const storageCluster = getStorageClusterInNs(storageClusters, odfNamespace);
+
+  const { healthState } = useGetOCSHealth(storageCluster);
   const operatorName = t('Data Foundation');
 
   return (
@@ -87,7 +99,7 @@ export const StoragePopover: React.FC<PrometheusHealthPopupProps> = ({
         >
           <div className="odf-status-popup__row">
             <Link to="/odf/overview">{operatorName}</Link>
-            {healthStateMapping[healthStatus]?.icon}
+            {healthStateMapping[healthState]?.icon}
           </div>
         </StatusPopupSection>
       </StackItem>
@@ -96,10 +108,3 @@ export const StoragePopover: React.FC<PrometheusHealthPopupProps> = ({
 };
 
 export { getStorageSystemHealthState as healthHandler };
-
-export const healthResource: FirehoseResource = {
-  kind: referenceForModel(CephClusterModel),
-  namespaced: false,
-  isList: true,
-  prop: 'ceph',
-};

--- a/packages/odf/components/overview/storage-cluster-card/StorageClusterCard.spec.tsx
+++ b/packages/odf/components/overview/storage-cluster-card/StorageClusterCard.spec.tsx
@@ -34,6 +34,7 @@ jest.mock('@odf/core/utils', () => ({
       (cluster) => cluster?.metadata?.namespace === namespace
     );
   }),
+  isExternalCluster: jest.fn(() => false),
 }));
 
 jest.mock('@odf/ocs/queries', () => ({
@@ -104,6 +105,9 @@ jest.mock('@odf/shared/useCustomTranslationHook', () => ({
 }));
 
 jest.mock('@odf/shared/utils', () => ({
+  referenceForModel: jest.fn(
+    (model) => `${model?.apiGroup}~${model?.apiVersion}~${model?.kind}`
+  ),
   getOprChannelFromSub: jest.fn((sub) => sub?.spec?.channel || DASH),
   getOprVersionFromCSV: jest.fn((csv) => csv?.spec?.version || DASH),
   getStorageClusterMetric: jest.fn((metric) => {
@@ -146,6 +150,7 @@ jest.mock('@odf/ocs/hooks/useOcsHealth', () => ({
 
 jest.mock('@odf/ocs/utils', () => ({
   getDataResiliencyState: jest.fn(),
+  getNooBaaHealthFromCR: jest.fn(() => ({ state: 'OK' })),
 }));
 
 const mockStorageCluster = {

--- a/packages/odf/components/overview/storage-cluster-card/StorageClusterCard.spec.tsx
+++ b/packages/odf/components/overview/storage-cluster-card/StorageClusterCard.spec.tsx
@@ -34,6 +34,7 @@ jest.mock('@odf/core/utils', () => ({
       (cluster) => cluster?.metadata?.namespace === namespace
     );
   }),
+  isExternalCluster: jest.fn(() => false),
 }));
 
 jest.mock('@odf/ocs/queries', () => ({
@@ -104,6 +105,9 @@ jest.mock('@odf/shared/useCustomTranslationHook', () => ({
 }));
 
 jest.mock('@odf/shared/utils', () => ({
+  referenceForModel: jest.fn(
+    (model) => `${model?.apiGroup}~${model?.apiVersion}~${model?.kind}`
+  ),
   getOprChannelFromSub: jest.fn((sub) => sub?.spec?.channel || DASH),
   getOprVersionFromCSV: jest.fn((csv) => csv?.spec?.version || DASH),
   getStorageClusterMetric: jest.fn((metric) => {
@@ -146,6 +150,7 @@ jest.mock('@odf/ocs/hooks/useOcsHealth', () => ({
 
 jest.mock('@odf/ocs/utils', () => ({
   getDataResiliencyState: jest.fn(),
+  getNooBaaHealthFromCR: jest.fn(() => ({ state: 'OK' })),
 }));
 
 const mockStorageCluster = {
@@ -232,6 +237,7 @@ describe('StorageClusterCard', () => {
     (useGetOCSHealth as jest.Mock).mockReturnValue({
       healthState: HealthState.OK,
       message: 'Healthy',
+      mcgHealth: { state: HealthState.OK },
     });
 
     (useRawCapacity as jest.Mock).mockReturnValue([
@@ -345,6 +351,7 @@ describe('StorageClusterCard', () => {
       (useGetOCSHealth as jest.Mock).mockReturnValue({
         healthState: HealthState.OK,
         message: 'Healthy',
+        mcgHealth: { state: HealthState.OK },
       });
 
       render(
@@ -362,6 +369,7 @@ describe('StorageClusterCard', () => {
       (useGetOCSHealth as jest.Mock).mockReturnValue({
         healthState: HealthState.WARNING,
         message: 'Warning',
+        mcgHealth: { state: HealthState.WARNING },
       });
 
       render(
@@ -377,6 +385,7 @@ describe('StorageClusterCard', () => {
       (useGetOCSHealth as jest.Mock).mockReturnValue({
         healthState: HealthState.ERROR,
         message: 'Error',
+        mcgHealth: { state: HealthState.ERROR },
       });
 
       render(
@@ -1025,15 +1034,12 @@ describe('StorageClusterCard', () => {
       (useGetOCSHealth as jest.Mock).mockReturnValue({
         healthState: HealthState.WARNING,
         message: 'Warning',
+        mcgHealth: { state: HealthState.OK },
       });
 
-      let callCount = 0;
-      (getDataResiliencyState as jest.Mock).mockImplementation(() => {
-        callCount++;
-        if (callCount === 1) {
-          return { state: HealthState.ERROR, message: 'Error' };
-        }
-        return { state: HealthState.OK, message: 'Healthy' };
+      (getDataResiliencyState as jest.Mock).mockReturnValue({
+        state: HealthState.ERROR,
+        message: 'Error',
       });
 
       render(

--- a/packages/odf/components/overview/storage-cluster-card/StorageClusterCard.tsx
+++ b/packages/odf/components/overview/storage-cluster-card/StorageClusterCard.tsx
@@ -5,16 +5,19 @@ import {
   odfSubscriptionResource,
   storageClusterResource,
 } from '@odf/core/resources';
-import { getStorageClusterInNs } from '@odf/core/utils';
+import { getStorageClusterInNs, isExternalCluster } from '@odf/core/utils';
 import { DANGER_THRESHOLD, WARNING_THRESHOLD } from '@odf/ocs/constants/charts';
 import { useGetOCSHealth } from '@odf/ocs/hooks/useOcsHealth';
-import { resiliencyProgressQuery, StatusCardQueries } from '@odf/ocs/queries';
-import { getDataResiliencyState } from '@odf/ocs/utils';
+import { resiliencyProgressQuery } from '@odf/ocs/queries';
+import { NooBaaKind } from '@odf/ocs/types';
+import { getDataResiliencyState, getNooBaaHealthFromCR } from '@odf/ocs/utils';
 import {
   DASH,
   getName,
+  getNamespace,
   healthStateMapping,
   healthStateMessage,
+  NooBaaSystemModel,
   ODF_OPERATOR,
   StorageClusterKind,
   SubscriptionKind,
@@ -31,10 +34,12 @@ import {
   getOprVersionFromCSV,
   getStorageClusterMetric,
   humanizeBinaryBytes,
+  referenceForModel,
 } from '@odf/shared/utils';
 import {
   HealthState,
   useK8sWatchResource,
+  WatchK8sResource,
 } from '@openshift-console/dynamic-plugin-sdk';
 import {
   ChartDonut,
@@ -89,11 +94,30 @@ export const StorageClusterCard: React.FC<CardProps> = ({ className }) => {
   const [subscription, subscriptionLoaded, subscriptionError] =
     useSafeK8sWatchResource<SubscriptionKind>(odfSubscriptionResource);
 
-  const storageCluster = getStorageClusterInNs(storageClusters, odfNamespace);
+  const filteredInternalStorageClusters = storageClusters?.filter(
+    (cluster) => !isExternalCluster(cluster)
+  );
+  const storageCluster = getStorageClusterInNs(
+    filteredInternalStorageClusters,
+    odfNamespace
+  );
   const clusterName = getName(storageCluster);
 
   const { healthState, message: healthMessage } =
     useGetOCSHealth(storageCluster);
+
+  const noobaaResource: WatchK8sResource = React.useMemo(
+    () => ({
+      kind: referenceForModel(NooBaaSystemModel),
+      isList: true,
+      namespaced: true,
+      namespace: odfNamespace,
+    }),
+    [odfNamespace]
+  );
+
+  const [noobaaData, noobaaLoaded, noobaaLoadError] =
+    useK8sWatchResource<NooBaaKind[]>(noobaaResource);
 
   const [totalCapacity, usedCapacity, capacityLoading, capacityLoadError] =
     useRawCapacity(clusterName);
@@ -104,22 +128,24 @@ export const StorageClusterCard: React.FC<CardProps> = ({ className }) => {
       basePath: usePrometheusBasePath(),
     });
 
-  const [objectResiliencyProgress, objectResiliencyProgressError] =
-    useCustomPrometheusPoll({
-      query: StatusCardQueries.MCG_REBUILD_PROGRESS_QUERY,
-      endpoint: 'api/v1/query' as any,
-      basePath: usePrometheusBasePath(),
-    });
-
-  const objectResiliencyState = getDataResiliencyState(
-    [
-      {
-        response: objectResiliencyProgress,
-        error: objectResiliencyProgressError,
-      },
-    ],
-    t
+  // Get Object Resiliency state from NooBaa CR status.phase instead of Prometheus
+  const systemNamespace = getNamespace(storageCluster);
+  const noobaaCluster: NooBaaKind | undefined = noobaaData?.find(
+    (noobaa) => getNamespace(noobaa) === systemNamespace
   );
+
+  const objectResiliencyState = React.useMemo(() => {
+    if (noobaaLoadError) {
+      return { state: HealthState.NOT_AVAILABLE };
+    }
+    if (!noobaaLoaded) {
+      return { state: HealthState.LOADING };
+    }
+    if (!noobaaCluster) {
+      return { state: HealthState.NOT_AVAILABLE };
+    }
+    return getNooBaaHealthFromCR(noobaaCluster, t);
+  }, [noobaaCluster, noobaaLoaded, noobaaLoadError, t]);
   const cephDataResiliencyState = getDataResiliencyState(
     [{ response: cephResiliencyProgress, error: cephResiliencyProgressError }],
     t

--- a/packages/odf/components/overview/storage-cluster-card/StorageClusterCard.tsx
+++ b/packages/odf/components/overview/storage-cluster-card/StorageClusterCard.tsx
@@ -8,7 +8,7 @@ import {
 import { getStorageClusterInNs } from '@odf/core/utils';
 import { DANGER_THRESHOLD, WARNING_THRESHOLD } from '@odf/ocs/constants/charts';
 import { useGetOCSHealth } from '@odf/ocs/hooks/useOcsHealth';
-import { resiliencyProgressQuery, StatusCardQueries } from '@odf/ocs/queries';
+import { resiliencyProgressQuery } from '@odf/ocs/queries';
 import { getDataResiliencyState } from '@odf/ocs/utils';
 import {
   DASH,
@@ -92,8 +92,11 @@ export const StorageClusterCard: React.FC<CardProps> = ({ className }) => {
   const storageCluster = getStorageClusterInNs(storageClusters, odfNamespace);
   const clusterName = getName(storageCluster);
 
-  const { healthState, message: healthMessage } =
-    useGetOCSHealth(storageCluster);
+  const {
+    healthState,
+    message: healthMessage,
+    mcgHealth,
+  } = useGetOCSHealth(storageCluster);
 
   const [totalCapacity, usedCapacity, capacityLoading, capacityLoadError] =
     useRawCapacity(clusterName);
@@ -104,22 +107,6 @@ export const StorageClusterCard: React.FC<CardProps> = ({ className }) => {
       basePath: usePrometheusBasePath(),
     });
 
-  const [objectResiliencyProgress, objectResiliencyProgressError] =
-    useCustomPrometheusPoll({
-      query: StatusCardQueries.MCG_REBUILD_PROGRESS_QUERY,
-      endpoint: 'api/v1/query' as any,
-      basePath: usePrometheusBasePath(),
-    });
-
-  const objectResiliencyState = getDataResiliencyState(
-    [
-      {
-        response: objectResiliencyProgress,
-        error: objectResiliencyProgressError,
-      },
-    ],
-    t
-  );
   const cephDataResiliencyState = getDataResiliencyState(
     [{ response: cephResiliencyProgress, error: cephResiliencyProgressError }],
     t
@@ -132,11 +119,10 @@ export const StorageClusterCard: React.FC<CardProps> = ({ className }) => {
   const cephResiliencyIcon =
     healthStateMapping?.[cephDataResiliencyState.state]?.icon;
   const objectResiliencyMessage =
-    objectResiliencyState.state === HealthState.OK
+    mcgHealth.state === HealthState.OK
       ? t('Healthy')
-      : healthStateMessage(objectResiliencyState.state, t);
-  const objectResiliencyIcon =
-    healthStateMapping?.[objectResiliencyState.state]?.icon;
+      : healthStateMessage(mcgHealth.state, t);
+  const objectResiliencyIcon = healthStateMapping?.[mcgHealth.state]?.icon;
 
   const odfVersion =
     csvLoaded && _.isEmpty(csvError) ? getOprVersionFromCSV(csv) : DASH;

--- a/packages/shared/src/types/storage.ts
+++ b/packages/shared/src/types/storage.ts
@@ -293,7 +293,54 @@ export type CleanupPolicy = {
   wipeDevicesFromOtherClusters: boolean;
 };
 
-export type NoobaaSystemKind = K8sResourceCommon;
+export enum NooBaaSystemPhase {
+  Rejected = 'Rejected',
+  Verifying = 'Verifying',
+  Creating = 'Creating',
+  Connecting = 'Connecting',
+  Configuring = 'Configuring',
+  Ready = 'Ready',
+}
+
+export type NooBaaStatus = {
+  observedGeneration?: number;
+  phase?: NooBaaSystemPhase;
+  conditions?: Array<{
+    type: string;
+    status: string;
+    reason?: string;
+    message?: string;
+    lastTransitionTime?: string;
+  }>;
+  relatedObjects?: K8sResourceCommon[];
+  actualImage?: string;
+  upgradePhase?: string;
+  postgresUpdatePhase?: string;
+  readme?: string;
+  lastKeyRotateTime?: string;
+  beforeUpgradeDbImage?: string;
+  accounts?: {
+    admin: {
+      secretRef: {
+        name: string;
+        namespace: string;
+      };
+    };
+  };
+  services?: Record<string, unknown>;
+  endpoints?: {
+    readyCount: number;
+    virtualHosts: string[];
+  };
+  dbStatus?: Record<string, unknown>;
+};
+
+export type NooBaaKind = K8sResourceCommon & {
+  spec?: Record<string, unknown>;
+  status?: NooBaaStatus;
+};
+
+export type NoobaaSystemKind = NooBaaKind;
 
 export enum CapacityAutoscalingStatus {
   Failed = 'Failed',

--- a/plugins/odf/console-extensions.json
+++ b/plugins/odf/console-extensions.json
@@ -284,11 +284,10 @@
     }
   },
   {
-    "type": "console.dashboards/overview/health/prometheus",
+    "type": "console.dashboards/overview/health/resource",
     "properties": {
       "title": "Storage",
-      "queries": ["NooBaa_health_status"],
-      "additionalResource": { "$codeRef": "healthResource.healthResource" },
+      "resources": { "$codeRef": "healthResource.healthResources" },
       "healthHandler": { "$codeRef": "healthResource.healthHandler" },
       "popupComponent": { "$codeRef": "healthResource.StoragePopover" },
       "popupTitle": "Storage"


### PR DESCRIPTION
- Introduced NooBaaSystemPhase enum to represent various phases of the NooBaa system.
- Added NooBaaStatus type to encapsulate the status details of NooBaa, including observed generation, conditions, and related objects.
- Updated useOcsHealth hook to utilize NooBaa CR status.phase for health state determination instead of Prometheus metrics.
- Enhanced StorageClusterCard to fetch NooBaa data and reflect its health state accurately.
- Implemented getNooBaaHealthFromCR utility function to map NooBaa phases to health states.

These changes improve the accuracy of health reporting for NooBaa systems in the ODF console.

Fixes https://redhat.atlassian.net/browse/DFBUGS-5839

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved storage cluster health reporting using current NooBaa resource status.
  - Transitional NooBaa states now display as in progress instead of errors.
  - Rejected NooBaa configurations now show a clear error status and message.
  - Unified health information across the storage cluster overview, object service status card, and health dashboard.
  - Added clearer handling for missing cluster information, unavailable applications, and skipped actions.

- **Localization**
  - Added English messages for NooBaa lifecycle, readiness, and rejection states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->