### PR TITLE
Fix third party storage doc link

### DIFF
--- a/packages/shared/src/constants/doc.ts
+++ b/packages/shared/src/constants/doc.ts
@@ -36,7 +36,7 @@ export const multusSetupDoc = (odfDocVersion: string): string =>
   )}/planning_your_deployment/index#multus-networking-setup_odf`;
 
 export const tpsDoc = (odfDocVersion: string): string =>
-  `${odfDRDocHome(odfDocVersion)}#storage-agnostic-disaster-recovery-for-third-party-vendors_common`;
+  `${odfDRDocHome(odfDocVersion)}#storage-agnostic-disaster-recovery-for-third-party-vendors`;
 
 export const externalSystemsDoc = (odfDocVersion: string): string =>
   `${odfDocBasePath(


### PR DESCRIPTION
https://redhat.atlassian.net/browse/DFBUGS-3939

As per the below comment in jira's failed QA , remove the _common tag at the end of third party storage doc link 
 this link will work once after 4.22 docs are GAed

https://redhat.atlassian.net/browse/DFBUGS-3939?focusedCommentId=17133268