### PR TITLE
RHSTOR-9044: List infrastructure nodes in Scale dashboard

### DIFF
--- a/locales/en/plugin__odf-console.json
+++ b/locales/en/plugin__odf-console.json
@@ -1360,6 +1360,7 @@
   "Loading...": "Loading...",
   "Local storage is also present in the cluster.": "Local storage is also present in the cluster.",
   "Local Storage Operator not installed": "Local Storage Operator not installed",
+  "Local StorageCluster": "Local StorageCluster",
   "Local Volume Discovery": "Local Volume Discovery",
   "Local Volume Set": "Local Volume Set",
   "LocalVolumeSet name": "LocalVolumeSet name",

--- a/packages/odf/components/create-storage-system/external-systems/common/payload.spec.ts
+++ b/packages/odf/components/create-storage-system/external-systems/common/payload.spec.ts
@@ -1,3 +1,4 @@
+import { SCALE_DAEMON_NODE_LABEL } from '@odf/core/constants';
 import { NodeModel } from '@odf/shared';
 import { Patch } from '@openshift-console/dynamic-plugin-sdk';
 import { WizardNodeState } from '../../reducer';
@@ -7,7 +8,6 @@ import {
   ExternalKMMRegistryConfig,
 } from './payload';
 
-const DAEMON_SELECTOR_LABEL_KEY = 'scale.spectrum.ibm.com/daemon-selector/';
 const LABEL_PATH = '/metadata/labels/scale.spectrum.ibm.com~1daemon-selector';
 
 const mockK8sPatchByName = jest.fn().mockResolvedValue({});
@@ -169,7 +169,7 @@ describe('payload', () => {
           rack: '',
           uid: 'uid-empty',
           roles: [],
-          labels: { [DAEMON_SELECTOR_LABEL_KEY]: '' },
+          labels: { [SCALE_DAEMON_NODE_LABEL]: '' },
           taints: [],
           architecture: 'amd64',
         },
@@ -195,7 +195,7 @@ describe('payload', () => {
           uid: 'uid-daemon',
           roles: [],
           labels: {
-            [DAEMON_SELECTOR_LABEL_KEY]: 'applied',
+            [SCALE_DAEMON_NODE_LABEL]: 'applied',
           },
           taints: [],
           architecture: 'amd64',
@@ -293,7 +293,7 @@ describe('payload', () => {
           rack: '',
           uid: 'uid-3',
           roles: [],
-          labels: { [DAEMON_SELECTOR_LABEL_KEY]: 'applied' },
+          labels: { [SCALE_DAEMON_NODE_LABEL]: 'applied' },
           taints: [],
           architecture: 'amd64',
         },

--- a/packages/odf/components/create-storage-system/external-systems/common/payload.ts
+++ b/packages/odf/components/create-storage-system/external-systems/common/payload.ts
@@ -1,6 +1,7 @@
 import {
   IBM_SCALE_LOCAL_CLUSTER_NAME,
   IBM_SCALE_NAMESPACE,
+  SCALE_DAEMON_NODE_LABEL,
 } from '@odf/core/constants';
 import { ClusterKind } from '@odf/core/types/scale';
 import {
@@ -28,7 +29,7 @@ export type ExternalKMMRegistryConfig = {
 };
 
 export const labelNodes = (nodes: WizardNodeState[]) => {
-  const labelPath = `/metadata/labels/scale.spectrum.ibm.com~1daemon-selector`;
+  const labelPath = `/metadata/labels/${SCALE_DAEMON_NODE_LABEL.replace('/', '~1')}`;
   const requests: Promise<K8sKind>[] = [];
   nodes.forEach((node) => {
     const patch: Patch[] = [];
@@ -44,7 +45,7 @@ export const labelNodes = (nodes: WizardNodeState[]) => {
       path: labelPath,
       value: '',
     });
-    if (!node.labels?.['scale.spectrum.ibm.com/daemon-selector/']) {
+    if (!node.labels?.[SCALE_DAEMON_NODE_LABEL]) {
       requests.push(k8sPatchByName(NodeModel, node.name, null, patch));
     }
   });
@@ -61,7 +62,7 @@ export const createScaleLocalClusterPayload = (
   const spec: ClusterKind['spec'] = {
     daemon: {
       nodeSelector: {
-        'scale.spectrum.ibm.com/daemon-selector': '',
+        [SCALE_DAEMON_NODE_LABEL]: '',
       },
       roles: [],
       clusterProfile: {

--- a/packages/odf/components/scale-dashboard/LocalStorageClusterCard.spec.tsx
+++ b/packages/odf/components/scale-dashboard/LocalStorageClusterCard.spec.tsx
@@ -1,0 +1,305 @@
+import * as React from 'react';
+import {
+  IBM_SCALE_LOCAL_CLUSTER_NAME,
+  IBM_SCALE_NAMESPACE,
+  SCALE_DAEMON_NODE_LABEL,
+} from '@odf/core/constants';
+import { ClusterKind, EncryptionConfigKind } from '@odf/core/types/scale';
+import { NodeKind } from '@odf/shared/types';
+import { useK8sWatchResources } from '@openshift-console/dynamic-plugin-sdk';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom-v5-compat';
+import LocalStorageClusterCard from './LocalStorageClusterCard';
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  ...jest.requireActual('@openshift-console/dynamic-plugin-sdk'),
+  useK8sWatchResources: jest.fn(),
+}));
+
+jest.mock('@openshift-console/dynamic-plugin-sdk-internal', () => ({
+  ResourceInventoryItem: (props) => (
+    <div data-test={props.dataTest}>
+      {props.isLoading ? (
+        <span>Loading...</span>
+      ) : props.error ? (
+        <span>Error</span>
+      ) : (
+        <a href={props.basePath}>{props.resources?.length} Nodes</a>
+      )}
+    </div>
+  ),
+}));
+
+jest.mock('@odf/shared/useCustomTranslationHook', () => ({
+  useCustomTranslation: () => ({
+    t: (key: string, params?: Record<string, unknown>) => {
+      if (params) {
+        return Object.entries(params).reduce(
+          (str, [k, v]) => str.replace(`{{ ${k} }}`, String(v)),
+          key
+        );
+      }
+      return key;
+    },
+  }),
+}));
+
+const makeNode = (name: string, labels: Record<string, string>): NodeKind =>
+  ({
+    apiVersion: 'v1',
+    kind: 'Node',
+    metadata: { name, labels, uid: name },
+    spec: {},
+  }) as NodeKind;
+
+const scaleNode = (name: string) =>
+  makeNode(name, { [SCALE_DAEMON_NODE_LABEL]: '' });
+
+const systemName = 'my-scale-system';
+
+const makeCluster = (name: string): ClusterKind => ({
+  apiVersion: 'scale.spectrum.ibm.com/v1beta1',
+  kind: 'Cluster',
+  metadata: { name, uid: name, creationTimestamp: '2026-01-01T00:00:00Z' },
+  spec: {
+    license: { accept: true, license: 'data-management' },
+  },
+});
+
+const makeEncryptionConfig = (name: string): EncryptionConfigKind => ({
+  apiVersion: 'scale.spectrum.ibm.com/v1beta1',
+  kind: 'EncryptionConfig',
+  metadata: {
+    name,
+    namespace: 'ibm-spectrum-scale',
+    uid: name,
+    creationTimestamp: '2026-01-01T00:00:00Z',
+  },
+  spec: {
+    server: 'keyserver.example.com',
+    tenant: 'test-tenant',
+    client: 'test-client',
+    secret: 'test-secret',
+  },
+});
+
+type SetupMocksOptions = {
+  cluster?: ClusterKind | null;
+  clusterLoaded?: boolean;
+  clusterLoadError?: unknown;
+  nodes?: NodeKind[];
+  nodesLoaded?: boolean;
+  nodesLoadError?: unknown;
+  encryptionConfig?: EncryptionConfigKind | null;
+  encryptionConfigLoaded?: boolean;
+  encryptionConfigLoadError?: unknown;
+};
+
+const setupMocks = ({
+  cluster = makeCluster(IBM_SCALE_LOCAL_CLUSTER_NAME),
+  clusterLoaded = true,
+  clusterLoadError,
+  nodes = [],
+  nodesLoaded = true,
+  nodesLoadError,
+  encryptionConfig = null,
+  encryptionConfigLoaded = true,
+  encryptionConfigLoadError,
+}: SetupMocksOptions = {}) => {
+  (useK8sWatchResources as jest.Mock).mockReturnValue({
+    cluster: {
+      data: cluster,
+      loaded: clusterLoaded,
+      loadError: clusterLoadError ?? null,
+    },
+    nodes: {
+      data: nodes,
+      loaded: nodesLoaded,
+      loadError: nodesLoadError ?? null,
+    },
+    encryptionConfig: {
+      data: encryptionConfig,
+      loaded: encryptionConfigLoaded,
+      loadError: encryptionConfigLoadError ?? null,
+    },
+  });
+};
+
+const renderCard = () =>
+  render(
+    <MemoryRouter initialEntries={[`/${systemName}`]}>
+      <Routes>
+        <Route path="/:systemName" element={<LocalStorageClusterCard />} />
+      </Routes>
+    </MemoryRouter>
+  );
+
+describe('LocalStorageClusterCard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render the card title', () => {
+    setupMocks();
+    renderCard();
+    expect(screen.getByText('Local StorageCluster')).toBeInTheDocument();
+  });
+
+  describe('Name field', () => {
+    it('should watch the single local cluster resource', () => {
+      setupMocks();
+      renderCard();
+
+      expect(useK8sWatchResources).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cluster: expect.objectContaining({
+            name: IBM_SCALE_LOCAL_CLUSTER_NAME,
+            namespace: IBM_SCALE_NAMESPACE,
+            isList: false,
+          }),
+        })
+      );
+    });
+
+    it('should display the cluster name', () => {
+      setupMocks({ cluster: makeCluster('my-scale-cluster') });
+      renderCard();
+      expect(screen.getByText('my-scale-cluster')).toBeInTheDocument();
+    });
+
+    it('should display N/A when cluster does not exist', () => {
+      setupMocks({ cluster: null });
+      renderCard();
+      expect(screen.getByText('N/A')).toBeInTheDocument();
+    });
+
+    it('should display a skeleton while loading', () => {
+      setupMocks({ clusterLoaded: false });
+      const { container } = renderCard();
+      expect(container.querySelector('.pf-v6-c-skeleton')).toBeInTheDocument();
+      expect(screen.queryByText('-')).not.toBeInTheDocument();
+      expect(screen.queryByText('N/A')).not.toBeInTheDocument();
+    });
+
+    it('should display N/A on error', () => {
+      setupMocks({
+        clusterLoaded: false,
+        clusterLoadError: new Error('failed'),
+      });
+      renderCard();
+      expect(screen.getByText('N/A')).toBeInTheDocument();
+    });
+  });
+
+  describe('Node inventory', () => {
+    it('should watch only nodes selected for the local cluster', () => {
+      setupMocks();
+      renderCard();
+
+      expect(useK8sWatchResources).toHaveBeenCalledWith(
+        expect.objectContaining({
+          nodes: expect.objectContaining({
+            kind: 'Node',
+            isList: true,
+            selector: {
+              matchExpressions: [
+                { key: SCALE_DAEMON_NODE_LABEL, operator: 'Exists' },
+              ],
+            },
+          }),
+        })
+      );
+    });
+
+    it('should display the count of nodes returned by the label-selector watch', () => {
+      setupMocks({
+        nodes: [scaleNode('node-1'), scaleNode('node-2'), scaleNode('node-3')],
+      });
+      renderCard();
+      expect(screen.getByText('3 Nodes')).toBeInTheDocument();
+    });
+
+    it('should show 0 nodes when the watch returns an empty list', () => {
+      setupMocks({ nodes: [] });
+      renderCard();
+      expect(screen.getByText('0 Nodes')).toBeInTheDocument();
+    });
+
+    it('should show loading state while nodes load', () => {
+      setupMocks({ nodesLoaded: false });
+      renderCard();
+      expect(screen.getByText('Loading...')).toBeInTheDocument();
+    });
+
+    it('should show error state on load failure', () => {
+      setupMocks({ nodesLoadError: new Error('forbidden') });
+      renderCard();
+      expect(screen.getByText('Error')).toBeInTheDocument();
+    });
+
+    it('should link to the Nodes page with the local cluster label filter', () => {
+      setupMocks({ nodes: [scaleNode('node-1')] });
+      renderCard();
+      const link = screen.getByRole('link', { name: '1 Nodes' });
+      expect(link).toHaveAttribute(
+        'href',
+        `/k8s/cluster/nodes?label=${encodeURIComponent(`${SCALE_DAEMON_NODE_LABEL}=`)}`
+      );
+    });
+  });
+
+  describe('Encryption field', () => {
+    it('should watch the single remote cluster encryption config', () => {
+      setupMocks();
+      renderCard();
+
+      expect(useK8sWatchResources).toHaveBeenCalledWith(
+        expect.objectContaining({
+          encryptionConfig: expect.objectContaining({
+            name: `${systemName}-encryption-config`,
+            namespace: IBM_SCALE_NAMESPACE,
+            isList: false,
+          }),
+        })
+      );
+    });
+
+    it('should show Disabled when no EncryptionConfig exists', () => {
+      setupMocks({
+        encryptionConfig: null,
+        encryptionConfigLoaded: false,
+        encryptionConfigLoadError: { response: { status: 404 } },
+      });
+      renderCard();
+      expect(screen.getByText('Disabled')).toBeInTheDocument();
+    });
+
+    it('should show N/A when the EncryptionConfig watch fails', () => {
+      setupMocks({
+        encryptionConfig: null,
+        encryptionConfigLoaded: false,
+        encryptionConfigLoadError: { response: { status: 403 } },
+      });
+      renderCard();
+      expect(screen.getByText('N/A')).toBeInTheDocument();
+      expect(screen.queryByText('Disabled')).not.toBeInTheDocument();
+    });
+
+    it('should show Enabled when EncryptionConfig exists', () => {
+      setupMocks({
+        encryptionConfig: makeEncryptionConfig('my-encryption'),
+      });
+      renderCard();
+      expect(screen.getByText('Enabled')).toBeInTheDocument();
+    });
+
+    it('should show a skeleton while loading', () => {
+      setupMocks({ encryptionConfigLoaded: false });
+      const { container } = renderCard();
+      expect(container.querySelector('.pf-v6-c-skeleton')).toBeInTheDocument();
+      expect(screen.queryByText('-')).not.toBeInTheDocument();
+      expect(screen.queryByText('Enabled')).not.toBeInTheDocument();
+      expect(screen.queryByText('Disabled')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/odf/components/scale-dashboard/LocalStorageClusterCard.tsx
+++ b/packages/odf/components/scale-dashboard/LocalStorageClusterCard.tsx
@@ -1,0 +1,139 @@
+import * as React from 'react';
+import {
+  IBM_SCALE_LOCAL_CLUSTER_NAME,
+  IBM_SCALE_NAMESPACE,
+  SCALE_DAEMON_NODE_LABEL,
+} from '@odf/core/constants';
+import { ClusterKind, EncryptionConfigKind } from '@odf/core/types/scale';
+import { getName, useCustomTranslation } from '@odf/shared';
+import { NodeModel } from '@odf/shared/models';
+import { ClusterModel, EncryptionConfigModel } from '@odf/shared/models/scale';
+import { NodeKind } from '@odf/shared/types';
+import {
+  isNotFoundError,
+  referenceForModel,
+  resourcePathFromModel,
+} from '@odf/shared/utils';
+import { useK8sWatchResources } from '@openshift-console/dynamic-plugin-sdk';
+import { ResourceInventoryItem } from '@openshift-console/dynamic-plugin-sdk-internal';
+import { useParams } from 'react-router-dom-v5-compat';
+import {
+  Card,
+  CardBody,
+  CardHeader,
+  CardTitle,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  Skeleton,
+} from '@patternfly/react-core';
+
+const nodesHref = `${resourcePathFromModel(NodeModel)}?label=${encodeURIComponent(
+  `${SCALE_DAEMON_NODE_LABEL}=`
+)}`;
+
+const LocalStorageClusterCard: React.FC = () => {
+  const { t } = useCustomTranslation();
+  const { systemName } = useParams<{ systemName: string }>();
+
+  const watchResources = React.useMemo(
+    () => ({
+      cluster: {
+        kind: referenceForModel(ClusterModel),
+        namespace: IBM_SCALE_NAMESPACE,
+        name: IBM_SCALE_LOCAL_CLUSTER_NAME,
+        isList: false,
+      },
+      nodes: {
+        kind: NodeModel.kind,
+        isList: true,
+        selector: {
+          matchExpressions: [
+            { key: SCALE_DAEMON_NODE_LABEL, operator: 'Exists' as const },
+          ],
+        },
+      },
+      encryptionConfig: {
+        kind: referenceForModel(EncryptionConfigModel),
+        namespace: IBM_SCALE_NAMESPACE,
+        name: `${systemName}-encryption-config`,
+        isList: false,
+      },
+    }),
+    [systemName]
+  );
+
+  const resources = useK8sWatchResources<{
+    cluster: ClusterKind;
+    nodes: NodeKind[];
+    encryptionConfig: EncryptionConfigKind;
+  }>(watchResources);
+
+  const cluster = resources.cluster?.data as ClusterKind;
+  const clusterLoaded = resources.cluster?.loaded;
+  const clusterLoadError = resources.cluster?.loadError;
+
+  const nodes = (resources.nodes?.data ?? []) as NodeKind[];
+  const nodesLoaded = resources.nodes?.loaded;
+  const nodesLoadError = resources.nodes?.loadError;
+
+  const encryptionConfig = resources.encryptionConfig
+    ?.data as EncryptionConfigKind;
+  const encryptionConfigLoaded = resources.encryptionConfig?.loaded;
+  const encryptionConfigLoadError = resources.encryptionConfig?.loadError;
+
+  const clusterName = getName(cluster);
+  const isEncrypted = !!getName(encryptionConfig);
+  const encryptionConfigNotFound = isNotFoundError(encryptionConfigLoadError);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t('Local StorageCluster')}</CardTitle>
+      </CardHeader>
+      <CardBody>
+        <DescriptionList>
+          <DescriptionListGroup>
+            <DescriptionListTerm>{t('Name')}</DescriptionListTerm>
+            <DescriptionListDescription>
+              {clusterLoadError ? (
+                t('N/A')
+              ) : !clusterLoaded ? (
+                <Skeleton width="35%" />
+              ) : (
+                clusterName || t('N/A')
+              )}
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+        </DescriptionList>
+        <ResourceInventoryItem
+          dataTest="inventory-nodes"
+          isLoading={!nodesLoaded}
+          error={!!nodesLoadError}
+          kind={NodeModel as any}
+          resources={nodes}
+          basePath={nodesHref}
+        />
+        <DescriptionList className="pf-v6-u-mt-md">
+          <DescriptionListGroup>
+            <DescriptionListTerm>{t('Encryption')}</DescriptionListTerm>
+            <DescriptionListDescription>
+              {encryptionConfigLoadError && !encryptionConfigNotFound ? (
+                t('N/A')
+              ) : !encryptionConfigLoaded && !encryptionConfigNotFound ? (
+                <Skeleton width="35%" />
+              ) : isEncrypted ? (
+                t('Enabled')
+              ) : (
+                t('Disabled')
+              )}
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+        </DescriptionList>
+      </CardBody>
+    </Card>
+  );
+};
+
+export default LocalStorageClusterCard;

--- a/packages/odf/components/scale-dashboard/ScaleDashboard.tsx
+++ b/packages/odf/components/scale-dashboard/ScaleDashboard.tsx
@@ -20,6 +20,7 @@ import ActivityCard from './ActivityCard';
 import CapacityCard from './CapacityCard';
 import DetailsCard from './DetailsCard';
 import FileSystemCard from './FileSystems';
+import LocalStorageClusterCard from './LocalStorageClusterCard';
 import StatusCard from './StatusCard';
 
 const scaleDashboardActions = (
@@ -73,7 +74,10 @@ const ScaleDashboard: React.FC = () => {
     isList: false,
   });
 
-  const leftCards: OverviewGridCard[] = [{ Card: DetailsCard }];
+  const leftCards: OverviewGridCard[] = [
+    { Card: DetailsCard },
+    { Card: LocalStorageClusterCard },
+  ];
 
   const rightCards: OverviewGridCard[] = [{ Card: ActivityCard }];
 

--- a/packages/odf/constants/scale.ts
+++ b/packages/odf/constants/scale.ts
@@ -1,6 +1,7 @@
 export const IBM_SCALE_NAMESPACE = 'ibm-spectrum-scale';
 export const IBM_SCALE_OPERATOR_NAME = 'ibm-spectrum-scale-operator';
 export const IBM_SCALE_LOCAL_CLUSTER_NAME = 'ibm-spectrum-scale';
+export const SCALE_DAEMON_NODE_LABEL = 'scale.spectrum.ibm.com/daemon-selector';
 export const SAN_STORAGE_SYSTEM_NAME = 'SAN_Storage';
 export const KMM_OPERATOR_NAME = 'kernel-module-management';
 export const KMM_OPERATOR_NAMESPACE = 'openshift-kmm';


### PR DESCRIPTION
## Description

Add a **Local StorageCluster** card to the Scale dashboard showing:
- **Name**: Cluster name from the Scale `Cluster` CR
- **Inventory**: Node count filtered by `scale.spectrum.ibm.com/daemon-selector` label, rendered as a hyperlink to the OCP search page with the label pre-applied
- **Encryption**: Enabled/Disabled based on `EncryptionConfig` CR presence in `ibm-spectrum-scale` namespace

Placed in the left sidebar below the existing Details card, matching the OCS internal dashboard inventory card pattern.

**Not in scope:** Pencil/edit icons (separate stories), PVC/PV inventory counts.

**JIRA:** https://issues.redhat.com/browse/RHSTOR-9044

---

## Change Type

- [x] Feature
- [ ] Bug Fix
- [ ] Improvement
- [ ] Refactor
- [ ] Tests

---

## Component / Area Impacted

- [ ] ODF
- [ ] FDF
- [ ] Client
- [ ] MCO
- [ ] Fusion Access (SAN Storage)
- [x] CNSA (Remote Mount)
- [ ] E2E Test

---

## Screenshots / Recordings

### Screenshots


<img width="1200" height="1475" alt="image" src="https://github.com/user-attachments/assets/36ad24f8-14f6-4e95-9aa0-4da120bdb473" />
<img width="1200" height="1475" alt="image" src="https://github.com/user-attachments/assets/9d00f678-697e-4d27-a01f-f0df222890e2" />

### Recordings / Demo Videos

N/A

---

## Testing

- [x] Unit Tests
- [ ] E2E Tests
- [ ] No Tests Required (with justification below)

13 unit tests covering:
- Card title rendering
- Cluster name display (loaded, loading, error, empty states)
- Node inventory filtering by `scale.spectrum.ibm.com/daemon-selector` label
- Node count link pointing to correct OCP search URL
- Encryption status derived from EncryptionConfig CR presence
- Loading and error states for all data sources

---

## Additional Notes

- Pencil/edit icons for Inventory and Encryption fields are tracked in separate stories.
- The node label `scale.spectrum.ibm.com/daemon-selector` is the same label applied during CNSA cluster creation in the storage system wizard.