### PR TITLE
Fix topology sidebar showing Unknown DR status by computing full health data

### DIFF
--- a/packages/mco/components/topology/sidebar/AppSidebar.tsx
+++ b/packages/mco/components/topology/sidebar/AppSidebar.tsx
@@ -9,15 +9,19 @@ import {
   EmptyStateBody,
 } from '@patternfly/react-core';
 import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
-import { getProtectedCondition } from '../../../utils';
-import { getDRStatus } from '../../../utils/dr-status';
 import { getPAVDRPolicyName } from '../../../utils/pav';
+import { TopologyDataContext } from '../context/TopologyContext';
 import {
   AppSidebarItem,
   StaticAppsSidebarData,
   OperationAppSidebarData,
 } from '../types';
-import { getAppLink, DRStatusIcon } from '../utils/sidebar-utils';
+import {
+  getAppLink,
+  DRStatusIcon,
+  getOperationDRStatus,
+  buildDRPolicyByName,
+} from '../utils/sidebar-utils';
 import { DRPCFilterToolbar } from './DRPCFilterToolbar';
 import './TopologySidebar.scss';
 
@@ -118,6 +122,8 @@ export const DRPCTable: React.FC<DRPCTableProps> = ({ apps }) => {
 
 export const AppSidebar: React.FC<AppSidebarProps> = ({ edgeData }) => {
   const { t } = useCustomTranslation();
+  const { clusterPairPoliciesMap } = React.useContext(TopologyDataContext);
+
   if ('isStatic' in edgeData && edgeData.isStatic === true) {
     return (
       <div className="mco-topology-sidebar__container">
@@ -137,21 +143,13 @@ export const AppSidebar: React.FC<AppSidebarProps> = ({ edgeData }) => {
   const operations =
     operationData.operations ||
     (operationData.operation ? [operationData.operation] : []);
-  const appsFromOperations = operations.map((op) => {
-    const protectedCondition = getProtectedCondition(op.drpc);
-    return {
-      name: op.applicationName,
-      namespace: op.applicationNamespace,
-      status: getDRStatus({
-        phase: op.phase,
-        progression: op.progression,
-        protectedCondition,
-        volumeLastGroupSyncTime: op.drpc?.status?.lastGroupSyncTime,
-        action: op.action,
-      }),
-      drPolicy: op.pav ? getPAVDRPolicyName(op.pav) : '',
-    };
-  });
+  const drPolicyByName = buildDRPolicyByName(clusterPairPoliciesMap);
+  const appsFromOperations = operations.map((op) => ({
+    name: op.applicationName,
+    namespace: op.applicationNamespace,
+    status: getOperationDRStatus(op, drPolicyByName),
+    drPolicy: op.pav ? getPAVDRPolicyName(op.pav) : '',
+  }));
 
   return (
     <div className="mco-topology-sidebar__container">

--- a/packages/mco/components/topology/sidebar/OperationSidebar.tsx
+++ b/packages/mco/components/topology/sidebar/OperationSidebar.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { getDRStatus } from '@odf/mco/utils/dr-status';
 import { DASH } from '@odf/shared/constants';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { useNavigate } from 'react-router-dom-v5-compat';
@@ -19,17 +18,16 @@ import {
 import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
 import { getClustersFromPairKey } from '../../../hooks/useDRPoliciesByClusterPair';
 import { getPAVDRPolicyName } from '../../../utils/pav';
+import { TopologyDataContext } from '../context/TopologyContext';
 import { DROperationInfo, OperationEdgeSidebarData } from '../types';
-import { DRStatusIcon, getAppLink } from '../utils/sidebar-utils';
+import {
+  DRStatusIcon,
+  getAppLink,
+  getOperationDRStatus,
+  buildDRPolicyByName,
+} from '../utils/sidebar-utils';
 import { DRPCFilterToolbar } from './DRPCFilterToolbar';
 import './TopologySidebar.scss';
-
-const getOperationStatus = (op: DROperationInfo) =>
-  getDRStatus({
-    phase: op.phase,
-    progression: op.progression,
-    action: op.action,
-  });
 
 type OperationSidebarProps = {
   edgeData: OperationEdgeSidebarData;
@@ -42,12 +40,22 @@ const OperationsTableView: React.FC<{
 }> = ({ operations, cluster1, cluster2 }) => {
   const { t } = useCustomTranslation();
   const navigate = useNavigate();
+  const { clusterPairPoliciesMap } = React.useContext(TopologyDataContext);
+  const drPolicyByName = React.useMemo(
+    () => buildDRPolicyByName(clusterPairPoliciesMap),
+    [clusterPairPoliciesMap]
+  );
   const [nameFilter, setNameFilter] = React.useState('');
   const [selectedStatuses, setSelectedStatuses] = React.useState<string[]>([]);
 
   const uniqueStatuses = React.useMemo(
-    () => Array.from(new Set(operations.map((op) => getOperationStatus(op)))),
-    [operations]
+    () =>
+      Array.from(
+        new Set(
+          operations.map((op) => getOperationDRStatus(op, drPolicyByName))
+        )
+      ),
+    [operations, drPolicyByName]
   );
 
   const filteredOperations = React.useMemo(() => {
@@ -60,11 +68,11 @@ const OperationsTableView: React.FC<{
     }
     if (selectedStatuses.length > 0) {
       results = results.filter((op) =>
-        selectedStatuses.includes(getOperationStatus(op))
+        selectedStatuses.includes(getOperationDRStatus(op, drPolicyByName))
       );
     }
     return results;
-  }, [operations, nameFilter, selectedStatuses]);
+  }, [operations, nameFilter, selectedStatuses, drPolicyByName]);
 
   const operationCount = operations.length;
 
@@ -166,7 +174,12 @@ const OperationsTableView: React.FC<{
                         </div>
                       </Td>
                       <Td dataLabel={t('DR Status')}>
-                        <DRStatusIcon status={getOperationStatus(operation)} />
+                        <DRStatusIcon
+                          status={getOperationDRStatus(
+                            operation,
+                            drPolicyByName
+                          )}
+                        />
                       </Td>
                       <Td dataLabel={t('Policy')}>
                         {operation.pav

--- a/packages/mco/components/topology/utils/sidebar-utils.tsx
+++ b/packages/mco/components/topology/utils/sidebar-utils.tsx
@@ -9,10 +9,89 @@ import { referenceForModel } from '@odf/shared/utils';
 import { InProgressIcon } from '@patternfly/react-icons';
 import { t_color_blue_40 as blueInfoColor } from '@patternfly/react-tokens';
 import { NodeStatus } from '@patternfly/react-topology';
+import { ClusterPairPoliciesMap } from '../../../hooks/useDRPoliciesByClusterPair';
+import { DRPolicyKind } from '../../../types';
+import {
+  getReplicationHealth,
+  getReplicationType,
+  getProtectedCondition,
+} from '../../../utils';
 import {
   DRStatus,
+  getDRStatus,
+  isCleanupRequired,
   isUserActionRequired as isUserActionRequiredUtil,
 } from '../../../utils/dr-status';
+import { DROperationInfo } from '../types';
+
+/**
+ * Builds a map of DR policy name → DRPolicyKind from the cluster pair policies map.
+ */
+export const buildDRPolicyByName = (
+  clusterPairPoliciesMap?: ClusterPairPoliciesMap
+): Map<string, DRPolicyKind> => {
+  const map = new Map<string, DRPolicyKind>();
+  if (!clusterPairPoliciesMap) return map;
+  Object.values(clusterPairPoliciesMap).forEach((policies) => {
+    policies.forEach((policyInfo) => {
+      if (policyInfo.policy?.metadata?.name) {
+        map.set(policyInfo.policy.metadata.name, policyInfo.policy);
+      }
+    });
+  });
+  return map;
+};
+
+/**
+ * Computes the full DR status for an operation using all available data.
+ * Mirrors the computation in node-generator's computeOperationDRStatus.
+ */
+export const getOperationDRStatus = (
+  op: DROperationInfo,
+  drPolicyByName: Map<string, DRPolicyKind>
+): DRStatus => {
+  const drpc = op.drpc;
+  const drPolicyName = drpc?.spec?.drPolicyRef?.name;
+  const drPolicy = drPolicyName ? drPolicyByName.get(drPolicyName) : undefined;
+  const schedulingInterval = drPolicy?.spec?.schedulingInterval;
+  const protectedCondition = getProtectedCondition(drpc);
+  const volumeLastGroupSyncTime = drpc?.status?.lastGroupSyncTime;
+
+  const volumeReplicationHealth =
+    volumeLastGroupSyncTime && schedulingInterval
+      ? getReplicationHealth(
+          volumeLastGroupSyncTime,
+          schedulingInterval,
+          drPolicy ? getReplicationType(drPolicy) : undefined
+        )
+      : undefined;
+
+  const kubeObjectSchedulingInterval =
+    drpc?.spec?.kubeObjectProtection?.captureInterval;
+  const kubeObjectReplicationHealth =
+    kubeObjectSchedulingInterval && drpc?.status?.lastKubeObjectProtectionTime
+      ? getReplicationHealth(
+          drpc.status.lastKubeObjectProtectionTime,
+          kubeObjectSchedulingInterval
+        )
+      : undefined;
+
+  return getDRStatus({
+    isCleanupRequired: isCleanupRequired(
+      drpc?.status?.phase,
+      drpc?.status?.progression
+    ),
+    phase: op.phase,
+    volumeReplicationHealth,
+    kubeObjectReplicationHealth,
+    progression: op.progression,
+    volumeLastGroupSyncTime,
+    protectedCondition,
+    schedulingInterval,
+    actionStartTime: drpc?.status?.actionStartTime,
+    action: op.action,
+  });
+};
 
 export const getAppLink = (name: string, namespace: string) => {
   return `/k8s/ns/${namespace}/${referenceForModel(DRPlacementControlModel)}/${name}`;


### PR DESCRIPTION
Fixes https://redhat.atlassian.net/browse/DFBUGS-7001`

The AppSidebar and OperationSidebar were calling getDRStatus with only phase/progression/action, missing volumeReplicationHealth and schedulingInterval. When status evaluation reached the health check with an empty replicationHealths array, it returned Unknown instead of the correct status.

Extracted a shared getOperationDRStatus helper in sidebar-utils that looks up the DR policy from context to derive the full health data, matching the computation in node-generator's computeOperationDRStatus.