### PR TITLE
DFBUGS-7048: [release-4.21] Hide host data replication separation UI on 4.21

### DIFF
--- a/packages/odf/components/create-storage-system/create-storage-system-steps/security-and-network-step/configure.tsx
+++ b/packages/odf/components/create-storage-system/create-storage-system-steps/security-and-network-step/configure.tsx
@@ -12,6 +12,10 @@ import { MultusNetworkConfigurationComponent } from './multus';
 import { NICSelectComponent } from './nic';
 import './configure.scss';
 
+// DFBUGS-7048: 4.21 backend does not support public/cluster CIDR separation under
+// Host networking. Keep the code for an easy restore; hide the UI until support lands.
+const SHOW_HOST_NETWORK_SEPARATION = false;
+
 export const NetworkFormGroup: React.FC<NetworkFormGroupProps> = ({
   setNetworkType,
   networkType,
@@ -105,6 +109,7 @@ export const NetworkFormGroup: React.FC<NetworkFormGroupProps> = ({
           setIsMultusAcknowledged={setIsMultusAcknowledged}
         />
       ) : (
+        SHOW_HOST_NETWORK_SEPARATION &&
         isFDF && (
           <NICSelectComponent
             cephClusterCIDR={cephClusterCIDR ?? ''}


### PR DESCRIPTION
BZ: https://redhat.atlassian.net/browse/DFBUGS-7048

On 4.21, the backend does not support separating client data path from replication path via public/cluster CIDR under Host networking. The UI was restored on release-4.21 via [RHSTOR-6952](https://redhat.atlassian.net/browse/RHSTOR-6952) / PR #2593, which exposed options users cannot actually use. This PR removes that unsupported UI and all related validation/state on 4.21 only.

Host networking remains available. Only the separation controls (Isolate Ceph network, public/cluster CIDR) are removed.

Reason for this change:
QE filed [DFBUGS-7048](https://redhat.atlassian.net/browse/DFBUGS-7048) because 4.21 users could configure replication separation in the UI, but the backend does not support it.
This is not the same as [DFBUGS-7002](https://redhat.atlassian.net/browse/DFBUGS-7002) (4.22/master), which keeps separation UI but shows cluster network only.

This PR: 
Remove NICSelectComponent from Security and network step when Host is selected
Remove CIDR/mon-ip validation from wizard footer
Remove usePublicNetwork / useClusterNetwork state and actions from reducer
Delete unused files: nic.tsx, nic.spec.tsx, nic.scss, cidr-utils.ts, cidr-utils.spec.ts
Remove unused English locale strings for the separation UI
