### PR TITLE
fix-create-bc-wizard

### DIFF
--- a/packages/odf/components/bucket-class/create-bc.tsx
+++ b/packages/odf/components/bucket-class/create-bc.tsx
@@ -193,8 +193,7 @@ const BucketClassWizardFooter: React.FC<BucketClassWizardFooterProps> = ({
           backingStores: state.tier2BackingStore.map(getName),
         });
       }
-    }
-    if (state.bucketClassType === BucketClassType.VECTOR) {
+    } else if (state.bucketClassType === BucketClassType.VECTOR) {
       payload = {
         ...metadata,
         spec: {
@@ -204,7 +203,7 @@ const BucketClassWizardFooter: React.FC<BucketClassWizardFooterProps> = ({
           },
         },
       };
-    } else {
+    } else if (state.bucketClassType === BucketClassType.NAMESPACE) {
       switch (state.namespacePolicyType) {
         case NamespacePolicyType.SINGLE:
           payload = {
@@ -457,6 +456,13 @@ const CreateBucketClass: React.FC = () => {
             state={state}
             dispatcher={dispatch}
             namespace={namespace}
+          />
+        ) : state.bucketClassType === BucketClassType.VECTOR ? (
+          <SingleNamespaceStorePage
+            state={state}
+            dispatch={dispatch}
+            namespace={namespace}
+            launchModal={launchNamespaceStoreModal}
           />
         ) : (
           renderNamespaceStorePage()

--- a/packages/odf/components/bucket-class/create-bc.tsx
+++ b/packages/odf/components/bucket-class/create-bc.tsx
@@ -232,7 +232,7 @@ const BucketClassWizardFooter: React.FC<BucketClassWizardFooterProps> = ({
           },
         },
       };
-    } else {
+    } else if (state.bucketClassType === BucketClassType.NAMESPACE) {
       switch (state.namespacePolicyType) {
         case NamespacePolicyType.SINGLE:
           payload = {
@@ -498,6 +498,13 @@ const CreateBucketClass: React.FC = () => {
             state={state}
             dispatcher={dispatch}
             namespace={namespace}
+          />
+        ) : state.bucketClassType === BucketClassType.VECTOR ? (
+          <SingleNamespaceStorePage
+            state={state}
+            dispatch={dispatch}
+            namespace={namespace}
+            launchModal={launchNamespaceStoreModal}
           />
         ) : (
           renderNamespaceStorePage()

--- a/packages/odf/components/bucket-class/state.ts
+++ b/packages/odf/components/bucket-class/state.ts
@@ -67,7 +67,7 @@ export const reducer = (state: State, action: Action) => {
     case 'setBucketClassName':
       return Object.assign({}, state, { bucketClassName: action.name });
     case 'setBucketClassType':
-      return Object.assign({}, state, { bucketClassType: action.value });
+      return Object.assign({}, initialState, { bucketClassType: action.value });
     case 'setNamespacePolicyType':
       return Object.assign({}, state, { namespacePolicyType: action.value });
     case 'setReadNamespaceStore':

--- a/packages/odf/components/bucket-class/state.ts
+++ b/packages/odf/components/bucket-class/state.ts
@@ -73,7 +73,7 @@ export const reducer = (state: State, action: Action) => {
     case 'setBucketClassName':
       return Object.assign({}, state, { bucketClassName: action.name });
     case 'setBucketClassType':
-      return Object.assign({}, state, { bucketClassType: action.value });
+      return Object.assign({}, initialState, { bucketClassType: action.value });
     case 'setNamespacePolicyType':
       return Object.assign({}, state, { namespacePolicyType: action.value });
     case 'setReadNamespaceStore':


### PR DESCRIPTION
Jira bug: https://redhat.atlassian.net/browse/DFBUGS-8302

Yaml files:

1- Standard bucket class: 

apiVersion: noobaa.io/v1alpha1
kind: BucketClass
metadata:
  resourceVersion: '291346'
  name: test-standard
  uid: c27ba977-b412-4d44-bd4b-64d4d3d6197c
  creationTimestamp: '2026-07-07T05:51:57Z'
  generation: 1
  managedFields:
    - apiVersion: noobaa.io/v1alpha1
      fieldsType: FieldsV1
      fieldsV1:
        'f:spec':
          .: {}
          'f:placementPolicy':
            .: {}
            'f:tiers': {}
      manager: Mozilla
      operation: Update
      time: '2026-07-07T05:51:57Z'
    - apiVersion: noobaa.io/v1alpha1
      fieldsType: FieldsV1
      fieldsV1:
        'f:metadata':
          'f:finalizers':
            .: {}
            'v:"noobaa.io/finalizer"': {}
          'f:labels':
            .: {}
            'f:app': {}
      manager: noobaa-operator
      operation: Update
      time: '2026-07-07T05:51:57Z'
    - apiVersion: noobaa.io/v1alpha1
      fieldsType: FieldsV1
      fieldsV1:
        'f:status':
          .: {}
          'f:conditions': {}
          'f:phase': {}
      manager: noobaa-operator
      operation: Update
      subresource: status
      time: '2026-07-07T06:08:48Z'
  namespace: openshift-storage
  finalizers:
    - noobaa.io/finalizer
  labels:
    app: noobaa
spec:
  placementPolicy:
    tiers:
      - backingStores:
          - noobaa-default-backing-store
        placement: Spread
status:
  conditions:
    - lastHeartbeatTime: '2026-07-07T06:08:48Z'
      lastTransitionTime: '2026-07-07T06:08:48Z'
      message: noobaa operator completed reconcile - bucket class is ready
      reason: BucketClassPhaseReady
      status: 'True'
      type: Available
    - lastHeartbeatTime: '2026-07-07T06:08:48Z'
      lastTransitionTime: '2026-07-07T06:08:48Z'
      message: noobaa operator completed reconcile - bucket class is ready
      reason: BucketClassPhaseReady
      status: 'False'
      type: Progressing
    - lastHeartbeatTime: '2026-07-07T06:08:48Z'
      lastTransitionTime: '2026-07-07T05:51:57Z'
      message: noobaa operator completed reconcile - bucket class is ready
      reason: BucketClassPhaseReady
      status: 'False'
      type: Degraded
    - lastHeartbeatTime: '2026-07-07T06:08:48Z'
      lastTransitionTime: '2026-07-07T06:08:48Z'
      message: noobaa operator completed reconcile - bucket class is ready
      reason: BucketClassPhaseReady
      status: 'True'
      type: Upgradeable
  phase: Ready


2- Namespace bucket class: 

apiVersion: noobaa.io/v1alpha1
kind: BucketClass
metadata:
  resourceVersion: '288033'
  name: test-namespace
  uid: b4dd3d76-54af-46f8-9103-b426fd08924b
  creationTimestamp: '2026-07-07T06:05:53Z'
  generation: 1
  managedFields:
    - apiVersion: noobaa.io/v1alpha1
      fieldsType: FieldsV1
      fieldsV1:
        'f:spec':
          .: {}
          'f:namespacePolicy':
            .: {}
            'f:single':
              .: {}
              'f:resource': {}
            'f:type': {}
      manager: Mozilla
      operation: Update
      time: '2026-07-07T06:05:53Z'
    - apiVersion: noobaa.io/v1alpha1
      fieldsType: FieldsV1
      fieldsV1:
        'f:metadata':
          'f:finalizers':
            .: {}
            'v:"noobaa.io/finalizer"': {}
          'f:labels':
            .: {}
            'f:app': {}
      manager: noobaa-operator
      operation: Update
      time: '2026-07-07T06:05:53Z'
    - apiVersion: noobaa.io/v1alpha1
      fieldsType: FieldsV1
      fieldsV1:
        'f:status':
          .: {}
          'f:conditions': {}
          'f:phase': {}
      manager: noobaa-operator
      operation: Update
      subresource: status
      time: '2026-07-07T06:05:56Z'
  namespace: openshift-storage
  finalizers:
    - noobaa.io/finalizer
  labels:
    app: noobaa
spec:
  namespacePolicy:
    single:
      resource: test-n-store
    type: Single
status:
  conditions:
    - lastHeartbeatTime: '2026-07-07T06:05:56Z'
      lastTransitionTime: '2026-07-07T06:05:53Z'
      message: NooBaa NamespaceStore "test-n-store" is not yet ready
      reason: TemporaryError
      status: 'False'
      type: Available
    - lastHeartbeatTime: '2026-07-07T06:05:56Z'
      lastTransitionTime: '2026-07-07T06:05:53Z'
      message: NooBaa NamespaceStore "test-n-store" is not yet ready
      reason: TemporaryError
      status: 'True'
      type: Progressing
    - lastHeartbeatTime: '2026-07-07T06:05:56Z'
      lastTransitionTime: '2026-07-07T06:05:53Z'
      message: NooBaa NamespaceStore "test-n-store" is not yet ready
      reason: TemporaryError
      status: 'False'
      type: Degraded
    - lastHeartbeatTime: '2026-07-07T06:05:56Z'
      lastTransitionTime: '2026-07-07T06:05:53Z'
      message: NooBaa NamespaceStore "test-n-store" is not yet ready
      reason: TemporaryError
      status: 'False'
      type: Upgradeable
  phase: Verifying
  
  3- Vector bucket class: 
  
  apiVersion: noobaa.io/v1alpha1
kind: BucketClass
metadata:
  resourceVersion: '540786'
  name: test-vector-bc-harsh
  uid: 156106f1-0928-4483-9f2f-6773b42e84b0
  creationTimestamp: '2026-07-07T09:42:12Z'
  generation: 1
  managedFields:
    - apiVersion: noobaa.io/v1alpha1
      fieldsType: FieldsV1
      fieldsV1:
        'f:spec':
          .: {}
          'f:vectorPolicy':
            .: {}
            'f:resource': {}
            'f:vectorDBType': {}
      manager: Mozilla
      operation: Update
      time: '2026-07-07T09:42:12Z'
    - apiVersion: noobaa.io/v1alpha1
      fieldsType: FieldsV1
      fieldsV1:
        'f:metadata':
          'f:finalizers':
            .: {}
            'v:"noobaa.io/finalizer"': {}
          'f:labels':
            .: {}
            'f:app': {}
      manager: noobaa-operator
      operation: Update
      time: '2026-07-07T09:42:12Z'
    - apiVersion: noobaa.io/v1alpha1
      fieldsType: FieldsV1
      fieldsV1:
        'f:status':
          .: {}
          'f:conditions': {}
          'f:phase': {}
      manager: noobaa-operator
      operation: Update
      subresource: status
      time: '2026-07-07T09:42:12Z'
  namespace: openshift-storage
  finalizers:
    - noobaa.io/finalizer
  labels:
    app: noobaa
spec:
  vectorPolicy:
    resource: test-namespacestore-harsh
    vectorDBType: lance
status:
  conditions:
    - lastHeartbeatTime: '2026-07-07T09:42:12Z'
      lastTransitionTime: '2026-07-07T09:42:12Z'
      message: noobaa operator completed reconcile - bucket class is ready
      reason: BucketClassPhaseReady
      status: 'True'
      type: Available
    - lastHeartbeatTime: '2026-07-07T09:42:12Z'
      lastTransitionTime: '2026-07-07T09:42:12Z'
      message: noobaa operator completed reconcile - bucket class is ready
      reason: BucketClassPhaseReady
      status: 'False'
      type: Progressing
    - lastHeartbeatTime: '2026-07-07T09:42:12Z'
      lastTransitionTime: '2026-07-07T09:42:12Z'
      message: noobaa operator completed reconcile - bucket class is ready
      reason: BucketClassPhaseReady
      status: 'False'
      type: Degraded
    - lastHeartbeatTime: '2026-07-07T09:42:12Z'
      lastTransitionTime: '2026-07-07T09:42:12Z'
      message: noobaa operator completed reconcile - bucket class is ready
      reason: BucketClassPhaseReady
      status: 'True'
      type: Upgradeable
  phase: Ready




Fix recording: 


https://github.com/user-attachments/assets/efae3739-4177-4003-ba48-67bcc342a977

In this screen recording, we can see that the state is reset when the BucketClassType radio button is changed. For example, for the Namespace and Vector bucket class types, the Namespace Stores field is reset.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deep archive configuration to the standard bucket class creation wizard.
  * Added archive namespace-store selection and validation before continuing or completing creation.
  * Vector resource configurations now use the streamlined single namespace-store experience.

* **Bug Fixes**
  * Changing the bucket class type now clears previously entered configuration values, preventing stale settings from carrying over.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->