### PR TITLE
Reduce s390x minimum CPU requirements to 12/18/24

### DIFF
--- a/packages/odf/components/create-storage-system/create-storage-system-steps/capacity-and-nodes-step/configure-performance.spec.tsx
+++ b/packages/odf/components/create-storage-system/create-storage-system-steps/capacity-and-nodes-step/configure-performance.spec.tsx
@@ -141,7 +141,7 @@ describe('Configure Performance', () => {
       />
     );
 
-    expect(screen.getByText(/15 CPUs/i)).toBeInTheDocument();
+    expect(screen.getByText(/12 CPUs/i)).toBeInTheDocument();
     expect(screen.getByText(/72 GiB/i)).toBeInTheDocument();
   });
 
@@ -164,7 +164,7 @@ describe('Configure Performance', () => {
       />
     );
 
-    expect(screen.getByText(/21 CPUs/i)).toBeInTheDocument();
+    expect(screen.getByText(/18 CPUs/i)).toBeInTheDocument();
     expect(screen.getByText(/72 GiB/i)).toBeInTheDocument();
   });
 
@@ -187,7 +187,7 @@ describe('Configure Performance', () => {
       />
     );
 
-    expect(screen.getByText(/30 CPUs/i)).toBeInTheDocument();
+    expect(screen.getByText(/24 CPUs/i)).toBeInTheDocument();
     expect(screen.getByText(/96 GiB/i)).toBeInTheDocument();
   });
 
@@ -211,7 +211,7 @@ describe('Configure Performance', () => {
       />
     );
 
-    expect(screen.getByText(/27 CPUs/i)).toBeInTheDocument();
+    expect(screen.getByText(/24 CPUs/i)).toBeInTheDocument();
     expect(screen.getByText(/102 GiB/i)).toBeInTheDocument();
   });
 });

--- a/packages/odf/constants/common.ts
+++ b/packages/odf/constants/common.ts
@@ -73,15 +73,15 @@ export const ARCHITECTURE_S390X = 's390x';
  */
 export const S390X_CPU_ADJUSTMENTS = {
   [ResourceProfile.Lean]: {
-    minCpu: 15,
+    minCpu: 12,
     osdCpu: 0.75,
   },
   [ResourceProfile.Balanced]: {
-    minCpu: 21,
+    minCpu: 18,
     osdCpu: 1,
   },
   [ResourceProfile.Performance]: {
-    minCpu: 30,
+    minCpu: 24,
     osdCpu: 2,
   },
 };


### PR DESCRIPTION
## Summary
- Lowers IBM Z (s390x) resource profile minimum CPU requirements from 15/21/30 to 12/18/24 for Lean, Balanced, and Performance profiles
- Reflects reduced overhead from Noobaa and CSI pod resource optimizations
- Updates configure-performance unit tests to match the new values

Assisted by AI

Ref-https://redhat.atlassian.net/browse/RHSTOR-9418