### PR TITLE
RHSTOR-9146: Adds support for testing of external image registry

### DIFF
--- a/packages/odf/components/create-storage-system/external-systems/CreateSANSystem/CreateSANSystem.tsx
+++ b/packages/odf/components/create-storage-system/external-systems/CreateSANSystem/CreateSANSystem.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useExistingFileSystemNames } from '@odf/core/components/create-storage-system/external-systems/common/useResourceNameValidation';
 import { filterUsedDiscoveredDevices } from '@odf/core/components/utils';
+import { IBM_SCALE_NAMESPACE } from '@odf/core/constants';
 import { DiscoveredDevice, LocalDiskKind } from '@odf/core/types/scale';
 import {
   PageHeading,
@@ -46,7 +47,10 @@ import {
 import { SANSystemComponentState, initialComponentState } from './types';
 import { useDeviceFinder } from './useDeviceFinder';
 import useSANSystemFormValidation from './useFormValidation';
-import { usePersistentRegistryCheck } from './usePersistentRegistryCheck';
+import {
+  testRegistryConnection,
+  usePersistentRegistryCheck,
+} from './usePersistentRegistryCheck';
 
 type CreateSANSystemFormProps = {
   componentState: SANSystemComponentState;
@@ -133,7 +137,22 @@ const CreateSANSystemForm: React.FC<CreateSANSystemFormProps> = ({
   const onCreate = React.useCallback(async () => {
     setLoading(true);
     setError('');
-
+    const values = getValues();
+    const hasImageRegistry =
+      !!values.imageRegistryUrl && !!values.imageRepositoryName;
+    if (showRegistrySection) {
+      const registryConnectionResult = await testRegistryConnection(
+        values.imageRegistryUrl,
+        values.imageRepositoryName,
+        values.secretKey,
+        IBM_SCALE_NAMESPACE
+      );
+      if (!registryConnectionResult.ok) {
+        setError(registryConnectionResult.error);
+        setLoading(false);
+        return;
+      }
+    }
     const mappedLuns: DiscoveredDevice[] = sharedDevices.filter((lun) =>
       componentState.selectedLUNs.has(lun.WWN)
     );
@@ -143,9 +162,6 @@ const CreateSANSystemForm: React.FC<CreateSANSystemFormProps> = ({
     try {
       if (!isLocalClusterConfigured) {
         await labelNodes(componentState.selectedNodes)();
-        const values = getValues();
-        const hasImageRegistry =
-          !!values.imageRegistryUrl && !!values.imageRepositoryName;
         const buildExternalKmmRegistry = ():
           | ExternalKMMRegistryConfig
           | undefined => {
@@ -195,11 +211,12 @@ const CreateSANSystemForm: React.FC<CreateSANSystemFormProps> = ({
       setLoading(false);
     }
   }, [
-    sharedDevices,
-    componentState.selectedLUNs,
-    componentState.selectedNodes,
-    isLocalClusterConfigured,
     getValues,
+    showRegistrySection,
+    sharedDevices,
+    componentState.selectedNodes,
+    componentState.selectedLUNs,
+    isLocalClusterConfigured,
     lunGroupName,
     navigate,
     t,

--- a/packages/odf/components/create-storage-system/external-systems/CreateSANSystem/usePersistentRegistryCheck.ts
+++ b/packages/odf/components/create-storage-system/external-systems/CreateSANSystem/usePersistentRegistryCheck.ts
@@ -1,6 +1,12 @@
-import { ImageRegistryConfigModel } from '@odf/shared';
+import {
+  ImageRegistryConfigModel,
+  UX_BACKEND_PROXY_ROOT_PATH,
+} from '@odf/shared';
 import { ImageRegistryConfigKind } from '@odf/shared/types';
-import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import {
+  consoleFetchJSON,
+  useK8sWatchResource,
+} from '@openshift-console/dynamic-plugin-sdk';
 
 export const usePersistentRegistryCheck = () => {
   const [config, loaded, error] = useK8sWatchResource<ImageRegistryConfigKind>({
@@ -31,4 +37,31 @@ export const usePersistentRegistryCheck = () => {
   }
 
   return [hasPersistentRegistry, loaded, error];
+};
+
+type RegistryConnectionResult = {
+  ok: boolean;
+  error: string;
+};
+
+export const testRegistryConnection = async (
+  imageRegistryUrl: string,
+  registryRepositoryName: string,
+  secretKey: string,
+  secretNamespace: string
+): Promise<RegistryConnectionResult> => {
+  const url = `${UX_BACKEND_PROXY_ROOT_PATH}/cnsa/registry-checks`;
+  try {
+    await consoleFetchJSON(url, 'POST', {
+      body: JSON.stringify({
+        imageRegistryUrl,
+        registryRepositoryName,
+        secretKey,
+        secretNamespace,
+      }),
+    });
+  } catch (e) {
+    return { ok: false, error: (e as Error).message };
+  }
+  return { ok: true, error: '' };
 };


### PR DESCRIPTION
## Summary

Tests the external image registry provided by user via the UX backend proxy
Stops creation of other resources if registry check fails

## Screenshot
<img width="931" height="964" alt="Screenshot 2026-07-13 at 11 18 44 AM" src="https://github.com/user-attachments/assets/2af9df94-74b6-4b58-975b-9a5e27565b45" />
