### PR TITLE
DFBUGS-7048: [release-4.21-compatibility] Hide data replication separation UI on 4.21

### DIFF
--- a/packages/odf/components/create-storage-system/create-storage-system-steps/security-and-network-step/configure.tsx
+++ b/packages/odf/components/create-storage-system/create-storage-system-steps/security-and-network-step/configure.tsx
@@ -12,6 +12,10 @@ import { MultusNetworkConfigurationComponent } from './multus';
 import { NICSelectComponent } from './nic';
 import './configure.scss';
 
+// DFBUGS-7048: 4.21 backend does not support public/cluster CIDR separation under
+// Host networking. Keep the code for an easy restore; hide the UI until support lands.
+const SHOW_HOST_NETWORK_SEPARATION = false;
+
 export const NetworkFormGroup: React.FC<NetworkFormGroupProps> = ({
   setNetworkType,
   networkType,
@@ -105,6 +109,7 @@ export const NetworkFormGroup: React.FC<NetworkFormGroupProps> = ({
           setIsMultusAcknowledged={setIsMultusAcknowledged}
         />
       ) : (
+        SHOW_HOST_NETWORK_SEPARATION &&
         isFDF && (
           <NICSelectComponent
             cephClusterCIDR={cephClusterCIDR ?? ''}


### PR DESCRIPTION
4.21 backend does not support public/cluster CIDR separation under Host networking. Remove the [RHSTOR-6952](https://redhat.atlassian.net/browse/RHSTOR-6952) separation UI, validation, state, and related utilities while keeping Host networking and [DFBUGS-5756](https://redhat.atlassian.net/browse/DFBUGS-5756) addressRanges normalization in the create wizard payload.

## Description

BZ: https://redhat.atlassian.net/browse/DFBUGS-7048

On 4.21, the backend does not support separating client data path from replication path via public/cluster CIDR under Host networking. The UI was restored on release-4.21 via [RHSTOR-6952](https://redhat.atlassian.net/browse/RHSTOR-6952) / PR https://github.com/red-hat-storage/odf-console/pull/2593, which exposed options users cannot actually use. This PR removes that unsupported UI and all related validation/state on 4.21 only.

Host networking remains available. Only the separation controls (Isolate Ceph network, public/cluster CIDR) are removed.

Reason for this change:
QE filed [DFBUGS-7048](https://redhat.atlassian.net/browse/DFBUGS-7048) because 4.21 users could configure replication separation in the UI, but the backend does not support it.
This is not the same as [DFBUGS-7002](https://redhat.atlassian.net/browse/DFBUGS-7002) (4.22/master), which keeps separation UI but shows cluster network only.

This PR:
Remove NICSelectComponent from Security and network step when Host is selected
Remove CIDR/mon-ip validation from wizard footer
Remove usePublicNetwork / useClusterNetwork state and actions from reducer
Delete unused files: nic.tsx, nic.spec.tsx, nic.scss, cidr-utils.ts, cidr-utils.spec.ts
Remove unused English locale strings for the separation UI

---

## Change Type

Please select all applicable options:

- [ ] Feature
- [x] Bug Fix
- [ ] Improvement
- [ ] Refactor
- [ ] Tests

---

## Component / Area Impacted

Please select all applicable options:

- [X] ODF
- [ ] FDF
- [ ] Client
- [ ] MCO
- [ ] Fusion Access (SAN Storage)
- [ ] CNSA (Remote Mount)
- [ ] E2E Test

---

## Screenshots / Recordings

### Screenshots
<img width="3424" height="1746" alt="image" src="https://github.com/user-attachments/assets/ac57cbd6-7a3a-4903-87c5-8deab71692f3" />

<!--
Add screenshots here if applicable.
-->

### Recordings / Demo Videos

<!--
Add screen recordings, demo videos, or GIFs here if applicable.
-->

---

## Testing

Please select the type of tests included:

- [ ] Unit Tests
- [ ] E2E Tests
- [ ] No Tests Required (with justification below)

<!--
Describe testing details:
- What was tested
- How it was tested
- Any edge cases covered
- Any missing coverage (if applicable)
-->

---

## Additional Notes

<!--
Add any additional notes, caveats, follow-up tasks, or reviewer guidance here.
-->
