### PR TITLE
fix(e2e): update Cypress selectors for release-4.21 console PF5 migration

### DIFF
--- a/cypress/tests/persistent-dashboard-check.spec.ts
+++ b/cypress/tests/persistent-dashboard-check.spec.ts
@@ -1,4 +1,4 @@
-import { SECOND } from '../consts';
+import { MINUTE, SECOND } from '../consts';
 import { getPVCJSON } from '../helpers/pvc';
 import { ODFCommon } from '../views/odf-common';
 import { deletePVCFromCLI } from '../views/pvc';
@@ -19,9 +19,13 @@ describe('Check Persistent Dashboard', () => {
 
   it('Check Status Card is healthy', () => {
     cy.log('Check if Storage Cluster is Healthy');
-    cy.byTestID('success-icon').first().should('be.visible');
+    cy.byTestID('success-icon', { timeout: 5 * MINUTE })
+      .first()
+      .should('be.visible');
     cy.log('Check if Data Resiliency is Healthy');
-    cy.byTestID('success-icon').last().should('be.visible');
+    cy.byTestID('success-icon', { timeout: 5 * MINUTE })
+      .last()
+      .should('be.visible');
   });
 
   it('Check Details card is correct', () => {

--- a/cypress/views/pvc.ts
+++ b/cypress/views/pvc.ts
@@ -13,7 +13,8 @@ export const pvc = {
     cy.byTestID('pvc-size').type('{moveToEnd}');
     cy.byTestID('pvc-size').type(size);
     if (mode === 'Block') {
-      cy.byTestID('Block-radio-input').click();
+      // eslint-disable-next-line cypress/require-data-selectors
+      cy.get('#volumeMode-Block').click();
     }
     cy.byTestID('create-pvc').click();
     cy.byTestID('resource-status').contains('Bound', { timeout: 50000 });

--- a/cypress/views/storage-class.ts
+++ b/cypress/views/storage-class.ts
@@ -33,14 +33,14 @@ export const createStorageClass = (
 
   cy.log('Selecting Ceph RBD provisioner');
   cy.byTestID('storage-class-provisioner-dropdown').click();
-  cy.byLegacyTestID('dropdown-text-filter').type(
-    'openshift-storage.rbd.csi.ceph.com'
-  );
-  cy.byTestID('dropdown-menu-item-link').should(
+  cy.byTestID('console-select-search-input')
+    .find('input')
+    .type('openshift-storage.rbd.csi.ceph.com');
+  cy.byTestID('console-select-item').should(
     'contain',
     'openshift-storage.rbd.csi.ceph.com'
   );
-  cy.byTestID('dropdown-menu-item-link').click();
+  cy.byTestID('console-select-item').click();
 
   if (encrypted) {
     cy.log('Enabling encryption');

--- a/cypress/views/storage-pool.ts
+++ b/cypress/views/storage-pool.ts
@@ -45,11 +45,13 @@ export const showAvailablePoolsInSCForm = (poolType: PoolType) => {
       : CEPH_DEFAULT_FS_POOL_NAME;
 
   cy.log('Selecting provisioner');
-  cy.byTestID('storage-class-provisioner-dropdown').click();
-  cy.byLegacyTestID('dropdown-text-filter').type(
-    `openshift-storage.${provisioner}.csi.ceph.com`
-  );
-  cy.byTestID('dropdown-menu-item-link')
+  cy.byTestID('storage-class-provisioner-dropdown')
+    .should('be.visible')
+    .click();
+  cy.byTestID('console-select-search-input')
+    .find('input')
+    .type(`openshift-storage.${provisioner}.csi.ceph.com`);
+  cy.byTestID('console-select-item')
     .contains(`openshift-storage.${provisioner}.csi.ceph.com`)
     .click();
   cy.log('Show Storage pool list.');


### PR DESCRIPTION
OCP 4.21 console migrated StorageClass and PVC forms from PF4 to PF5, breaking 6 e2e tests that referenced removed data-test attributes.

Selector changes:
- dropdown-text-filter → console-select-search-input (ConsoleSelect)
- dropdown-menu-item-link → console-select-item (SelectOption)
- Block-radio-input → #volumeMode-Block (PF5 Radio uses id only)
- Add visibility wait on provisioner dropdown to fix timing race

## Description

<!--
Provide a clear and concise description of the change.
Include context, motivation, linked issues, and any important implementation details.
-->

---

## Change Type

Please select all applicable options:

- [ ] Feature
- [x] Bug Fix
- [ ] Improvement
- [ ] Refactor
- [ ] Tests

---

## Component / Area Impacted

Please select all applicable options:

- [x] ODF
- [ ] FDF
- [ ] Client
- [ ] MCO
- [ ] Fusion Access (SAN Storage)
- [ ] CNSA (Remote Mount)
- [ ] E2E Test

---

## Screenshots / Recordings

### Screenshots

<!--
Add screenshots here if applicable.
-->

### Recordings / Demo Videos

<!--
Add screen recordings, demo videos, or GIFs here if applicable.
-->

---

## Testing

Please select the type of tests included:

- [ ] Unit Tests
- [ ] E2E Tests
- [ ] No Tests Required (with justification below)

<!--
Describe testing details:
- What was tested
- How it was tested
- Any edge cases covered
- Any missing coverage (if applicable)
-->

---

## Additional Notes

<!--
Add any additional notes, caveats, follow-up tasks, or reviewer guidance here.
-->
