### PR TITLE
Fix to retain BucketClass name when navigating back

### DIFF
--- a/packages/odf/components/bucket-class/wizard-pages/general-page.tsx
+++ b/packages/odf/components/bucket-class/wizard-pages/general-page.tsx
@@ -116,6 +116,9 @@ const GeneralPage: React.FC<GeneralPageProps> = ({
   } = useForm({
     ...formSettings,
     resolver,
+    defaultValues: {
+      'bucketclassname-input': state.bucketClassName,
+    },
   });
 
   const bucketClassName: string = watch('bucketclassname-input');


### PR DESCRIPTION
## Description

In a BucketClass creation wizard, when we navigate back to the 'General' page, the 'BucketClass name', which user provided previously, is cleared and user has to type it again.

Expected behaviour is to retain the name, which user initially provided.

<!--
Provide a clear and concise description of the change.
Include context, motivation, linked issues, and any important implementation details.
-->

---

## Change Type

Please select all applicable options:

- [ ] Feature
- [x] Bug Fix
- [ ] Improvement
- [ ] Refactor
- [ ] Tests

---

## Component / Area Impacted

Please select all applicable options:

- [ ] ODF
- [ ] FDF
- [ ] Client
- [ ] MCO
- [ ] Fusion Access (SAN Storage)
- [ ] CNSA (Remote Mount)
- [ ] E2E Test

---

## Screenshots / Recordings

### Screenshots

<!--
Add screenshots here if applicable.
-->

### Recordings / Demo Videos

<!--
Add screen recordings, demo videos, or GIFs here if applicable.
-->

---

## Testing

Please select the type of tests included:

- [ ] Unit Tests
- [ ] E2E Tests
- [ ] No Tests Required (with justification below)

<!--
Describe testing details:
- What was tested
- How it was tested
- Any edge cases covered
- Any missing coverage (if applicable)
-->

---

## Additional Notes

<!--
Add any additional notes, caveats, follow-up tasks, or reviewer guidance here.
-->
