### PR TITLE
Fixes health status to reflect unknown when status field is missing

### DIFF
--- a/packages/odf/components/ibm-common/lun-group-health.ts
+++ b/packages/odf/components/ibm-common/lun-group-health.ts
@@ -1,5 +1,6 @@
 import { FileSystemKind } from '@odf/core/types/scale';
 import { HealthState } from '@openshift-console/dynamic-plugin-sdk';
+import * as _ from 'lodash-es';
 
 /** Stuck LUN group creation is treated as error after this (same as LUNCard). */
 export const LUN_GROUP_CREATION_TIMEOUT_MS = 5 * 60 * 1000;
@@ -69,6 +70,9 @@ export const isLunGroupCreating = (fileSystem: FileSystemKind): boolean => {
 export const getLUNGroupStatus = (fileSystem: FileSystemKind): HealthState => {
   if (isLunGroupConnected(fileSystem)) {
     return HealthState.OK;
+  }
+  if (_.isEmpty(fileSystem.status)) {
+    return HealthState.UNKNOWN;
   }
   if (isLunGroupCreating(fileSystem)) {
     const creationTimestamp = fileSystem.metadata?.creationTimestamp;


### PR DESCRIPTION
## Description

In DR relations when a FS is moved at first status is not present for a while for such cases we need to show status as Unknown instead of any other values.

---

## Change Type

Please select all applicable options:

- [ ] Feature
- [x] Bug Fix
- [ ] Improvement
- [ ] Refactor
- [ ] Tests

---

## Component / Area Impacted

Please select all applicable options:

- [ ] ODF
- [ ] FDF
- [ ] Client
- [ ] MCO
- [x] Fusion Access (SAN Storage)
- [ ] CNSA (Remote Mount)
- [ ] E2E Test

---

## Screenshots / Recordings

### Screenshots

<!--
Add screenshots here if applicable.
-->

### Recordings / Demo Videos

<!--
Add screen recordings, demo videos, or GIFs here if applicable.
-->

---

## Testing

Please select the type of tests included:

- [ ] Unit Tests
- [ ] E2E Tests
- [x] No Tests Required (with justification below)

<!--
Describe testing details:
- What was tested
- How it was tested
- Any edge cases covered
- Any missing coverage (if applicable)
-->

---

## Additional Notes

Fixes https://redhat.atlassian.net/browse/DFBUGS-8860
