### PR TITLE
Fix SAN Selected Nodes Table initial selection

### DIFF
--- a/packages/odf/components/create-storage-system/select-nodes-table/select-local-cluster-nodes-table.tsx
+++ b/packages/odf/components/create-storage-system/select-nodes-table/select-local-cluster-nodes-table.tsx
@@ -296,13 +296,15 @@ const InternalNodeTable: React.FC<NodeTableProps> = ({
     localClusterRoleSort,
   ]);
 
-  const [selectedRows, setSelectedRows] = React.useState<NodeData[]>([]);
+  // Initialize with all nodes selected (only once on first load, not when user deselects all)
+  const [selectedRows, setSelectedRows] = React.useState<NodeData[]>(
+    () => filteredData
+  );
 
   React.useEffect(() => {
-    if (!filteredData.length) return;
-    setSelectedRows(filteredData);
-    onRowSelected(filteredData);
-  }, [filteredData, selectedRows.length, onRowSelected]);
+    onRowSelected(selectedRows);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleRowSelection = React.useCallback(
     (selected: NodeData[]) => {


### PR DESCRIPTION
## Description

Unable to unselect the nodes from the SelectLocalClusterNodesTable while configuring the SAN system

**Fix**
Match SelectNodesTable: initialize selection once (select all filteredData on first load), then let only handleRowSelection change selection.

---

## Change Type

Please select all applicable options:

- [ ] Feature
- [x] Bug Fix
- [ ] Improvement
- [ ] Refactor
- [ ] Tests

---

## Component / Area Impacted

Please select all applicable options:

- [ ] ODF
- [x] FDF
- [ ] Client
- [ ] MCO
- [x] Fusion Access (SAN Storage)
- [ ] CNSA (Remote Mount)
- [ ] E2E Test

---

## Screenshots / Recordings

### Screenshots

<img width="1840" height="1124" alt="Screenshot 2026-07-24 at 18 45 49" src="https://github.com/user-attachments/assets/44f1e8d6-81c7-49b9-93c8-8edd51e23169" />

<img width="1840" height="1124" alt="Screenshot 2026-07-24 at 18 45 54" src="https://github.com/user-attachments/assets/16e3fb4e-2450-4586-922a-a3765573e507" />

---

## Testing

Please select the type of tests included:

- [ ] Unit Tests
- [ ] E2E Tests
- [ ] No Tests Required (with justification below)

<!--
Describe testing details:
- Go to  Connect External Systems -> SAN
- Unselect all the SelectedNodes from the table
-->

---

## Additional Notes

<!--
Add any additional notes, caveats, follow-up tasks, or reviewer guidance here.
-->
