### PR TITLE
Add filesystem capacity metrics to Scale dashboard

### DIFF
--- a/locales/en/plugin__odf-console.json
+++ b/locales/en/plugin__odf-console.json
@@ -2385,6 +2385,7 @@
   "Topology": "Topology",
   "Topology view is not supported for External mode": "Topology view is not supported for External mode",
   "Total": "Total",
+  "Total capacity": "Total capacity",
   "Total IOPS": "Total IOPS",
   "Total Latency": "Total Latency",
   "total limit": "total limit",

--- a/packages/odf/components/scale-dashboard/FileSystems.tsx
+++ b/packages/odf/components/scale-dashboard/FileSystems.tsx
@@ -1,11 +1,18 @@
 import * as React from 'react';
+import { SCALE_QUERIES, ScaleQueries } from '@odf/core/queries/system-list';
 import { FileSystemKind } from '@odf/core/types/scale';
-import { getName } from '@odf/shared';
+import { DASH, getName } from '@odf/shared';
+import {
+  useCustomPrometheusPoll,
+  usePrometheusBasePath,
+} from '@odf/shared/hooks/custom-prometheus-poll';
 import { FileSystemModel } from '@odf/shared/models/scale';
 import { GreenCheckCircleIcon } from '@odf/shared/status/icons';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
-import { referenceForModel } from '@odf/shared/utils';
+import { humanizeBinaryBytes, referenceForModel } from '@odf/shared/utils';
 import {
+  PrometheusEndpoint,
+  PrometheusResponse,
   useK8sWatchResource,
   RedExclamationCircleIcon,
   YellowExclamationTriangleIcon,
@@ -21,6 +28,7 @@ import {
   ContentVariants,
   EmptyState,
   EmptyStateVariant,
+  Skeleton,
   Title,
 } from '@patternfly/react-core';
 import { CubesIcon } from '@patternfly/react-icons';
@@ -36,6 +44,20 @@ const isConnected = (fileSystem: FileSystemKind) => {
   return fileSystem.status?.conditions?.some(
     (condition) => condition.type === 'Success' && condition.status === 'True'
   );
+};
+
+export const getFileSystemCapacity = (
+  response: PrometheusResponse,
+  fileSystemName: string
+): string => {
+  const values = response?.data?.result
+    ?.filter((result) => result.metric?.gpfs_fs_name === fileSystemName)
+    .map((result) => Number(result.value?.[1]))
+    .filter(Number.isFinite);
+
+  return values?.length
+    ? humanizeBinaryBytes(values.reduce((sum, value) => sum + value, 0)).string
+    : DASH;
 };
 
 const FileSystemStatusIcon: React.FC<{
@@ -73,6 +95,19 @@ const FileSystemsTable: React.FC = () => {
   const externalSystemName = params['systemName'];
   const [fileSystems, fileSystemsLoaded, fileSystemsLoadError] =
     useK8sWatchResource<FileSystemKind[]>(resource);
+  const prometheusBasePath = usePrometheusBasePath();
+  const [usedCapacity, usedCapacityError, usedCapacityLoading] =
+    useCustomPrometheusPoll({
+      query: SCALE_QUERIES[ScaleQueries.USED_CAPACITY],
+      endpoint: PrometheusEndpoint.QUERY,
+      basePath: prometheusBasePath,
+    });
+  const [totalCapacity, totalCapacityError, totalCapacityLoading] =
+    useCustomPrometheusPoll({
+      query: SCALE_QUERIES[ScaleQueries.RAW_CAPACITY],
+      endpoint: PrometheusEndpoint.QUERY,
+      basePath: prometheusBasePath,
+    });
   const filteredFileSystems = filterScaleFileSystems(
     fileSystems,
     externalSystemName
@@ -105,6 +140,8 @@ const FileSystemsTable: React.FC = () => {
             <Tr>
               <Th>{t('Name')}</Th>
               <Th>{t('Connection status')}</Th>
+              <Th>{t('Used capacity')}</Th>
+              <Th>{t('Total capacity')}</Th>
             </Tr>
           </Thead>
           <Tbody>
@@ -113,6 +150,24 @@ const FileSystemsTable: React.FC = () => {
                 <Td>{getName(fileSystem)}</Td>
                 <Td>
                   {isConnected(fileSystem) ? t('Connected') : t('Disconnected')}
+                </Td>
+                <Td>
+                  {usedCapacityLoading ? (
+                    <Skeleton width="35%" />
+                  ) : usedCapacityError ? (
+                    DASH
+                  ) : (
+                    getFileSystemCapacity(usedCapacity, getName(fileSystem))
+                  )}
+                </Td>
+                <Td>
+                  {totalCapacityLoading ? (
+                    <Skeleton width="35%" />
+                  ) : totalCapacityError ? (
+                    DASH
+                  ) : (
+                    getFileSystemCapacity(totalCapacity, getName(fileSystem))
+                  )}
                 </Td>
               </Tr>
             ))}


### PR DESCRIPTION

Show per-filesystem used and total capacity in the Remote CNSA dashboard using existing IBM Scale Prometheus metrics.

Jira: https://redhat.atlassian.net/browse/RHSTOR-9041

## Changes

- append Used capacity and Total capacity columns to the filesystem table
- aggregate capacity across all disk pools for each filesystem
- show loading skeletons and dash fallbacks for unavailable metrics
- add focused tests for metric aggregation and rendering states



<img width="677" height="332" alt="image" src="https://github.com/user-attachments/assets/cacb0941-6ddf-4ce6-a92c-7f890e1dae6d" />
