### PR TITLE
[release-4.19] Fixes cypress tests

### DIFF
--- a/cypress/support.ts
+++ b/cypress/support.ts
@@ -53,7 +53,7 @@ Cypress.Commands.add('install', () => {
       cy.byLegacyTestID('item-filter').type(ODF_OPERATOR_NAME);
       // data-test-operator-row="OpenShift Data Foundation"
       cy.byTestOperatorRow(ODF_OPERATOR_NAME).click();
-      cy.byLegacyTestID('horizontal-link-Storage System').click();
+      cy.byLegacyTestID('horizontal-link-Storage Systems').click();
       cy.byTestID('item-create').click();
 
       // Wait for the StorageSystem page to load.

--- a/cypress/tests/obc-test.spec.ts
+++ b/cypress/tests/obc-test.spec.ts
@@ -44,7 +44,8 @@ describe('Test Object Bucket Claim resource', () => {
   it('Test if Object Bucket Claim details page is rendered correctly', () => {
     cy.log('Test if OBC is bound');
     listPage.searchInList(OBC_NAME);
-    cy.byTestID(`resource-link-${OBC_NAME}`).click();
+    cy.byTestID(`resource-link-${OBC_NAME}`).should('be.visible').click();
+    cy.location('pathname').should('include', `/${OBC_NAME}`);
     cy.byTestID('resource-status').contains(BOUND, { timeout: MINUTE });
 
     cy.log('Test if secret data is masked');

--- a/cypress/views/list-page.ts
+++ b/cypress/views/list-page.ts
@@ -13,6 +13,15 @@ export const listPage = {
       cy.byTestActionID(actionName).click();
     },
   },
-  searchInList: (searchTerm: string) =>
-    cy.byTestID('name-filter-input').type(searchTerm),
+  searchInList: (searchTerm: string) => {
+    cy.byTestID('name-filter-input').clear();
+    cy.byTestID('name-filter-input').type(searchTerm);
+    // Console's name filter debounces URL updates (250ms). Wait until that
+    // settles while still on the list page; otherwise a late replace can
+    // navigate back from a details page opened immediately after search.
+    cy.location('search').should(
+      'include',
+      `name=${encodeURIComponent(searchTerm)}`
+    );
+  },
 };

--- a/cypress/views/pvc.ts
+++ b/cypress/views/pvc.ts
@@ -13,7 +13,8 @@ export const pvc = {
     cy.byTestID('pvc-size').type('{moveToEnd}');
     cy.byTestID('pvc-size').type(size);
     if (mode === 'Block') {
-      cy.byTestID('Block-radio-input').click();
+      // eslint-disable-next-line cypress/require-data-selectors
+      cy.get('#volumeMode-Block').click();
     }
     cy.byTestID('create-pvc').click();
     cy.byTestID('resource-status').contains('Bound', { timeout: 50000 });

--- a/cypress/views/storage-class.ts
+++ b/cypress/views/storage-class.ts
@@ -33,14 +33,10 @@ export const createStorageClass = (
 
   cy.log('Selecting Ceph RBD provisioner');
   cy.byTestID('storage-class-provisioner-dropdown').click();
-  cy.byLegacyTestID('dropdown-text-filter').type(
+  cy.byTestID('console-select-search-input').type(
     'openshift-storage.rbd.csi.ceph.com'
   );
-  cy.byTestID('dropdown-menu-item-link').should(
-    'contain',
-    'openshift-storage.rbd.csi.ceph.com'
-  );
-  cy.byTestID('dropdown-menu-item-link').click();
+  cy.contains('openshift-storage.rbd.csi.ceph.com').click();
 
   if (encrypted) {
     cy.log('Enabling encryption');

--- a/cypress/views/storage-pool.ts
+++ b/cypress/views/storage-pool.ts
@@ -48,12 +48,10 @@ export const showAvailablePoolsInSCForm = (poolType: PoolType) => {
 
   cy.log('Selecting provisioner');
   cy.byTestID('storage-class-provisioner-dropdown').click();
-  cy.byLegacyTestID('dropdown-text-filter').type(
+  cy.byTestID('console-select-search-input').type(
     `openshift-storage.${provisioner}.csi.ceph.com`
   );
-  cy.byTestID('dropdown-menu-item-link')
-    .contains(`openshift-storage.${provisioner}.csi.ceph.com`)
-    .click();
+  cy.contains(`openshift-storage.${provisioner}.csi.ceph.com`).click();
   cy.log('Show Storage pool list.');
   cy.byTestID('pool-dropdown-toggle', { timeout: 5 * SECOND })
     .should('be.visible')


### PR DESCRIPTION
## Summary
- Cherry-pick of #3010 (Fixes cypress tests) to release-4.19
- Fixes the `horizontal-link-Storage System` selector bug in `cypress/support.ts` (singular → plural "Storage Systems") that was causing CI to fail with: `Timed out retrying after 30000ms: Expected to find element: '[data-test-id="horizontal-link-Storage System"]'`

This supersedes the automated cherry-pick PR #3018.

/assign ttrishag


