### PR TITLE
Fix SAN NodesTable auto-select nodes

### DIFF
--- a/packages/odf/components/create-storage-system/external-systems/CreateSANSystem/CreateSANSystem.tsx
+++ b/packages/odf/components/create-storage-system/external-systems/CreateSANSystem/CreateSANSystem.tsx
@@ -172,7 +172,7 @@ const CreateSANSystemForm: React.FC<CreateSANSystemFormProps> = ({
     );
     try {
       if (!isLocalClusterConfigured) {
-        await labelNodes(componentState.selectedNodes)();
+        await labelNodes(componentState.selectedNodes, true)();
         const buildExternalKmmRegistry = ():
           | ExternalKMMRegistryConfig
           | undefined => {

--- a/packages/odf/components/create-storage-system/external-systems/common/NodesSection.spec.tsx
+++ b/packages/odf/components/create-storage-system/external-systems/common/NodesSection.spec.tsx
@@ -15,11 +15,14 @@ jest.mock('@odf/core/components/utils', () => ({
   ),
 }));
 
-jest.mock('../../select-nodes-table/select-local-cluster-nodes-table', () => ({
-  SelectLocalClusterNodesTable: () => (
-    <div data-test-id="local-cluster-nodes-table" />
-  ),
-}));
+jest.mock(
+  './select-local-cluster-nodes-table/select-local-cluster-nodes-table',
+  () => ({
+    SelectLocalClusterNodesTable: () => (
+      <div data-test-id="local-cluster-nodes-table" />
+    ),
+  })
+);
 
 jest.mock('../../../nodes-table/NodesTable', () => ({
   NodesTable: ({ nodes, selectedNodes, loaded, isRowSelectable }) => (

--- a/packages/odf/components/create-storage-system/external-systems/common/NodesSection.tsx
+++ b/packages/odf/components/create-storage-system/external-systems/common/NodesSection.tsx
@@ -28,8 +28,8 @@ import {
 } from '@patternfly/react-core';
 import { NodesTable } from '../../../nodes-table/NodesTable';
 import { WizardNodeState } from '../../reducer';
-import { SelectLocalClusterNodesTable } from '../../select-nodes-table/select-local-cluster-nodes-table';
 import { KernelDevelEligibility } from '../CreateScaleSystem/types';
+import { SelectLocalClusterNodesTable } from './select-local-cluster-nodes-table/select-local-cluster-nodes-table';
 
 type IncludeControlPlaneCheckboxProps = {
   isChecked: boolean;
@@ -264,10 +264,17 @@ export const SANNodesSection: React.FC<SANNodesSectionProps> = React.memo(
     const onNodeSelect = React.useCallback(
       (nodes: NodeData[]) => {
         setSelectedNodes(
-          createWizardNodeState(nodes, { enableStretchCluster })
+          createWizardNodeState(nodes, { enableStretchCluster }).map((node) => {
+            const previousRole = selectedNodes.find(
+              (n) => n.name === node.name
+            )?.localClusterRole;
+            return previousRole && node.localClusterRole !== NodeType.ARBITER
+              ? { ...node, localClusterRole: previousRole }
+              : node;
+          })
         );
       },
-      [enableStretchCluster, setSelectedNodes]
+      [enableStretchCluster, setSelectedNodes, selectedNodes]
     );
 
     const onLocalClusterRoleChange = React.useCallback(

--- a/packages/odf/components/create-storage-system/external-systems/common/payload.spec.ts
+++ b/packages/odf/components/create-storage-system/external-systems/common/payload.spec.ts
@@ -118,24 +118,26 @@ describe('payload', () => {
           labels: undefined,
           taints: [],
           architecture: 'amd64',
+          localClusterRole: 'disk-node',
         },
       ];
-      const execute = labelNodes(nodes);
+      const execute = labelNodes(nodes, true);
       await execute();
 
-      expect(mockK8sPatchByName).toHaveBeenCalledTimes(2);
+      expect(mockK8sPatchByName).toHaveBeenCalledTimes(1);
       expect(getDaemonPatchCalls()).toHaveLength(1);
-      expect(getDaemonPatchCalls()[0]).toEqual([
+      expect(getNodeRolePatchCalls()).toHaveLength(1);
+      expect(mockK8sPatchByName.mock.calls[0]).toEqual([
         NodeModel,
         'node-no-labels',
         null,
         expect.arrayContaining([
           { op: 'add', path: '/metadata/labels', value: {} },
           { op: 'add', path: LABEL_PATH, value: '' },
+          { op: 'add', path: NODE_ROLE_LABEL_PATH, value: 'disk-node' },
         ]),
       ]);
-      const daemonPatch: Patch[] = getDaemonPatchCalls()[0][3];
-      expect(daemonPatch).toHaveLength(2);
+      expect(mockK8sPatchByName.mock.calls[0][3]).toHaveLength(3);
     });
 
     it('should not add /metadata/labels when node already has labels so existing labels are not replaced by {}', async () => {
@@ -185,20 +187,22 @@ describe('payload', () => {
           labels: { [SCALE_DAEMON_NODE_LABEL]: '' },
           taints: [],
           architecture: 'amd64',
+          localClusterRole: 'disk-node',
         },
       ];
-      const execute = labelNodes(nodes);
+      const execute = labelNodes(nodes, true);
       await execute();
 
-      expect(mockK8sPatchByName).toHaveBeenCalledTimes(2);
+      expect(mockK8sPatchByName).toHaveBeenCalledTimes(1);
       expect(getDaemonPatchCalls()).toHaveLength(1);
-      const daemonPatch: Patch[] = getDaemonPatchCalls()[0][3];
-      expect(daemonPatch).toHaveLength(1);
-      expect(daemonPatch[0]).toEqual({
-        op: 'add',
-        path: LABEL_PATH,
-        value: '',
-      });
+      const patch: Patch[] = mockK8sPatchByName.mock.calls[0][3];
+      expect(patch).toEqual(
+        expect.arrayContaining([
+          { op: 'add', path: LABEL_PATH, value: '' },
+          { op: 'add', path: NODE_ROLE_LABEL_PATH, value: 'disk-node' },
+        ])
+      );
+      expect(patch.some((p) => p.path === '/metadata/labels')).toBe(false);
     });
 
     it('should skip daemon-selector patch when node already has daemon-selector label with truthy value', async () => {
@@ -220,7 +224,7 @@ describe('payload', () => {
           localClusterRole: 'disk-node',
         },
       ];
-      const execute = labelNodes(nodes);
+      const execute = labelNodes(nodes, true);
       await execute();
 
       expect(getDaemonPatchCalls()).toHaveLength(0);
@@ -263,9 +267,10 @@ describe('payload', () => {
           architecture: 'amd64',
         },
       ];
-      const execute = labelNodes(nodes);
+      const execute = labelNodes(nodes, true);
       await execute();
 
+      expect(mockK8sPatchByName).toHaveBeenCalledTimes(2);
       expect(getDaemonPatchCalls()).toHaveLength(2);
       expect(getDaemonPatchCalls()[0]).toEqual([
         NodeModel,
@@ -296,6 +301,7 @@ describe('payload', () => {
           labels: undefined,
           taints: [],
           architecture: 'amd64',
+          localClusterRole: 'disk-node',
         },
         {
           name: 'node-with-other-labels',
@@ -309,6 +315,7 @@ describe('payload', () => {
           labels: { 'custom.io/label': 'keep-me' },
           taints: [],
           architecture: 'amd64',
+          localClusterRole: 'disk-node',
         },
         {
           name: 'node-with-daemon-selector',
@@ -322,11 +329,13 @@ describe('payload', () => {
           labels: { [SCALE_DAEMON_NODE_LABEL]: 'applied' },
           taints: [],
           architecture: 'amd64',
+          localClusterRole: 'cluster-node',
         },
       ];
-      const execute = labelNodes(nodes);
+      const execute = labelNodes(nodes, true);
       await execute();
 
+      expect(mockK8sPatchByName).toHaveBeenCalledTimes(3);
       expect(getDaemonPatchCalls()).toHaveLength(2);
       expect(getNodeRolePatchCalls()).toHaveLength(3);
 
@@ -341,10 +350,20 @@ describe('payload', () => {
         expect(daemonOp).toMatchObject({ value: '' });
       });
 
-      expect(patch1).toHaveLength(2);
-      expect(patch2).toHaveLength(1);
       expect(patch1.some((op) => op.path === '/metadata/labels')).toBe(true);
       expect(patch2.some((op) => op.path === '/metadata/labels')).toBe(false);
+      expect(patch1).toEqual(
+        expect.arrayContaining([
+          { op: 'add', path: LABEL_PATH, value: '' },
+          { op: 'add', path: NODE_ROLE_LABEL_PATH, value: 'disk-node' },
+        ])
+      );
+      expect(patch2).toEqual(
+        expect.arrayContaining([
+          { op: 'add', path: LABEL_PATH, value: '' },
+          { op: 'add', path: NODE_ROLE_LABEL_PATH, value: 'disk-node' },
+        ])
+      );
     });
 
     it('should return a function that resolves to Promise.all of patch requests', async () => {
@@ -364,12 +383,14 @@ describe('payload', () => {
           labels: undefined,
           taints: [],
           architecture: 'amd64',
+          localClusterRole: 'disk-node',
         },
       ];
-      const execute = labelNodes(nodes);
+      const execute = labelNodes(nodes, true);
       const result = await execute();
 
-      expect(result).toEqual([resolved, resolved]);
+      expect(mockK8sPatchByName).toHaveBeenCalledTimes(1);
+      expect(result).toEqual([resolved]);
     });
 
     it('should patch node-role from localClusterRole', async () => {
@@ -389,17 +410,20 @@ describe('payload', () => {
           localClusterRole: 'disk-node',
         },
       ];
-      const execute = labelNodes(nodes);
+      const execute = labelNodes(nodes, true);
       await execute();
 
+      expect(mockK8sPatchByName).toHaveBeenCalledTimes(1);
       expect(getNodeRolePatchCalls()).toHaveLength(1);
-      expect(getNodeRolePatchCalls()[0][3]).toEqual([
-        {
-          op: 'add',
-          path: NODE_ROLE_LABEL_PATH,
-          value: 'disk-node',
-        },
-      ]);
+      expect(getNodeRolePatchCalls()[0][3]).toEqual(
+        expect.arrayContaining([
+          {
+            op: 'add',
+            path: NODE_ROLE_LABEL_PATH,
+            value: 'disk-node',
+          },
+        ])
+      );
     });
 
     it('should use replace for node-role when label already exists', async () => {
@@ -419,16 +443,74 @@ describe('payload', () => {
           localClusterRole: 'cluster-node',
         },
       ];
+      const execute = labelNodes(nodes, true);
+      await execute();
+
+      expect(mockK8sPatchByName).toHaveBeenCalledTimes(1);
+      expect(getNodeRolePatchCalls()[0][3]).toEqual(
+        expect.arrayContaining([
+          {
+            op: 'replace',
+            path: NODE_ROLE_LABEL_PATH,
+            value: 'cluster-node',
+          },
+        ])
+      );
+    });
+
+    it('should send a single patch containing both daemon and role label paths', async () => {
+      const nodes: WizardNodeState[] = [
+        {
+          name: 'node-combined',
+          hostName: 'node-combined',
+          cpu: '2',
+          memory: '4Gi',
+          zone: '',
+          rack: '',
+          uid: 'uid-combined',
+          roles: [],
+          labels: undefined,
+          taints: [],
+          architecture: 'amd64',
+          localClusterRole: 'disk-node',
+        },
+      ];
+      const execute = labelNodes(nodes, true);
+      await execute();
+
+      expect(mockK8sPatchByName).toHaveBeenCalledTimes(1);
+      const patch: Patch[] = mockK8sPatchByName.mock.calls[0][3];
+      expect(patch).toEqual([
+        { op: 'add', path: '/metadata/labels', value: {} },
+        { op: 'add', path: LABEL_PATH, value: '' },
+        { op: 'add', path: NODE_ROLE_LABEL_PATH, value: 'disk-node' },
+      ]);
+      expect(patch.some((op) => op.path === LABEL_PATH)).toBe(true);
+      expect(patch.some((op) => op.path === NODE_ROLE_LABEL_PATH)).toBe(true);
+    });
+
+    it('should not patch node-role when patchNodeRoleLabel is false', async () => {
+      const nodes: WizardNodeState[] = [
+        {
+          name: 'node-disk',
+          hostName: 'node-disk',
+          cpu: '2',
+          memory: '4Gi',
+          zone: '',
+          rack: '',
+          uid: 'uid-disk',
+          roles: [],
+          labels: { 'some.io/label': 'value' },
+          taints: [],
+          architecture: 'amd64',
+          localClusterRole: 'disk-node',
+        },
+      ];
       const execute = labelNodes(nodes);
       await execute();
 
-      expect(getNodeRolePatchCalls()[0][3]).toEqual([
-        {
-          op: 'replace',
-          path: NODE_ROLE_LABEL_PATH,
-          value: 'cluster-node',
-        },
-      ]);
+      expect(getDaemonPatchCalls()).toHaveLength(1);
+      expect(getNodeRolePatchCalls()).toHaveLength(0);
     });
   });
 

--- a/packages/odf/components/create-storage-system/external-systems/common/payload.ts
+++ b/packages/odf/components/create-storage-system/external-systems/common/payload.ts
@@ -61,11 +61,19 @@ export const createConfigMapPayload = (
   return () => k8sCreate({ model: ConfigMapModel, data: configMap });
 };
 
-export const labelNodes = (nodes: WizardNodeState[]) => {
+export const labelNodes = (
+  nodes: WizardNodeState[],
+  patchNodeRoleLabel = false
+) => {
   const labelPath = `/metadata/labels/${SCALE_DAEMON_NODE_LABEL.replace('/', '~1')}`;
   const nodeRoleLabelPath = `/metadata/labels/${LOCAL_CLUSTER_NODE_ROLE_LABEL}`;
   const requests: Promise<K8sKind>[] = [];
+
   nodes.forEach((node) => {
+    if (!patchNodeRoleLabel && node.labels?.[SCALE_DAEMON_NODE_LABEL]) {
+      return;
+    }
+
     const patch: Patch[] = [];
     if (!node.labels) {
       patch.push({
@@ -74,31 +82,23 @@ export const labelNodes = (nodes: WizardNodeState[]) => {
         value: {},
       });
     }
-    patch.push({
-      op: 'add',
-      path: labelPath,
-      value: '',
-    });
     if (!node.labels?.[SCALE_DAEMON_NODE_LABEL]) {
-      requests.push(k8sPatchByName(NodeModel, node.name, null, patch));
-    }
-  });
-  nodes.forEach((node) => {
-    const rolePatch: Patch[] = [];
-    if (!node.labels) {
-      rolePatch.push({
+      patch.push({
         op: 'add',
-        path: '/metadata/labels',
-        value: {},
+        path: labelPath,
+        value: '',
       });
     }
-    rolePatch.push({
-      op: node.labels?.[LOCAL_CLUSTER_NODE_ROLE_LABEL] ? 'replace' : 'add',
-      path: nodeRoleLabelPath,
-      value: node.localClusterRole,
-    });
-    requests.push(k8sPatchByName(NodeModel, node.name, null, rolePatch));
+    if (patchNodeRoleLabel) {
+      patch.push({
+        op: node.labels?.[LOCAL_CLUSTER_NODE_ROLE_LABEL] ? 'replace' : 'add',
+        path: nodeRoleLabelPath,
+        value: node.localClusterRole,
+      });
+    }
+    requests.push(k8sPatchByName(NodeModel, node.name, null, patch));
   });
+
   return () => Promise.all(requests);
 };
 

--- a/packages/odf/components/create-storage-system/external-systems/common/select-local-cluster-nodes-table/select-local-cluster-nodes-table-footer.tsx
+++ b/packages/odf/components/create-storage-system/external-systems/common/select-local-cluster-nodes-table/select-local-cluster-nodes-table-footer.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { getTotalCpu, getTotalMemory } from '@odf/core/components/utils';
+import { getAllZone } from '@odf/core/utils';
+import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
+import { humanizeBinaryBytes } from '@odf/shared/utils';
+import { Content } from '@patternfly/react-core';
+import { WizardNodeState } from '../../../reducer';
+
+export const SelectLocalClusterNodesTableFooter: React.FC<SelectNodesDetailsProps> =
+  React.memo(({ nodes }) => {
+    const { t } = useCustomTranslation();
+
+    const totalCpu = getTotalCpu(nodes);
+    const totalMemory = getTotalMemory(nodes);
+    const zones = getAllZone(nodes);
+
+    return (
+      <Content>
+        <Content component="p" data-test-id="nodes-selected">
+          {t('{{nodeCount, number}} node', {
+            nodeCount: nodes.length,
+            count: nodes.length,
+          })}{' '}
+          {t('selected ({{cpu}} CPUs and {{memory}} on ', {
+            cpu: totalCpu,
+            memory: humanizeBinaryBytes(totalMemory).string,
+          })}
+          {t('{{zoneCount, number}} zone', {
+            zoneCount: zones.size,
+            count: zones.size,
+          })}
+          {')'}
+        </Content>
+      </Content>
+    );
+  });
+SelectLocalClusterNodesTableFooter.displayName =
+  'SelectLocalClusterNodesTableFooter';
+
+type SelectNodesDetailsProps = {
+  nodes: WizardNodeState[];
+};

--- a/packages/odf/components/create-storage-system/external-systems/common/select-local-cluster-nodes-table/select-local-cluster-nodes-table.scss
+++ b/packages/odf/components/create-storage-system/external-systems/common/select-local-cluster-nodes-table/select-local-cluster-nodes-table.scss
@@ -1,0 +1,11 @@
+.odf-capacity-and-nodes__select-nodes {
+  .odf-m-pane__body {
+    /* Removes padding from the list page to align the table with rest of the form  */
+    padding: 0;
+  }
+  .co-m-nav-title {
+    // overrides extra space added by `co-m-nav-title`
+    padding: 0;
+    margin: 0;
+  }
+}

--- a/packages/odf/components/create-storage-system/external-systems/common/select-local-cluster-nodes-table/select-local-cluster-nodes-table.tsx
+++ b/packages/odf/components/create-storage-system/external-systems/common/select-local-cluster-nodes-table/select-local-cluster-nodes-table.tsx
@@ -48,9 +48,9 @@ import {
 } from '@patternfly/react-icons';
 import { Td } from '@patternfly/react-table';
 import { SortByDirection } from '@patternfly/react-table';
-import { WizardNodeState } from '../reducer';
-import { SelectNodesTableFooter } from './select-nodes-table-footer';
-import './select-nodes-table.scss';
+import { WizardNodeState } from '../../../reducer';
+import { SelectLocalClusterNodesTableFooter } from './select-local-cluster-nodes-table-footer';
+import './select-local-cluster-nodes-table.scss';
 
 const tableColumnClasses = {
   name: classNames('pf-v6-u-w-33-on-md', 'pf-v6-u-w-50-on-sm'),
@@ -88,30 +88,15 @@ const getLocalClusterRole = (
   );
 
 const LocalClusterRoleDropdown: React.FC<{
-  node: NodeData;
   role: NodeType;
-  enableStretchCluster?: boolean;
   onRoleChange: (role: NodeType) => void;
-}> = ({ node, role, enableStretchCluster, onRoleChange }) => {
+}> = ({ role, onRoleChange }) => {
   const { t } = useCustomTranslation();
-  const showArbiterNode = enableStretchCluster && isArbiterNode(node);
-
   return (
     <SingleSelectDropdown
       className="dropdown--full-width"
       selectedKey={role}
       selectOptions={[
-        ...(showArbiterNode
-          ? [
-              <SelectOption
-                key={NodeType.ARBITER}
-                value={NodeType.ARBITER}
-                isDisabled
-              >
-                {t('Arbiter node')}
-              </SelectOption>,
-            ]
-          : []),
         <SelectOption key={NodeType.CLUSTER} value={NodeType.CLUSTER}>
           {t('Cluster node')}
         </SelectOption>,
@@ -133,6 +118,7 @@ const NodeRow: React.FC<RowComponentType<NodeData>> = ({
   const { enableStretchCluster, nodes, onLocalClusterRoleChange } = extraProps;
   const nodeName = getName(node);
   const role = getLocalClusterRole(node, nodes, enableStretchCluster);
+  const showArbiterNode = enableStretchCluster && isArbiterNode(node);
 
   return (
     <>
@@ -147,14 +133,16 @@ const NodeRow: React.FC<RowComponentType<NodeData>> = ({
         {getNodeRoles(node).sort().join(', ') || '-'}
       </Td>
       <Td dataLabel={t('Local cluster role')}>
-        <LocalClusterRoleDropdown
-          node={node}
-          role={role}
-          enableStretchCluster={enableStretchCluster}
-          onRoleChange={(newRole) =>
-            onLocalClusterRoleChange(nodeName, newRole)
-          }
-        />
+        {showArbiterNode ? (
+          t('Arbiter node')
+        ) : (
+          <LocalClusterRoleDropdown
+            role={role}
+            onRoleChange={(newRole) =>
+              onLocalClusterRoleChange(nodeName, newRole)
+            }
+          />
+        )}
       </Td>
       <Td dataLabel={t('CPU')}>
         {humanizeCpuCores(getNodeCPUCapacity(node)).string || '-'}
@@ -297,14 +285,24 @@ const InternalNodeTable: React.FC<NodeTableProps> = ({
   ]);
 
   // Initialize with all nodes selected (only once on first load, not when user deselects all)
-  const [selectedRows, setSelectedRows] = React.useState<NodeData[]>(
-    () => filteredData
-  );
+  const [selectedRows, setSelectedRows] = React.useState<NodeData[]>([]);
+  const hasInitializedSelection = React.useRef(false);
 
   React.useEffect(() => {
-    onRowSelected(selectedRows);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    hasInitializedSelection.current = false;
+  }, [includeControlPlane, enableStretchCluster]);
+
+  React.useEffect(() => {
+    if (hasInitializedSelection.current) return;
+    if (!filteredData.length) {
+      setSelectedRows([]);
+      onRowSelected([]);
+      return;
+    }
+    setSelectedRows(filteredData);
+    onRowSelected(filteredData);
+    hasInitializedSelection.current = true;
+  }, [filteredData, onRowSelected]);
 
   const handleRowSelection = React.useCallback(
     (selected: NodeData[]) => {
@@ -325,7 +323,6 @@ const InternalNodeTable: React.FC<NodeTableProps> = ({
         setSelectedRows={handleRowSelection}
         loaded={true}
         variant={TableVariant.COMPACT}
-        initialSortColumnIndex={2}
       />
     </div>
   );
@@ -405,7 +402,7 @@ export const SelectLocalClusterNodesTable: React.FC<
           />
         </StatusBox>
       </ListPageBody>
-      {!!nodes.length && <SelectNodesTableFooter nodes={nodes} />}
+      {!!nodes.length && <SelectLocalClusterNodesTableFooter nodes={nodes} />}
     </div>
   );
 };


### PR DESCRIPTION
## Description

1. Control plane nodes are not auto-selected when control plane nodes option is selected.
2. Arbiter node shouldn't be a dropdown

<img width="1568" height="906" alt="image" src="https://github.com/user-attachments/assets/75db8eb9-a405-41d0-b6a4-e757f73aca9b" />

---

## Change Type

Please select all applicable options:

- [ ] Feature
- [✅ ] Bug Fix
- [ ] Improvement
- [ ] Refactor
- [ ] Tests

---

## Component / Area Impacted

Please select all applicable options:

- [ ] ODF
- [✅ ] FDF
- [ ] Client
- [ ] MCO
- [✅ ] Fusion Access (SAN Storage)
- [ ] CNSA (Remote Mount)
- [ ] E2E Test

---

## Screenshots / Recordings

### Recordings / Demo Videos

https://github.com/user-attachments/assets/1b1c9a3f-4ecf-4bdc-90e7-880245b60b4b

---

## Testing

Please select the type of tests included:

- [✅ ] Unit Tests
- [ ] E2E Tests
- [ ] No Tests Required (with justification below)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a summary footer to local cluster node selection, showing selected nodes, CPU, memory, and zones.
  * Arbiter nodes are clearly identified, with role options focused on cluster and disk roles.

* **Bug Fixes**
  * Improved node selection resets when cluster settings change.
  * Corrected SAN system node labeling during creation.
  * Preserved existing node roles while applying applicable labels.

* **Style**
  * Improved layout and spacing for the local cluster node selection interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->