### PR TITLE
Update minimum required values for MCG profiles

### DIFF
--- a/packages/odf/utils/mcg-profile.ts
+++ b/packages/odf/utils/mcg-profile.ts
@@ -13,7 +13,7 @@ const MCG_PROFILE_REQUIREMENTS: Record<
 > = {
   [McgPerformanceProfile.Default]: { cpu: 4.4, memoryGiB: 8.83 },
   [McgPerformanceProfile.MixedWorkload]: { cpu: 16.2, memoryGiB: 28.49 },
-  [McgPerformanceProfile.SmallObjects]: { cpu: 20.2, memoryGiB: 44.49 },
+  [McgPerformanceProfile.SmallObjects]: { cpu: 18.2, memoryGiB: 44.49 },
 };
 
 const MCG_PROFILE_REQUIREMENTS_S390X: Record<
@@ -22,7 +22,7 @@ const MCG_PROFILE_REQUIREMENTS_S390X: Record<
 > = {
   [McgPerformanceProfile.Default]: { cpu: 2.2, memoryGiB: 8.83 },
   [McgPerformanceProfile.MixedWorkload]: { cpu: 8.1, memoryGiB: 28.49 },
-  [McgPerformanceProfile.SmallObjects]: { cpu: 10.1, memoryGiB: 44.49 },
+  [McgPerformanceProfile.SmallObjects]: { cpu: 9.1, memoryGiB: 44.49 },
 };
 
 export const getMcgProfileRequirements = (


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHSTOR-9083

Update minimum required values for MCG profiles

CPU request for small objects is reduced with reference from the PR
https://github.com/noobaa/noobaa-operator/pull/2065

so the minimum requests are reduced by 2 
and for IBM Z minimum requests are reduced by 1.

 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced the CPU requirements for the SmallObjects profile on standard architectures and s390x.
  * Memory requirements remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->