### PR TITLE
fix: Display backup frequency as readable label instead of cron expression

### DIFF
--- a/packages/ocs/dashboards/object-service/automatic-backup/automatic-backup-card.tsx
+++ b/packages/ocs/dashboards/object-service/automatic-backup/automatic-backup-card.tsx
@@ -16,6 +16,11 @@ import {
   CardBody,
   DescriptionList,
 } from '@patternfly/react-core';
+const CRON_TO_LABEL: Record<string, string> = {
+  '0 0 * * *': 'Daily',
+  '0 0 * * 6': 'Weekly',
+  '0 0 1-7 * 6': 'Monthly',
+};
 
 const storageClusterResource = {
   kind: referenceForModel(StorageClusterModel),
@@ -49,7 +54,7 @@ const AutomaticBackupCard: React.FC = () => {
               isLoading={!ocsLoaded}
               error={ocsError}
             >
-              {dbBackup.schedule}
+              {t(CRON_TO_LABEL[dbBackup.schedule] || dbBackup.schedule)}
             </DetailItem>
 
             <DetailItem

--- a/packages/ocs/dashboards/object-service/automatic-backup/automatic-backup-card.tsx
+++ b/packages/ocs/dashboards/object-service/automatic-backup/automatic-backup-card.tsx
@@ -16,6 +16,7 @@ import {
   CardBody,
   DescriptionList,
 } from '@patternfly/react-core';
+
 const CRON_TO_LABEL: Record<string, string> = {
   '0 0 * * *': 'Daily',
   '0 0 * * 6': 'Weekly',

--- a/packages/ocs/dashboards/object-service/automatic-backup/automatic-backup-card.tsx
+++ b/packages/ocs/dashboards/object-service/automatic-backup/automatic-backup-card.tsx
@@ -20,7 +20,9 @@ import {
 
 const getReadableSchedule = (schedule: string): string => {
   const match = Object.entries(CRON_MAP).find(([, cron]) => cron === schedule);
-  return match ? match[0].charAt(0).toUpperCase() + match[0].slice(1) : schedule;
+  return match
+    ? match[0].charAt(0).toUpperCase() + match[0].slice(1)
+    : schedule;
 };
 
 const storageClusterResource = {

--- a/packages/ocs/dashboards/object-service/automatic-backup/automatic-backup-card.tsx
+++ b/packages/ocs/dashboards/object-service/automatic-backup/automatic-backup-card.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { CRON_MAP } from '@odf/core/components/create-storage-system/create-storage-system-steps/optional-settings-step/automatic-backup/automatic-backup';
 import { useGetClusterDetails } from '@odf/core/redux/utils';
 import { getStorageClusterInNs } from '@odf/core/utils';
 import {
@@ -17,11 +18,13 @@ import {
   DescriptionList,
 } from '@patternfly/react-core';
 
-const CRON_TO_LABEL: Record<string, string> = {
-  '0 0 * * *': 'Daily',
-  '0 0 * * 6': 'Weekly',
-  '0 0 1-7 * 6': 'Monthly',
-};
+const CRON_TO_LABEL: Record<string, string> = Object.entries(CRON_MAP).reduce(
+  (acc, [key, value]) => {
+    acc[value] = key.charAt(0).toUpperCase() + key.slice(1);
+    return acc;
+  },
+  {} as Record<string, string>
+);
 
 const storageClusterResource = {
   kind: referenceForModel(StorageClusterModel),

--- a/packages/ocs/dashboards/object-service/automatic-backup/automatic-backup-card.tsx
+++ b/packages/ocs/dashboards/object-service/automatic-backup/automatic-backup-card.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { CronTime, getCronTimeFromSchedule } from '@odf/core/constants';
 import { useGetClusterDetails } from '@odf/core/redux/utils';
 import { getStorageClusterInNs } from '@odf/core/utils';
 import {
@@ -9,6 +10,7 @@ import {
 import { OverviewDetailItem as DetailItem } from '@odf/shared/overview-page';
 import { referenceForModel } from '@odf/shared/utils';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import { TFunction } from 'i18next';
 import {
   Card,
   CardHeader,
@@ -16,6 +18,19 @@ import {
   CardBody,
   DescriptionList,
 } from '@patternfly/react-core';
+
+const getReadableSchedule = (schedule: string, t: TFunction): string => {
+  switch (getCronTimeFromSchedule(schedule)) {
+    case CronTime.DAILY:
+      return t('Daily');
+    case CronTime.WEEKLY:
+      return t('Weekly');
+    case CronTime.MONTHLY:
+      return t('Monthly');
+    default:
+      return schedule;
+  }
+};
 
 const storageClusterResource = {
   kind: referenceForModel(StorageClusterModel),
@@ -49,7 +64,7 @@ const AutomaticBackupCard: React.FC = () => {
               isLoading={!ocsLoaded}
               error={ocsError}
             >
-              {dbBackup.schedule}
+              {getReadableSchedule(dbBackup.schedule, t)}
             </DetailItem>
 
             <DetailItem

--- a/packages/ocs/dashboards/object-service/automatic-backup/automatic-backup-card.tsx
+++ b/packages/ocs/dashboards/object-service/automatic-backup/automatic-backup-card.tsx
@@ -18,13 +18,10 @@ import {
   DescriptionList,
 } from '@patternfly/react-core';
 
-const CRON_TO_LABEL: Record<string, string> = Object.entries(CRON_MAP).reduce(
-  (acc, [key, value]) => {
-    acc[value] = key.charAt(0).toUpperCase() + key.slice(1);
-    return acc;
-  },
-  {} as Record<string, string>
-);
+const getReadableSchedule = (schedule: string): string => {
+  const match = Object.entries(CRON_MAP).find(([, cron]) => cron === schedule);
+  return match ? match[0].charAt(0).toUpperCase() + match[0].slice(1) : schedule;
+};
 
 const storageClusterResource = {
   kind: referenceForModel(StorageClusterModel),
@@ -58,7 +55,7 @@ const AutomaticBackupCard: React.FC = () => {
               isLoading={!ocsLoaded}
               error={ocsError}
             >
-              {t(CRON_TO_LABEL[dbBackup.schedule] || dbBackup.schedule)}
+              {t(getReadableSchedule(dbBackup.schedule))}
             </DetailItem>
 
             <DetailItem

--- a/packages/odf/components/create-storage-system/create-storage-system-steps/optional-settings-step/automatic-backup/automatic-backup.tsx
+++ b/packages/odf/components/create-storage-system/create-storage-system-steps/optional-settings-step/automatic-backup/automatic-backup.tsx
@@ -1,4 +1,9 @@
 import * as React from 'react';
+import {
+  CronTime,
+  CRON_MAP,
+  getCronTimeFromSchedule,
+} from '@odf/core/constants';
 import { VolumeSnapshotClassKind, VolumeSnapshotClassModel } from '@odf/shared';
 import { SingleSelectDropdown } from '@odf/shared/dropdown';
 import { getName } from '@odf/shared/selectors';
@@ -18,25 +23,6 @@ import {
 } from '@patternfly/react-core';
 import { QuestionCircleIcon } from '@patternfly/react-icons';
 import { WizardDispatch, WizardState } from '../../../reducer';
-
-enum CronTime {
-  DAILY = 'daily',
-  WEEKLY = 'weekly',
-  MONTHLY = 'monthly',
-}
-
-const CRON_MAP: Record<CronTime, string> = {
-  [CronTime.DAILY]: '0 0 * * *', // Every day at 12:00 AM
-  [CronTime.WEEKLY]: '0 0 * * 6', // Every Saturday at 12:00 AM
-  [CronTime.MONTHLY]: '0 0 1-7 * 6', // First Saturday of each month at 12:00 AM
-};
-
-const getCronTimeFromSchedule = (schedule: string): CronTime => {
-  const entry = Object.entries(CRON_MAP).find(
-    ([, value]) => value === schedule
-  );
-  return entry ? (entry[0] as CronTime) : CronTime.DAILY;
-};
 
 const selectOptions = (volumeSnapshotClasses: VolumeSnapshotClassKind[]) =>
   volumeSnapshotClasses?.map((vsc) => (
@@ -84,7 +70,7 @@ export const AutomaticBackup: React.FC<AutomaticBackupProps> = ({
     )
   );
 
-  const selectedFrequency = getCronTimeFromSchedule(schedule);
+  const selectedFrequency = getCronTimeFromSchedule(schedule) ?? CronTime.DAILY;
   const handleSelect = (type: CronTime) => {
     dispatch({
       type: 'optionalSettings/dbBackup/schedule',

--- a/packages/odf/components/create-storage-system/create-storage-system-steps/optional-settings-step/automatic-backup/automatic-backup.tsx
+++ b/packages/odf/components/create-storage-system/create-storage-system-steps/optional-settings-step/automatic-backup/automatic-backup.tsx
@@ -19,13 +19,13 @@ import {
 import { QuestionCircleIcon } from '@patternfly/react-icons';
 import { WizardDispatch, WizardState } from '../../../reducer';
 
-enum CronTime {
+export enum CronTime {
   DAILY = 'daily',
   WEEKLY = 'weekly',
   MONTHLY = 'monthly',
 }
 
-const CRON_MAP: Record<CronTime, string> = {
+export const CRON_MAP: Record<CronTime, string> = {
   [CronTime.DAILY]: '0 0 * * *', // Every day at 12:00 AM
   [CronTime.WEEKLY]: '0 0 * * 6', // Every Saturday at 12:00 AM
   [CronTime.MONTHLY]: '0 0 1-7 * 6', // First Saturday of each month at 12:00 AM

--- a/packages/odf/components/create-storage-system/create-storage-system-steps/optional-settings-step/automatic-backup/automatic-backup.tsx
+++ b/packages/odf/components/create-storage-system/create-storage-system-steps/optional-settings-step/automatic-backup/automatic-backup.tsx
@@ -19,7 +19,7 @@ import {
 import { QuestionCircleIcon } from '@patternfly/react-icons';
 import { WizardDispatch, WizardState } from '../../../reducer';
 
-export enum CronTime {
+enum CronTime {
   DAILY = 'daily',
   WEEKLY = 'weekly',
   MONTHLY = 'monthly',

--- a/packages/odf/constants/automatic-backup.ts
+++ b/packages/odf/constants/automatic-backup.ts
@@ -1,0 +1,20 @@
+export enum CronTime {
+  DAILY = 'daily',
+  WEEKLY = 'weekly',
+  MONTHLY = 'monthly',
+}
+
+export const CRON_MAP: Record<CronTime, string> = {
+  [CronTime.DAILY]: '0 0 * * *', // Every day at 12:00 AM
+  [CronTime.WEEKLY]: '0 0 * * 6', // Every Saturday at 12:00 AM
+  [CronTime.MONTHLY]: '0 0 1-7 * 6', // First Saturday of each month at 12:00 AM
+};
+
+export const getCronTimeFromSchedule = (
+  schedule: string
+): CronTime | undefined => {
+  const entry = Object.entries(CRON_MAP).find(
+    ([, value]) => value === schedule
+  );
+  return entry ? (entry[0] as CronTime) : undefined;
+};

--- a/packages/odf/constants/index.ts
+++ b/packages/odf/constants/index.ts
@@ -1,3 +1,4 @@
+export * from './automatic-backup';
 export * from './common';
 export * from './erasure-coding';
 export * from './kms';


### PR DESCRIPTION



## Test plan
- [x] Patched StorageCluster with `schedule: "0 0 * * *"` → card shows **Daily**
- [x] Patched StorageCluster with `schedule: "0 0 * * 6"` → card shows **Weekly**
- [x] Patched StorageCluster with `schedule: "0 0 1-7 * 6"` → card shows **Monthly**


Jira:https://redhat.atlassian.net/issues?jql=assignee%20%3D%20currentUser%28%29%20and%20statusCategory%20in%20%282%2C%204%29%0AORDER%20BY%20status%20ASC%2C%20statusCategory%20DESC%2C%20updated%20DESC&selectedIssue=[DFBUGS-9100](https://redhat.atlassian.net/browse/DFBUGS-9100)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automatic backup schedules now display clear, translated labels for daily, weekly, and monthly frequencies.
  - Unrecognized schedules continue to display their configured value, ensuring schedule details remain visible.

- **Bug Fixes**
  - Improved consistency when interpreting and displaying automatic backup frequencies across backup configuration and status views.
  - Automatic backup configuration continues to default safely to a daily frequency when a schedule cannot be matched.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->