### PR TITLE
DFBUGS-6881: Unknown is displayed where “phase” is missing from the OBC status.

### DIFF
--- a/packages/odf/utils/mcg.ts
+++ b/packages/odf/utils/mcg.ts
@@ -77,7 +77,7 @@ export const getAttachOBCPatch = (
 };
 
 export const getPhase = (obj: K8sResourceKind): string => {
-  return _.get(obj, 'status.phase', 'Lost');
+  return _.get(obj, 'status.phase', 'Unknown');
 };
 
 export const isBound = (obj: K8sResourceKind): boolean =>


### PR DESCRIPTION
## Description
Jira link: https://redhat.atlassian.net/browse/DFBUGS-6881
Unknown is displayed where “phase” is missing from the OBC status.
<!--
Provide a clear and concise description of the change.
Include context, motivation, linked issues, and any important implementation details.
-->

---

## Change Type

Please select all applicable options:

- [ ] Bug Fix


---

## Component / Area Impacted

Please select all applicable options:

- [ ] ODF
- [ ] Client

---

## Screenshots / Recordings

### Screenshots

<!--
Add screenshots here if applicable.
-->

### Recordings / Demo Videos

https://github.com/user-attachments/assets/0f21de08-a4a9-4b1b-9090-8c42715f3546


<!--
Add screen recordings, demo videos, or GIFs here if applicable.
-->

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated phase display to show **“Unknown”** when no phase status is available, instead of incorrectly showing **“Lost.”**

<!-- end of auto-generated comment: release notes by coderabbit.ai -->