### PR TITLE
DFBUGS-9420: DeviceFinder -POST to include only disk nodes

### DIFF
--- a/packages/odf/components/create-storage-system/external-systems/CreateSANSystem/useDeviceFinder.ts
+++ b/packages/odf/components/create-storage-system/external-systems/CreateSANSystem/useDeviceFinder.ts
@@ -13,13 +13,28 @@ import { WizardNodeState } from '../../reducer';
 
 const DEVICE_FINDER_ENDPOINT = `${UX_BACKEND_PROXY_ROOT_PATH}/cnsa/devicefinder`;
 
-const initiateDeviceFinder = async () => {
+// Starts devicefinder on disk-node hostnames only.
+const initiateDeviceFinder = async (selectedHostnames: string[]) => {
   await consoleFetch(DEVICE_FINDER_ENDPOINT, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({}),
+    body: JSON.stringify({
+      nodeSelector: {
+        nodeSelectorTerms: [
+          {
+            matchExpressions: [
+              {
+                key: 'kubernetes.io/hostname',
+                operator: 'In',
+                values: selectedHostnames,
+              },
+            ],
+          },
+        ],
+      },
+    }),
   });
 };
 
@@ -71,6 +86,9 @@ export const useDeviceFinder = (selectedNodes?: WizardNodeState[]) => {
   const [deviceFinderLoading, setDeviceFinderLoading] = React.useState(true);
 
   const memoizedSelectedNodes = useDeepCompareMemoize(selectedNodes, true);
+  const discoveryStartedRef = React.useRef(false);
+  const [pollingEnabled, setPollingEnabled] = React.useState(false);
+
   React.useEffect(() => {
     // LUN discovery runs on disk nodes only.
     const diskNodes =
@@ -86,8 +104,20 @@ export const useDeviceFinder = (selectedNodes?: WizardNodeState[]) => {
         diskNodes
           ?.map((node) => node.labels?.['kubernetes.io/hostname'])
           .filter(Boolean) || [];
-      // Call devicefinder with a PUT request to update selected hostnames
       if (selectedHostnames.length > 0) {
+        if (!discoveryStartedRef.current) {
+          discoveryStartedRef.current = true;
+          initiateDeviceFinder(selectedHostnames)
+            .then(() => setPollingEnabled(true))
+            .catch((error) => {
+              discoveryStartedRef.current = false;
+              setDeviceFinderError(error as Error);
+              setDeviceFinderLoading(false);
+            });
+          return;
+        }
+
+        // Call devicefinder with a PUT request to update selected hostnames
         const payload = {
           nodeSelector: {
             nodeSelectorTerms: [
@@ -115,6 +145,7 @@ export const useDeviceFinder = (selectedNodes?: WizardNodeState[]) => {
         });
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [memoizedSelectedNodes]);
 
   // NEW: expose shared devices
@@ -124,54 +155,41 @@ export const useDeviceFinder = (selectedNodes?: WizardNodeState[]) => {
 
   // Initialize device finder and wait for completion before starting polling
   React.useEffect(() => {
+    if (!pollingEnabled) {
+      return;
+    }
+
     let intervalId: NodeJS.Timeout | null = null;
     let isMounted = true;
 
-    const init = async () => {
+    const fetchDeviceFinder = async () => {
       try {
-        await initiateDeviceFinder();
+        const response = await consoleFetch(DEVICE_FINDER_ENDPOINT);
+        const data = await response.json();
+        if (isMounted) {
+          setDeviceFinderResponse(data);
+
+          const shared = getSharedDiscoveredDevicesRepresentatives(data);
+          setSharedDevices(shared);
+        }
       } catch (error) {
         if (isMounted) {
           setDeviceFinderError(error as Error);
+        }
+      } finally {
+        if (isMounted) {
           setDeviceFinderLoading(false);
         }
-        return;
       }
-
-      if (!isMounted) return;
-
-      // Start polling after successful initialization
-      const fetchDeviceFinder = async () => {
-        try {
-          const response = await consoleFetch(DEVICE_FINDER_ENDPOINT);
-          const data = await response.json();
-          if (isMounted) {
-            setDeviceFinderResponse(data);
-
-            const shared = getSharedDiscoveredDevicesRepresentatives(data);
-            setSharedDevices(shared);
-          }
-        } catch (error) {
-          if (isMounted) {
-            setDeviceFinderError(error as Error);
-          }
-        } finally {
-          if (isMounted) {
-            setDeviceFinderLoading(false);
-          }
-        }
-      };
-
-      // Fetch immediately after initialization
-      fetchDeviceFinder();
-
-      // Then set up interval for subsequent polls
-      intervalId = setInterval(() => {
-        fetchDeviceFinder();
-      }, 5000);
     };
 
-    init();
+    // Fetch immediately after initialization
+    fetchDeviceFinder();
+
+    // Then set up interval for subsequent polls
+    intervalId = setInterval(() => {
+      fetchDeviceFinder();
+    }, 5000);
 
     return () => {
       isMounted = false;
@@ -179,7 +197,7 @@ export const useDeviceFinder = (selectedNodes?: WizardNodeState[]) => {
         clearInterval(intervalId);
       }
     };
-  }, []);
+  }, [pollingEnabled]);
 
   return {
     deviceFinderResponse,


### PR DESCRIPTION
## Description

DeviceFinder -POST to include only disk nodes instead of {}

---

## Change Type

Please select all applicable options:

- [ ] Feature
- [ ✅] Bug Fix
- [ ] Improvement
- [ ] Refactor
- [ ] Tests

---

## Component / Area Impacted

Please select all applicable options:

- [ ] ODF
- [✅ ] FDF
- [ ] Client
- [ ] MCO
- [ ✅] Fusion Access (SAN Storage)
- [ ] CNSA (Remote Mount)
- [ ] E2E Test

---

## Screenshots / Recordings

### Recordings / Demo Videos

https://github.com/user-attachments/assets/5b8f70bb-397f-42ed-a21f-aae4771d5613



---

## Testing

Please select the type of tests included:

- [✅ ] Unit Tests
- [ ✅] E2E Tests
- [ ] No Tests Required (with justification below)

<!--
Describe testing details:
- What was tested
- How it was tested
- Any edge cases covered
- Any missing coverage (if applicable)
-->

---

## Additional Notes

<!--
Add any additional notes, caveats, follow-up tasks, or reviewer guidance here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Device discovery now supports selected disk-node hostnames.
  * Discovery starts only after successful initialization and provides updated results as hostnames change.
  * Results are fetched immediately and refreshed automatically every five seconds.

* **Bug Fixes**
  * Improved handling of discovery initialization errors.
  * Discovery polling now stops correctly when no longer needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->