### PR TITLE
Switch CI image runtime from http-server to nginx

### DIFF
--- a/.github/workflows/quay-image.yml
+++ b/.github/workflows/quay-image.yml
@@ -16,10 +16,10 @@ jobs:
         id: vars
         run: echo ::set-output name=tag::$(echo ${GITHUB_SHA:0:8})
       - name: Build the tagged image
-        run: docker build . --file Dockerfile.ci --build-arg OPENSHIFT_CI=false --tag quay.io/ocs-dev/odf-console:${{steps.vars.outputs.tag}}
+        run: docker build . --file Dockerfile.prod --build-arg OPENSHIFT_CI=false --tag quay.io/ocs-dev/odf-console:${{steps.vars.outputs.tag}}
       - name: Push the tagged image
         run: docker push quay.io/ocs-dev/odf-console:${{steps.vars.outputs.tag}}
       - name: Build the latest image
-        run: docker build . --file Dockerfile.ci --build-arg OPENSHIFT_CI=false --tag quay.io/ocs-dev/odf-console:latest
+        run: docker build . --file Dockerfile.prod --build-arg OPENSHIFT_CI=false --tag quay.io/ocs-dev/odf-console:latest
       - name: Push the latest image to ocs-dev
         run: docker push quay.io/ocs-dev/odf-console:latest

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -23,4 +23,5 @@ FROM registry.access.redhat.com/ubi9/nginx-120
 
 COPY --from=builder /dist /opt/app-root/src
 COPY --from=builder /dist /opt/app-root/src/compatibility
+RUN ln -sf /opt/app-root/etc/nginx.d/nginx.conf /etc/nginx/nginx.conf
 CMD ["/usr/libexec/s2i/run"]


### PR DESCRIPTION
## Description

The odf-operator now configures TLS settings (`ssl_protocols`, `ssl_ciphers`, `ssl_conf_command`) via nginx directives in a ConfigMap mounted into the odf-console pod. The current CI image uses Node.js `http-server`, which doesn't understand nginx config, causing CI e2e failures when the CSV Deployment spec tries to run `nginx`.

This PR replaces the Node.js `http-server` runtime stage in `Dockerfile.ci` with `ubi9/nginx-120`, matching the ocs-client-console prod image. The existing `default.conf` is baked into the image at `/opt/app-root/etc/nginx.d/default.conf` so it works standalone; the operator can still overlay via ConfigMap mount.

Unblocks odf-operator PR #892 (TLS profile support).

---

## Change Type

- [ ] Feature
- [ ] Bug Fix
- [x] Improvement
- [ ] Refactor
- [ ] Tests

---

## Component / Area Impacted

- [x] ODF
- [ ] FDF
- [x] Client
- [x] MCO
- [ ] Fusion Access (SAN Storage)
- [ ] CNSA (Remote Mount)
- [ ] E2E Test

---

## Screenshots / Recordings

N/A — infrastructure change, no UI impact.

---

## Testing

- [ ] Unit Tests
- [ ] E2E Tests
- [x] No Tests Required (with justification below)

This is a Dockerfile-only change. Verification:

```bash
docker build -t odf-console:test -f Dockerfile.ci . --build-arg OPENSHIFT_CI=false
docker run --rm odf-console:test which nginx
docker run --rm odf-console:test nginx -v
docker run --rm odf-console:test ls /opt/app-root/src/
docker run --rm odf-console:test cat /opt/app-root/etc/nginx.d/default.conf


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added production container builds for selected plugin distributions.
  * Published both tagged and latest container images through the release workflow.

* **Refactor**
  * Updated application containers to use NGINX for serving built assets.
  * Improved startup and deployment compatibility across supported environments.
  * Removed the previous Node-based static server and script-based startup process.
  * Application functionality remains unchanged for end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->