### PR TITLE
DFBUGS-6514: [release-4.18] Remove unnecessary getObject api calls

### DIFF
--- a/packages/odf/components/s3-browser/object-details/ObjectDetailsSidebar.tsx
+++ b/packages/odf/components/s3-browser/object-details/ObjectDetailsSidebar.tsx
@@ -73,7 +73,7 @@ const ObjectDetailsSidebarContent: React.FC<ObjectDetailsSidebarContentProps> =
     const { data: objectData, isLoading: isObjectDataLoading } = useSWR(
       `${objectKey}-${OBJECT_CACHE_KEY_SUFFIX}`,
       () =>
-        noobaaS3.getObject({
+        noobaaS3.headObject({
           Bucket: bucketName,
           Key: objectKey,
         })

--- a/packages/shared/src/s3/commands.ts
+++ b/packages/shared/src/s3/commands.ts
@@ -5,6 +5,7 @@ import {
   CreateBucketCommand,
   PutBucketTaggingCommand,
   GetObjectCommand,
+  HeadObjectCommand,
   GetObjectTaggingCommand,
   DeleteObjectsCommand,
   GetBucketEncryptionCommand,
@@ -26,6 +27,7 @@ import {
   PutBucketTags,
   GetSignedUrl,
   GetObject,
+  HeadObject,
   GetObjectTagging,
   DeleteObjects,
   DeleteBucket,
@@ -100,6 +102,8 @@ export class S3Commands extends S3Client {
     );
 
   getObject: GetObject = (input) => this.send(new GetObjectCommand(input));
+
+  headObject: HeadObject = (input) => this.send(new HeadObjectCommand(input));
 
   getObjectTagging: GetObjectTagging = (input) =>
     this.send(new GetObjectTaggingCommand(input));

--- a/packages/shared/src/s3/types.ts
+++ b/packages/shared/src/s3/types.ts
@@ -21,6 +21,8 @@ import {
   DeleteObjectsCommandOutput,
   GetObjectCommandInput,
   GetObjectCommandOutput,
+  HeadObjectCommandInput,
+  HeadObjectCommandOutput,
   GetObjectTaggingCommandInput,
   GetObjectTaggingCommandOutput,
   ListObjectVersionsCommandInput,
@@ -74,6 +76,10 @@ export type DeleteObjects = (
 export type GetObject = (
   input: GetObjectCommandInput
 ) => Promise<GetObjectCommandOutput>;
+
+export type HeadObject = (
+  input: HeadObjectCommandInput
+) => Promise<HeadObjectCommandOutput>;
 
 export type GetObjectTagging = (
   input: GetObjectTaggingCommandInput


### PR DESCRIPTION
https://redhat.atlassian.net/browse/DFBUGS-6514
use headObject instead of unnecessary getObject api calls
<img width="1728" height="1117" alt="4 18" src="https://github.com/user-attachments/assets/6a336dc7-2861-4d30-b436-50f793a62aaa" />
