### PR TITLE
Fix Dockerfile.prod symlink permission denied

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -23,5 +23,9 @@ FROM registry.access.redhat.com/ubi9/nginx-120
 
 COPY --from=builder /dist /opt/app-root/src
 COPY --from=builder /dist /opt/app-root/src/compatibility
+
+USER root
 RUN ln -sf /opt/app-root/etc/nginx.d/nginx.conf /etc/nginx/nginx.conf
+USER default
+
 CMD ["/usr/libexec/s2i/run"]


### PR DESCRIPTION
## Description

The `Dockerfile.prod` build fails with `Permission denied` when creating the nginx.conf symlink because the ubi9/nginx-120 image runs as a non-root user (UID 1001). This adds `USER root` before the `ln -sf` and `USER default` after, matching the ocs-client-console prod build pattern.

---

## Change Type

- [ ] Feature
- [x] Bug Fix
- [ ] Improvement
- [ ] Refactor
- [ ] Tests

---

## Component / Area Impacted

- [x] ODF
- [ ] FDF
- [x] Client
- [x] MCO
- [ ] Fusion Access (SAN Storage)
- [ ] CNSA (Remote Mount)
- [ ] E2E Test

---

## Screenshots / Recordings

N/A - Dockerfile-only change, no UI impact.

---

## Testing

- [ ] Unit Tests
- [ ] E2E Tests
- [x] No Tests Required (with justification below)

Build succeeds with the fix:

```bash
docker build -t odf-console:test -f Dockerfile.prod . --build-arg OPENSHIFT_CI=false
docker run --rm odf-console:test ls -la /etc/nginx/nginx.conf


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production startup configuration to ensure the web server uses the correct configuration when deployed.
  * Enhanced startup permissions handling for more reliable production launches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->