### PR TITLE
DFBUGS-6512: [release-4.19-compatibility] Remove unnecessary getObject api calls

### DIFF
--- a/packages/odf/components/s3-browser/object-details/ObjectDetailsSidebar.tsx
+++ b/packages/odf/components/s3-browser/object-details/ObjectDetailsSidebar.tsx
@@ -271,12 +271,12 @@ const ObjectOverview: React.FC<ObjectOverviewProps> = ({
   const isDeleteMarker = object?.isDeleteMarker;
 
   const { data: objectData, isLoading: isObjectDataLoading } = useSWR(
-    // don't fetch if object is a delete marker ("getObject" not supported)
+    // don't fetch if object is a delete marker ("headObject" not supported)
     isDeleteMarker
       ? null
       : `${objectKey}-${lastModified}-${OBJECT_CACHE_KEY_SUFFIX}`,
     () =>
-      noobaaS3.getObject({
+      noobaaS3.headObject({
         Bucket: bucketName,
         Key: objectKey,
         ...(showVersioning && { VersionId: versionId }),

--- a/packages/shared/src/s3/commands.ts
+++ b/packages/shared/src/s3/commands.ts
@@ -5,6 +5,7 @@ import {
   CreateBucketCommand,
   PutBucketTaggingCommand,
   GetObjectCommand,
+  HeadObjectCommand,
   GetObjectTaggingCommand,
   DeleteObjectsCommand,
   GetBucketEncryptionCommand,
@@ -34,6 +35,7 @@ import {
   PutBucketTags,
   GetSignedUrl,
   GetObject,
+  HeadObject,
   GetObjectTagging,
   DeleteObjects,
   DeleteBucket,
@@ -140,6 +142,8 @@ export class S3Commands extends S3Client {
     );
 
   getObject: GetObject = (input) => this.send(new GetObjectCommand(input));
+
+  headObject: HeadObject = (input) => this.send(new HeadObjectCommand(input));
 
   getObjectTagging: GetObjectTagging = (input) =>
     this.send(new GetObjectTaggingCommand(input));

--- a/packages/shared/src/s3/types.ts
+++ b/packages/shared/src/s3/types.ts
@@ -23,6 +23,8 @@ import {
   DeleteObjectsCommandOutput,
   GetObjectCommandInput,
   GetObjectCommandOutput,
+  HeadObjectCommandInput,
+  HeadObjectCommandOutput,
   GetObjectTaggingCommandInput,
   GetObjectTaggingCommandOutput,
   ListObjectVersionsCommandInput,
@@ -122,6 +124,10 @@ export type DeleteObjects = (
 export type GetObject = (
   input: GetObjectCommandInput
 ) => Promise<GetObjectCommandOutput>;
+
+export type HeadObject = (
+  input: HeadObjectCommandInput
+) => Promise<HeadObjectCommandOutput>;
 
 export type GetObjectTagging = (
   input: GetObjectTaggingCommandInput


### PR DESCRIPTION
https://redhat.atlassian.net/browse/DFBUGS-6512
use headObject instead of unnecessary getObject api calls
<img width="1728" height="1117" alt="4 19c" src="https://github.com/user-attachments/assets/519f293d-96eb-452b-bbfd-1429a8aa7f34" />
