### PR TITLE
Run nginx symlink step as root in Dockerfile.prod

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -23,5 +23,7 @@ FROM registry.access.redhat.com/ubi9/nginx-120
 
 COPY --from=builder /dist /opt/app-root/src
 COPY --from=builder /dist /opt/app-root/src/compatibility
+USER root
 RUN ln -sf /opt/app-root/etc/nginx.d/nginx.conf /etc/nginx/nginx.conf
+USER default
 CMD ["/usr/libexec/s2i/run"]


### PR DESCRIPTION
## Summary

- Run the `/etc/nginx/nginx.conf` symlink step as `root` in `Dockerfile.prod`, then switch back to `default`
- Aligns with the downstream Konflux odf-console container Dockerfile pattern

## Problem

When building `Dockerfile.prod` locally (e.g. to test a custom `odf-console` image on a cluster), the image build fails at the symlink step:

```
ln: failed to create symbolic link '/etc/nginx/nginx.conf': Permission denied
```

The `ubi9/nginx-120` base image runs as a non-root user, so the existing `RUN ln -sf` cannot write under `/etc/nginx/`.

If the symlink is missing, the container also fails at runtime with:

```
nginx: [emerg] "worker_processes" directive is not allowed here in /opt/app-root/etc/nginx.d/nginx.conf:2
```

## Test plan

- [ ] `docker build --platform=linux/amd64 -f Dockerfile.prod . --build-arg OPENSHIFT_CI=false`
- [ ] Confirm the build completes without permission errors on the symlink step
- [ ] Deploy the image to a cluster and confirm the `odf-console` pod starts and nginx serves the plugin


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production startup configuration by ensuring nginx setup completes successfully while the service runs with the intended non-privileged user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->