### PR TITLE
Removes console tour modal using CLI args

### DIFF
--- a/cypress/cypress.config.ts
+++ b/cypress/cypress.config.ts
@@ -8,6 +8,8 @@ export default defineConfig({
     setupNodeEvents,
     specPattern: 'cypress/tests/**/*.ts',
     supportFile: 'cypress/support.ts',
+    // Disables GuidedTour (INTERNAL_DO_NOT_USE.guided-tour) via INTEGRATION_TEST flag.
+    userAgent: 'ConsoleIntegrationTestEnvironment',
   },
   fixturesFolder: false,
   reporter: 'node_modules/cypress-multi-reporters',

--- a/cypress/support/login.ts
+++ b/cypress/support/login.ts
@@ -81,20 +81,6 @@ Cypress.Commands.add(
             /* eslint-enable cypress/require-data-selectors */
             masthead.username.shouldBeVisible();
           }
-
-          // Close console tour modal.
-          cy.byTestID('detail-item-title')
-            .contains('Cluster API address')
-            .should('be.visible');
-          // eslint-disable-next-line cypress/require-data-selectors
-          cy.get('body').then(($body) => {
-            if ($body.find(`[data-test="guided-tour-modal"]`).length > 0) {
-              cy.byTestID('tour-step-footer-secondary')
-                .contains('Skip tour')
-                .click();
-              cy.byTestID('guided-tour-modal').should('not.exist');
-            }
-          });
         });
       },
       { cacheAcrossSpecs: true }


### PR DESCRIPTION
## Description

Removes code that caused failures. Console tour modal is now disabled by CLI args.

---

## Change Type

Please select all applicable options:

- [ ] Feature
- [ ] Bug Fix
- [ ] Improvement
- [ ] Refactor
- [x] Tests

---

## Component / Area Impacted

Please select all applicable options:

- [ ] ODF
- [ ] FDF
- [ ] Client
- [ ] MCO
- [ ] Fusion Access (SAN Storage)
- [ ] CNSA (Remote Mount)
- [x] E2E Test

---

## Screenshots / Recordings

### Screenshots

<!--
Add screenshots here if applicable.
-->

### Recordings / Demo Videos

<!--
Add screen recordings, demo videos, or GIFs here if applicable.
-->

---

## Testing

Please select the type of tests included:

- [ ] Unit Tests
- [x] E2E Tests
- [ ] No Tests Required (with justification below)

<!--
Describe testing details:
- What was tested
- How it was tested
- Any edge cases covered
- Any missing coverage (if applicable)
-->

---

## Additional Notes

<!--
Add any additional notes, caveats, follow-up tasks, or reviewer guidance here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test setup by automatically bypassing the introductory tour.
  * Streamlined automated login flows so testing proceeds directly after authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->