### PR TITLE
fix filesystem namespaceStore creation

### DIFF
--- a/packages/odf/components/namespace-store/namespace-store-form.tsx
+++ b/packages/odf/components/namespace-store/namespace-store-form.tsx
@@ -425,7 +425,8 @@ const NamespaceStoreForm: React.FC<NamespaceStoreFormProps> = (props) => {
                     pvcObj?.status?.phase === 'Bound' &&
                     pvcObj?.spec?.accessModes.some(
                       (mode) => mode === 'ReadWriteMany'
-                    )
+                    ) &&
+                    pvcObj.spec.volumeMode === 'Filesystem'
                   }
                 />
               )}


### PR DESCRIPTION

## Description

Updated the filter to allow only PVCs that are:
Bound 
ReadWriteMany 
Filesystem volume mode 

The reason for this change is to make sure users can select only Filesystem PVCs for creating a Filesystem NamespaceStore.


---

## Change Type

Please select all applicable options:

- [ ] Feature
- [✅ ] Bug Fix
- [ ] Improvement
- [ ] Refactor
- [ ] Tests

---

## Component / Area Impacted

Please select all applicable options:

- [✅ ] ODF
- [ ] FDF
- [ ] Client
- [ ] MCO
- [ ] Fusion Access (SAN Storage)
- [ ] CNSA (Remote Mount)
- [ ] E2E Test

---

## Screenshots / Recordings

### Screenshots


<img width="1728" height="1068" alt="Screenshot 2026-08-24 at 14 50 46" src="https://github.com/user-attachments/assets/e9789e3e-dd55-467a-b647-0afe901421f0" />

<img width="1728" height="1066" alt="Screenshot 2026-08-24 at 14 51 00" src="https://github.com/user-attachments/assets/61f13741-c38e-4fc1-9b31-501c0b75921f" />

<img width="1728" height="1038" alt="Screenshot 2026-08-24 at 14 53 18" src="https://github.com/user-attachments/assets/6bb69537-1b5b-49c3-a7d9-ee62869f7ee7" />

---

## Testing

Please select the type of tests included:

- [ ] Unit Tests
- [ ] E2E Tests
- [ ] No Tests Required (with justification below)

<!--
Describe testing details:
- What was tested
- How it was tested
- Any edge cases covered
- Any missing coverage (if applicable)
-->

---

## Additional Notes

<!--
Add any additional notes, caveats, follow-up tasks, or reviewer guidance here.
-->
