### PR TITLE
Fix Subscription error leak for non-admin users

### DIFF
--- a/packages/odf/components/s3-common/hooks/useHubS3Endpoints.ts
+++ b/packages/odf/components/s3-common/hooks/useHubS3Endpoints.ts
@@ -128,11 +128,15 @@ export const useHubS3Endpoints: UseHubS3Endpoints = () => {
   const isLoaded = !isClientCluster || (isODFNsLoaded && configMapsLoaded);
 
   const hubS3EndpointsError = React.useMemo(() => {
+    if (!isClientCluster) {
+      return undefined;
+    }
+
     if (odfNsLoadError || configMapsError) {
       return odfNsLoadError || configMapsError;
     }
 
-    if (isClientCluster && isLoaded && !hubS3EndpointsData.noobaaS3Endpoint) {
+    if (isLoaded && !hubS3EndpointsData.noobaaS3Endpoint) {
       return new Error('NooBaa S3 hub endpoint is not available');
     }
 


### PR DESCRIPTION
## Description

Non-admin Object Browser flow shows Subscription error as user doesn't have required RBACs.
This flow doesn't need to access any Subscription resource, we have an alternate ux-backend-server endpoint for this already.
UI still showing this error for the user is a miss/leak in the flow.

---

## Change Type

Please select all applicable options:

- [ ] Feature
- [x] Bug Fix
- [ ] Improvement
- [ ] Refactor
- [ ] Tests

---

## Component / Area Impacted

Please select all applicable options:

- [x] ODF
- [x] FDF
- [ ] Client
- [ ] MCO
- [ ] Fusion Access (SAN Storage)
- [ ] CNSA (Remote Mount)
- [ ] E2E Test

---

## Screenshots / Recordings

### Screenshots

<!--
Add screenshots here if applicable.
-->

### Recordings / Demo Videos

<!--
Add screen recordings, demo videos, or GIFs here if applicable.
-->

---

## Testing

Please select the type of tests included:

- [ ] Unit Tests
- [ ] E2E Tests
- [ ] No Tests Required (with justification below)

<!--
Describe testing details:
- What was tested
- How it was tested
- Any edge cases covered
- Any missing coverage (if applicable)
-->

---

## Additional Notes

<!--
Add any additional notes, caveats, follow-up tasks, or reviewer guidance here.
-->
