### PR TITLE
Enable Create Namespacestore option in dropdown for Vector Bucketclass

### DIFF
--- a/packages/odf/components/namespace-store/namespace-store-dropdown.tsx
+++ b/packages/odf/components/namespace-store/namespace-store-dropdown.tsx
@@ -42,7 +42,7 @@ export const NamespaceStoreDropdown: React.FC<NamespaceStoreDropdownProps> = ({
     true
   );
 
-  const { noobaaNamespaceStores, hasNoFilesystemStores } = React.useMemo(() => {
+  const { noobaaNamespaceStores } = React.useMemo(() => {
     const filesystemStores = nnsData.filter(
       (nns) => getNamespaceStoreType(nns) === StoreProviders.FILESYSTEM
     );
@@ -56,7 +56,6 @@ export const NamespaceStoreDropdown: React.FC<NamespaceStoreDropdownProps> = ({
 
     return {
       noobaaNamespaceStores: stores,
-      hasNoFilesystemStores: filesystemStores.length === 0,
     };
   }, [nnsData, filterArchive, filterFilesystem]);
 
@@ -127,8 +126,7 @@ export const NamespaceStoreDropdown: React.FC<NamespaceStoreDropdownProps> = ({
       isDisabled={
         !!nnsLoadErr ||
         (namespacePolicy === NamespacePolicyType.MULTI &&
-          enabledItems?.length === 0) ||
-        (filterFilesystem && hasNoFilesystemStores)
+          enabledItems?.length === 0)
       }
       isFullWidth
     >

--- a/packages/odf/components/namespace-store/namespace-store-form.tsx
+++ b/packages/odf/components/namespace-store/namespace-store-form.tsx
@@ -369,18 +369,24 @@ const NamespaceStoreForm: React.FC<NamespaceStoreFormProps> = (props) => {
             isRequired: true,
           }}
           render={({ value, onChange, onBlur }) => (
-            // Changing key forces React to re-mount the dropdown when isArchive changes,
+            // Changing key forces React to re-mount the dropdown when isArchive/ isVector changes,
             // resetting its internal state to reflect the new defaultSelection and disabled state.
             <StaticDropdown
-              key={isArchive ? 'disabled' : 'enabled'}
+              key={isArchive || isVector ? 'disabled' : 'enabled'}
               className="nb-endpoints-form-entry__dropdown"
               onSelect={onChange}
               onBlur={onBlur}
               dropdownItems={providerDropdownItems}
-              defaultSelection={isArchive ? StoreProviders.S3 : value}
+              defaultSelection={
+                isArchive
+                  ? StoreProviders.S3
+                  : isVector
+                    ? StoreProviders.FILESYSTEM
+                    : value
+              }
               data-test="namespacestore-provider"
               isFullWidth
-              isDisabled={isArchive}
+              isDisabled={isArchive || isVector}
             />
           )}
         />


### PR DESCRIPTION
## Description

Issue: The Namespacestore dropdown was disabled for Vector BucketClass creation.
---

## Change Type

Please select all applicable options:

- [ ] Feature
- [ ✅] Bug Fix
- [ ] Improvement
- [ ] Refactor
- [ ] Tests

---

## Component / Area Impacted

Please select all applicable options:

- [ ✅] ODF
- [ ] FDF
- [ ] Client
- [ ] MCO
- [ ] Fusion Access (SAN Storage)
- [ ] CNSA (Remote Mount)
- [ ] E2E Test

---

## Screenshots / Recordings

### Screenshots
<img width="1690" height="1008" alt="Screenshot 2026-08-26 at 21 40 49" src="https://github.com/user-attachments/assets/7f7b83ea-c530-4881-96f4-0df7ea6c5ac1" />

<img width="1719" height="992" alt="Screenshot 2026-08-26 at 21 40 56" src="https://github.com/user-attachments/assets/4a13cbfa-afcb-43c9-a031-6cca7c4c9276" />

<img width="1718" height="975" alt="Screenshot 2026-08-26 at 21 36 15" src="https://github.com/user-attachments/assets/c80cf847-302f-4a06-bc43-43832707ae1d" />

---

## Testing

Please select the type of tests included:

- [ ] Unit Tests
- [ ] E2E Tests
- [ ] No Tests Required (with justification below)

<!--
Describe testing details:
- What was tested
- How it was tested
- Any edge cases covered
- Any missing coverage (if applicable)
-->

---

## Additional Notes

<!--
Add any additional notes, caveats, follow-up tasks, or reviewer guidance here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved namespace store configuration for Vector bucket workflows: the provider now defaults to Filesystem and is appropriately locked when required.
  - Corrected namespace store filtering behavior so the toggle remains available when filesystem filtering is enabled, even if no filesystem stores are present.
  - Improved provider selection updates when switching between archive, Vector, and standard namespace store configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->