### PR TITLE
Fix storage cluster navigation

### DIFF
--- a/packages/odf/components/Sections/StorageClusterSection.tsx
+++ b/packages/odf/components/Sections/StorageClusterSection.tsx
@@ -11,7 +11,9 @@ import {
   useGetInternalClusterDetails,
 } from '@odf/core/redux/utils';
 import { isCapacityAutoScalingAllowed, getResourceInNs } from '@odf/core/utils';
-import OCSSystemDashboard from '@odf/ocs/dashboards/ocs-system-dashboard';
+import OCSSystemDashboard, {
+  BLOCK_FILE,
+} from '@odf/ocs/dashboards/ocs-system-dashboard';
 import {
   CustomKebabItem,
   DEFAULT_INFRASTRUCTURE,
@@ -34,6 +36,7 @@ import {
 } from '@odf/shared/utils';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import { TFunction } from 'i18next';
+import { useLocation, useNavigate } from 'react-router';
 import { EmptyState, EmptyStateBody } from '@patternfly/react-core';
 import { CubesIcon } from '@patternfly/react-icons';
 import InitialEmptyStatePage from './InitialEmptyStatePage';
@@ -131,6 +134,19 @@ const useInternalStorageCluster = () => {
 
 const StorageClusterSection: React.FC = () => {
   const { t } = useCustomTranslation();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  React.useEffect(() => {
+    if (
+      location.pathname.endsWith('/odf/storage-cluster') ||
+      location.pathname.endsWith('/odf/storage-cluster/')
+    ) {
+      navigate('/odf/storage-cluster/' + BLOCK_FILE, {
+        replace: true,
+      });
+    }
+  }, [location.pathname, navigate]);
 
   const { selectedCluster, hasMultipleStorageClusters, currentStorageCluster } =
     useInternalStorageCluster();


### PR DESCRIPTION
## Description

**Issue**: Navigation of storage cluster in the sidebar is broken

**Fix**: Same pattern as Object Storage. If the URL is exactly /odf/storage-cluster, replace it with the first tab:
`/odf/storage-cluster` → `/odf/storage-cluster/block-file`

---

## Change Type

Please select all applicable options:

- [ ] Feature
- [ ✅] Bug Fix
- [ ] Improvement
- [ ] Refactor
- [ ] Tests

---

## Component / Area Impacted

Please select all applicable options:

- [✅ ] ODF
- [ ] FDF
- [ ] Client
- [ ] MCO
- [ ] Fusion Access (SAN Storage)
- [ ] CNSA (Remote Mount)
- [ ] E2E Test

---

## Screenshots / Recordings

### Recording

https://github.com/user-attachments/assets/ee8f5c4d-edb6-42e7-b2a7-b99cebb91ad8

---

## Testing

Please select the type of tests included:

- [ ] Unit Tests
- [ ] E2E Tests
- [ ] No Tests Required (with justification below)

<!--
Describe testing details:
- What was tested
- How it was tested
- Any edge cases covered
- Any missing coverage (if applicable)
-->

---

## Additional Notes

<!--
Add any additional notes, caveats, follow-up tasks, or reviewer guidance here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Storage Cluster route to redirect users to the Block File dashboard.
  * Redirects now work consistently for both standard and trailing-slash versions of the route.
  * Navigation replaces the previous route, keeping browser history clean and preventing users from returning to the outdated destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->