### PR TITLE
modal-rendering-dark-mode-fix

### DIFF
--- a/packages/odf/components/create-bs/create-bs-modal.tsx
+++ b/packages/odf/components/create-bs/create-bs-modal.tsx
@@ -23,16 +23,14 @@ const CreateBackingStoreFormModal: React.FC<
       header={Header}
       onClose={closeModal}
     >
-      <div className="nb-endpoints__modal">
-        <ModalBody>
-          <p>
-            {t(
-              'BackingStore represents a storage target to be used as the underlying storage for the data in Multicloud Object Gateway buckets.'
-            )}
-          </p>
-          <CreateBackingStoreForm onClose={closeModal} onCancel={closeModal} />
-        </ModalBody>
-      </div>
+      <ModalBody>
+        <p>
+          {t(
+            'BackingStore represents a storage target to be used as the underlying storage for the data in Multicloud Object Gateway buckets.'
+          )}
+        </p>
+        <CreateBackingStoreForm onClose={closeModal} onCancel={closeModal} />
+      </ModalBody>
     </Modal>
   );
 };

--- a/packages/odf/components/mcg-endpoints/noobaa-provider-endpoints.scss
+++ b/packages/odf/components/mcg-endpoints/noobaa-provider-endpoints.scss
@@ -52,10 +52,6 @@
   display: flex;
 }
 
-.nb-endpoints__modal {
-  background-color: var(--pf-t--global--background--color--100);
-}
-
 .nb-endpoints-page-form__short {
   width: 80%;
 }

--- a/packages/odf/components/namespace-store/namespace-store-modal.tsx
+++ b/packages/odf/components/namespace-store/namespace-store-modal.tsx
@@ -21,21 +21,19 @@ const NamespaceStoreModal: React.FC<NamespaceStoreModalProps> = (props) => {
       title={t('Create new NamespaceStore')}
       hasNoBodyWrapper={true}
     >
-      <div className="nb-endpoints__modal">
-        <ModalBody>
-          <p>
-            {t(
-              'Represents an underlying storage to be used as read or write target for the data in the namespace buckets.'
-            )}
-          </p>
-          <NamespaceStoreForm
-            namespace={odfNamespace}
-            onCancel={closeModal}
-            redirectHandler={closeModal}
-            isVector={extraProps?.isVector}
-          />
-        </ModalBody>
-      </div>
+      <ModalBody>
+        <p>
+          {t(
+            'Represents an underlying storage to be used as read or write target for the data in the namespace buckets.'
+          )}
+        </p>
+        <NamespaceStoreForm
+          namespace={odfNamespace}
+          onCancel={closeModal}
+          redirectHandler={closeModal}
+          isVector={extraProps?.isVector}
+        />
+      </ModalBody>
     </Modal>
   );
 };


### PR DESCRIPTION
## Description

It fixes the modal rendering issue in dark mode for the Create Namespace Store and Create Backing Store modals.
The issue was caused by an SCSS class that was being used by both modals, resulting in an incorrect UI rendering in dark mode.

Jira Link: https://redhat.atlassian.net/browse/DFBUGS-7421


## Change Type

Please select all applicable options:

- [ ] Feature
- [ ✅] Bug Fix
- [ ] Improvement
- [ ] Refactor
- [ ] Tests

---

## Component / Area Impacted

Please select all applicable options:

- [✅ ] ODF
- [ ] FDF
- [ ] Client
- [ ] MCO
- [ ] Fusion Access (SAN Storage)
- [ ] CNSA (Remote Mount)
- [ ] E2E Test

---

## Screenshots / Recordings

### Screenshots

Before: 
<img width="779" height="912" alt="image" src="https://github.com/user-attachments/assets/0bb04078-8a92-4f1b-95a1-73c15ab25931" />

After: 
<img width="779" height="912" alt="Screenshot 2026-08-27 at 4 51 09 PM" src="https://github.com/user-attachments/assets/42a8fca7-abb0-464e-b210-b0a6187c2afb" />

<!--
Add screenshots here if applicable.
-->

### Recordings / Demo Videos

<!--
Add screen recordings, demo videos, or GIFs here if applicable.
-->

---

## Testing

Please select the type of tests included:

- [ ✅] Unit Tests
- [✅ ] E2E Tests
- [ ] No Tests Required (with justification below)

<!--
Describe testing details:
- What was tested
- How it was tested
- Any edge cases covered
- Any missing coverage (if applicable)
-->

---

## Additional Notes

<!--
Add any additional notes, caveats, follow-up tasks, or reviewer guidance here.
-->
