### PR TITLE
Fix Protected Applications name search for partial matches

### DIFF
--- a/packages/mco/components/protected-applications/list-page.tsx
+++ b/packages/mco/components/protected-applications/list-page.tsx
@@ -18,6 +18,7 @@ import {
   K8sResourceCommon,
   useK8sWatchResource,
   useListPageFilter,
+  RowFilter,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { LaunchModal } from '@openshift-console/dynamic-plugin-sdk/lib/app/modal-support/ModalProvider';
 import { TFunction } from 'i18next';
@@ -399,6 +400,24 @@ const ProtectedAppsTableRow: React.FC<
   );
 };
 
+// Dedicated filter key so Name search is not tied to the default
+// type: 'name' filter handling, which can leave the filter stuck after clear.
+const PAV_NAME_FILTER = 'protected-application';
+
+const nameFilter: RowFilter<ProtectedApplicationViewKind>[] = [
+  {
+    type: PAV_NAME_FILTER,
+    filterGroupName: '',
+    reducer: () => undefined,
+    items: [],
+    filter: (filterValue, pav) =>
+      fuzzyCaseInsensitive(
+        filterValue.selected?.[0],
+        getApplicationName(pav) || ''
+      ),
+  },
+];
+
 export const ProtectedApplicationsListPage: React.FC = () => {
   const { t } = useCustomTranslation();
   const launcher: LaunchModal = useModalWrapper();
@@ -428,7 +447,10 @@ export const ProtectedApplicationsListPage: React.FC = () => {
   const isAllLoadedWOAnyError =
     pavsLoaded && drpcsLoaded && !pavsError && !drpcsError;
 
-  const [data, filteredData, onFilterChange] = useListPageFilter(pavs || []);
+  const [data, filteredData, onFilterChange] = useListPageFilter(
+    pavs || [],
+    nameFilter
+  );
 
   const [pagePavs, setPagePavs] = React.useState<
     ProtectedApplicationViewKind[]
@@ -547,6 +569,8 @@ export const ProtectedApplicationsListPage: React.FC = () => {
           data: data,
           loaded: drpcsLoaded && pavsLoaded,
           onFilterChange: onFilterChange,
+          nameFilter: PAV_NAME_FILTER,
+          hideLabelFilter: true,
         }}
         composableTableProps={{
           columns: getHeaderColumns(t),


### PR DESCRIPTION
Refs [DFBUGS-9554](https://redhat.atlassian.net/browse/DFBUGS-9554)

Before this change, the Protected Applications list used the default useListPageFilter name filter, which matches Kubernetes metadata.name (the ProtectedApplicationView / DRPC resource name). The Name column, however, renders getApplicationName(pav) from
status.applicationInfo.applicationRef.name. When those strings differ, searching contiguous parts of the displayed application name failed even though shorter prefixes sometimes still matched metadata.name.

Example: for displayed name appset-workload-eea5e47a9-rbd, queries like "appset" could appear to work while "appset-wo" or "appset-workload" returned no results.

The fix overrides the console name filter (type: 'name'), matching the existing CORS/Lifecycle list-page pattern, and filters only on the displayed application name with case-insensitive substring matching (includes). Policy, cluster, namespace, and DR status are intentionally not searched.

## Description

<!--
Provide a clear and concise description of the change.
Include context, motivation, linked issues, and any important implementation details.
-->

---

## Change Type

Please select all applicable options:

- [ ] Feature
- [x] Bug Fix
- [ ] Improvement
- [ ] Refactor
- [ ] Tests

---

## Component / Area Impacted

Please select all applicable options:

- [x] ODF
- [ ] FDF
- [ ] Client
- [ ] MCO
- [ ] Fusion Access (SAN Storage)
- [ ] CNSA (Remote Mount)
- [ ] E2E Test

---

## Screenshots / Recordings

### Screenshots

<!--
Add screenshots here if applicable.
-->

### Recordings / Demo Videos

https://github.com/user-attachments/assets/824c02f6-94c4-4229-9520-389bf5b86ead


<!--
Add screen recordings, demo videos, or GIFs here if applicable.
-->

---

## Testing

Please select the type of tests included:

- [ ] Unit Tests
- [ ] E2E Tests
- [ ] No Tests Required (with justification below)

<!--
Describe testing details:
- What was tested
- How it was tested
- Any edge cases covered
- Any missing coverage (if applicable)
-->

---

## Additional Notes

<!--
Add any additional notes, caveats, follow-up tasks, or reviewer guidance here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Improved protected application search to support case-insensitive fuzzy matching.
  - Updated filtering behavior for protected application lists.
  - Hid the label filter from the list interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->