### PR TITLE
adds default bucket class when creating obc of s3-vector type

### DIFF
--- a/packages/odf/components/mcg/CreateObjectBucketClaim.tsx
+++ b/packages/odf/components/mcg/CreateObjectBucketClaim.tsx
@@ -383,7 +383,8 @@ export const CreateOBCForm: React.FC<CreateOBCFormProps> = (props) => {
               }}
               onBlur={onBlur}
               className="odf-mcg__resource-dropdown"
-              {...(bucketType === BucketType.General && {
+              {...((bucketType === BucketType.General ||
+                bucketType === BucketType.S3Vector) && {
                 initialSelection: (resources) =>
                   resources.find(
                     (res) => getName(res) === 'noobaa-default-bucket-class'


### PR DESCRIPTION
## Description: 
Before: 
Earlier we could create OBC of bucketClass type S3-Vector without selecting the Bucket Class field. It would automatically select the deafult noobaa bcucket class, but it did not show it on the UI.

After: 
Now the default BC is visible on the UI.


Jira Link: https://redhat.atlassian.net/browse/DFBUGS-8203

---

## Change Type

Please select all applicable options:

- [ ] Feature
- [💁 ] Bug Fix
- [ ] Improvement
- [ ] Refactor
- [ ] Tests

---

## Component / Area Impacted

Please select all applicable options:

- [ 💁] ODF
- [ ] FDF
- [ ] Client
- [ ] MCO
- [ ] Fusion Access (SAN Storage)
- [ ] CNSA (Remote Mount)
- [ ] E2E Test

---

## Screenshots / Recordings

<img width="1619" height="986" alt="image" src="https://github.com/user-attachments/assets/864653e5-ee44-4269-8492-d4c7bdf89025" />


## Testing

Please select the type of tests included:

- [💁 ] Unit Tests
- [🙈 ] E2E Tests
- [ ] No Tests Required (with justification below)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - S3 Vector object bucket claims now default to the `noobaa-default-bucket-class` BucketClass, matching the behavior for general buckets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->