### PR TITLE
Fixed NameValueEditor heading spacing

### DIFF
--- a/packages/mco/components/modals/app-manage-policies/helper/assign-policy-view-footer.tsx
+++ b/packages/mco/components/modals/app-manage-policies/helper/assign-policy-view-footer.tsx
@@ -10,12 +10,14 @@ import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { Operator } from '@openshift-console/dynamic-plugin-sdk';
 import { TFunction } from 'i18next';
 import * as _ from 'lodash-es';
-import { useWizardContext, WizardFooterWrapper } from '@patternfly/react-core';
 import {
-  Button,
+  ActionGroup,
   Alert,
-  AlertVariant,
   AlertProps,
+  AlertVariant,
+  Button,
+  useWizardContext,
+  WizardFooterWrapper,
 } from '@patternfly/react-core';
 import { AssignPolicyViewState, PVCSelectorType } from '../utils/reducer';
 import { DRPolicyType } from '../utils/types';
@@ -183,32 +185,36 @@ export const AssignPolicyViewFooter: React.FC<AssignPolicyViewFooterProps> = ({
         </Alert>
       )}
       <WizardFooterWrapper>
-        <Button
-          isLoading={requestInProgress}
-          isDisabled={requestInProgress || validationError}
-          variant="primary"
-          onClick={handleNext}
-        >
-          {stepName ===
-          AssignPolicyStepsNames(t)[AssignPolicySteps.ReviewAndAssign]
-            ? t('Assign')
-            : t('Next')}
-        </Button>
-        {/* Disabling the back button for the first step (Policy) in wizard */}
-        <Button
-          variant="secondary"
-          onClick={goToPrevStep}
-          isDisabled={activeStep.index === 1 || requestInProgress}
-        >
-          {t('Back')}
-        </Button>
-        <Button
-          variant="link"
-          onClick={onCancel}
-          isDisabled={requestInProgress}
-        >
-          {t('Cancel')}
-        </Button>
+        <ActionGroup>
+          <Button
+            isLoading={requestInProgress}
+            isDisabled={requestInProgress || validationError}
+            variant="primary"
+            onClick={handleNext}
+            className="pf-v6-u-mr-md"
+          >
+            {stepName ===
+            AssignPolicyStepsNames(t)[AssignPolicySteps.ReviewAndAssign]
+              ? t('Assign')
+              : t('Next')}
+          </Button>
+          {/* Disabling the back button for the first step (Policy) in wizard */}
+          <Button
+            variant="secondary"
+            onClick={goToPrevStep}
+            isDisabled={activeStep.index === 1 || requestInProgress}
+            className="pf-v6-u-mr-md"
+          >
+            {t('Back')}
+          </Button>
+          <Button
+            variant="link"
+            onClick={onCancel}
+            isDisabled={requestInProgress}
+          >
+            {t('Cancel')}
+          </Button>
+        </ActionGroup>
       </WizardFooterWrapper>
     </>
   );

--- a/packages/mco/components/modals/app-manage-policies/helper/pvc-details-wizard-content.tsx
+++ b/packages/mco/components/modals/app-manage-policies/helper/pvc-details-wizard-content.tsx
@@ -28,6 +28,7 @@ import {
   GridItem,
   Popover,
   SelectOption,
+  Tooltip,
 } from '@patternfly/react-core';
 import { MinusCircleIcon } from '@patternfly/react-icons';
 import '../../../../style.scss';
@@ -141,6 +142,8 @@ const PairElement: React.FC<PairElementProps> = ({
   alwaysAllowRemove,
   pair,
   extraProps,
+  nameString,
+  valueString,
 }) => {
   const { t } = useCustomTranslation();
   const {
@@ -186,7 +189,7 @@ const PairElement: React.FC<PairElementProps> = ({
   return (
     <Grid hasGutter>
       <GridItem lg={5} sm={5}>
-        <FormGroup hasNoPaddingTop isRequired>
+        <FormGroup label={nameString} isRequired>
           <SingleSelectDropdown
             id="placement-selection-dropdown"
             selectedKey={selectedPlacement}
@@ -207,7 +210,7 @@ const PairElement: React.FC<PairElementProps> = ({
       </GridItem>
 
       <GridItem lg={5} sm={5}>
-        <FormGroup hasNoPaddingTop isRequired>
+        <FormGroup label={valueString} isRequired>
           <MultiSelectDropdown
             id="labels-selection-dropdown"
             selections={selectedLabels}
@@ -234,8 +237,8 @@ const PairElement: React.FC<PairElementProps> = ({
           />
         </FormGroup>
       </GridItem>
-      <GridItem lg={2} sm={2}>
-        <FormGroup hasNoPaddingTop>
+      <GridItem lg={2} sm={2} className="pf-v6-u-align-self-flex-end">
+        <Tooltip content={t('Remove')}>
           <Button
             icon={deleteIcon}
             type="button"
@@ -244,7 +247,7 @@ const PairElement: React.FC<PairElementProps> = ({
             isDisabled={(isEmpty && !alwaysAllowRemove) || isDisabled}
             variant="plain"
           />
-        </FormGroup>
+        </Tooltip>
       </GridItem>
     </Grid>
   );
@@ -327,6 +330,7 @@ export const PVCDetailsWizardContent: React.FC<
           nameString={t('Application resource')}
           valueString={t('PVC label selector')}
           addString={t('Add application resource')}
+          hideHeader
           extraProps={{
             unProtectedPlacementNames,
             labels,

--- a/packages/shared/src/utils/NameValueEditor.tsx
+++ b/packages/shared/src/utils/NameValueEditor.tsx
@@ -53,6 +53,7 @@ type NameValueEditorProps = {
   isAddDisabled?: boolean;
   className?: string;
   hideHeaderWhenNoItems?: boolean;
+  hideHeader?: boolean;
   IconComponent?: React.FC;
   nameMaxLength?: number;
   valueMaxLength?: number;
@@ -219,6 +220,7 @@ export const NameValueEditor: React.FC<NameValueEditorProps> =
       isAddDisabled,
       className,
       hideHeaderWhenNoItems = false,
+      hideHeader = false,
       nameMaxLength,
       valueMaxLength,
       IconComponent = PlusCircleIcon,
@@ -323,18 +325,20 @@ export const NameValueEditor: React.FC<NameValueEditorProps> =
         <>
           {hideHeaderWhenNoItems && _.isEmpty(pairElems) ? null : (
             <>
-              <div className="row pairs-list__heading">
-                {!readOnly && allowSorting && (
+              {!hideHeader && (
+                <div className="row pairs-list__heading">
+                  {!readOnly && allowSorting && (
+                    <div className="col-xs-1 co-empty__header" />
+                  )}
+                  <div className={classNames('col-xs-5', className)}>
+                    {nameStringUpdated}
+                  </div>
+                  <div className={classNames('col-xs-5', className)}>
+                    {valueStringUpdated}
+                  </div>
                   <div className="col-xs-1 co-empty__header" />
-                )}
-                <div className={classNames('col-xs-5', className)}>
-                  {nameStringUpdated}
                 </div>
-                <div className={classNames('col-xs-5', className)}>
-                  {valueStringUpdated}
-                </div>
-                <div className="col-xs-1 co-empty__header" />
-              </div>
+              )}
               {pairElems}
             </>
           )}


### PR DESCRIPTION
## Description

Fixed NameValueEditor heading spacing in the PVC Details Wizard

---

## Change Type

Please select all applicable options:

- [ ] Feature
- [✅ ] Bug Fix
- [ ] Improvement
- [ ] Refactor
- [ ] Tests

---

## Component / Area Impacted

Please select all applicable options:

- [ ] ODF
- [ ] FDF
- [ ] Client
- [✅ ] MCO
- [ ] Fusion Access (SAN Storage)
- [ ] CNSA (Remote Mount)
- [ ] E2E Test

---

## Screenshots / Recordings

<img width="1728" height="1077" alt="Screenshot 2026-09-07 at 18 35 22" src="https://github.com/user-attachments/assets/e0b8b32a-8e9c-4f41-bb11-dd669a80118a" />

---

## Testing

Please select the type of tests included:

- [ ] Unit Tests
- [ ] E2E Tests
- [ ] No Tests Required (with justification below)

<!--
Describe testing details:
- What was tested
- How it was tested
- Any edge cases covered
- Any missing coverage (if applicable)
-->

---

## Additional Notes

<!--
Add any additional notes, caveats, follow-up tasks, or reviewer guidance here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Added descriptive labels to placement and label fields in the PVC details wizard.
  * Added a “Remove” tooltip to the delete action.
  * Improved alignment and spacing for wizard controls.
* **User Interface**
  * Updated wizard navigation controls with consistent grouping and spacing.
  * Added support for hiding column headers in name/value editors where appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->