### PR TITLE
Fix leftover LocalDisks when deleting a LUN group

### DIFF
--- a/packages/odf/modals/lun-group/DeleteLUNModal.tsx
+++ b/packages/odf/modals/lun-group/DeleteLUNModal.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FileSystemKind, LocalDiskKind } from '@odf/core/types/scale';
+import { FileSystemKind } from '@odf/core/types/scale';
 import {
   getName,
   getNamespace,
@@ -16,12 +16,11 @@ import {
   ModalHeader,
 } from '@odf/shared/modals/Modal';
 import { FileSystemModel, LocalDiskModel } from '@odf/shared/models/scale';
-import { ListKind, PersistentVolumeClaimKind } from '@odf/shared/types';
+import { PersistentVolumeClaimKind } from '@odf/shared/types';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
-import { getStorageClassName } from '@odf/shared/utils';
+import { getStorageClassName, isNotFoundError } from '@odf/shared/utils';
 import {
   k8sDelete,
-  k8sList,
   k8sPatch,
   K8sModel,
   YellowExclamationTriangleIcon,
@@ -161,19 +160,11 @@ const DeleteLUNModal: React.FC<DeleteLUNModalProps> = ({
         ],
       });
 
-      // Get all LocalDisks that reference this FileSystem
-      const localDisksResponse = await k8sList<LocalDiskKind>({
-        model: LocalDiskModel,
-        queryParams: { ns: fsNamespace },
-      });
-
-      // API may return ListKind { items: [...] } or a raw array
-      const localDisksList = Array.isArray(localDisksResponse)
-        ? localDisksResponse
-        : ((localDisksResponse as ListKind<LocalDiskKind>)?.items ?? []);
-      const associatedDisks = localDisksList.filter(
-        (disk) => disk.status?.filesystem === fsName
-      );
+      const associatedDisks = (
+        resource.spec?.local?.pools?.flatMap((pool) => pool.disks) ?? []
+      ).map((name) => ({
+        metadata: { name, namespace: fsNamespace },
+      }));
 
       // Delete StorageClass if it exists
       if (filteredStorageClasses?.length > 0) {
@@ -218,8 +209,10 @@ const DeleteLUNModal: React.FC<DeleteLUNModalProps> = ({
         )
       );
 
+      // A stale disk name that no longer exists is not an error — ignore NotFound.
       const diskFailures = localDiskResults.filter(
-        (r): r is PromiseRejectedResult => r.status === 'rejected'
+        (r): r is PromiseRejectedResult =>
+          r.status === 'rejected' && !isNotFoundError(r.reason)
       );
 
       if (diskFailures.length > 0) {


### PR DESCRIPTION
## Description

When we are deleting the LUN Group in error state, not all the associated LocalDisks are deleted.
Fix by deleting the associated  localdisks that belong to that storage pools.

---

## Change Type

Please select all applicable options:

- [ ] Feature
- [✅ ] Bug Fix
- [ ] Improvement
- [ ] Refactor
- [ ] Tests

---

## Component / Area Impacted

Please select all applicable options:

- [ ] ODF
- [ ✅] FDF
- [ ] Client
- [ ] MCO
- [✅ ] Fusion Access (SAN Storage)
- [ ] CNSA (Remote Mount)
- [ ] E2E Test

---

## Screenshots / Recordings


### Recordings / Demo Videos


https://github.com/user-attachments/assets/fd941f40-1ce7-4d62-ac97-76e00045e768

---

## Testing

Please select the type of tests included:

- [ ] Unit Tests
- [ ] E2E Tests
- [ ] No Tests Required (with justification below)

<!--
Describe testing details:
- What was tested
- How it was tested
- Any edge cases covered
- Any missing coverage (if applicable)
-->

---

## Additional Notes

<!--
Add any additional notes, caveats, follow-up tasks, or reviewer guidance here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * LUN group deletion now identifies associated local disks from the file system’s local pool configuration.
  * Deletion continues successfully when an associated local disk is no longer found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->