### PR TITLE
Deep Arcive BucketClass should contain the label in dropdown

### DIFF
--- a/packages/odf/components/mcg/CreateObjectBucketClaim.tsx
+++ b/packages/odf/components/mcg/CreateObjectBucketClaim.tsx
@@ -6,6 +6,7 @@ import {
   createNewObjectBucketClaim,
   createNewSingleNamespaceBucketClass,
   generateGenericName,
+  getBucketClassTypeDisplayText,
   getStorageClassDescription,
 } from '@odf/core/utils';
 import {
@@ -176,6 +177,9 @@ export const CreateOBCForm: React.FC<CreateOBCFormProps> = (props) => {
     }
     return !hasVectorPolicy;
   };
+
+  const getBucketClassTypeDescription = (bc: K8sResourceKind) =>
+    getBucketClassTypeDisplayText(bc as BucketClassKind, t);
 
   const { odfNamespace } = useODFNamespaceSelector();
 
@@ -390,6 +394,7 @@ export const CreateOBCForm: React.FC<CreateOBCFormProps> = (props) => {
                   ),
               })}
               filterResource={filterBucketClassByVectorPolicy}
+              secondaryTextGenerator={getBucketClassTypeDescription}
               id="bc-dropdown"
               data-test="bc-dropdown"
               resource={bucketClassResource(odfNamespace)}


### PR DESCRIPTION
## Description

A Deep Archive BucketClass (BC) in BC's dropdown list should contain the Deep Archive label to distinguish those BCs easily.

<!--
Provide a clear and concise description of the change.
Include context, motivation, linked issues, and any important implementation details.
-->

---

## Change Type

Please select all applicable options:

- [ ] Feature
- [x] Bug Fix
- [ ] Improvement
- [ ] Refactor
- [ ] Tests

---

## Component / Area Impacted

Please select all applicable options:

- [x] ODF
- [ ] FDF
- [ ] Client
- [ ] MCO
- [ ] Fusion Access (SAN Storage)
- [ ] CNSA (Remote Mount)
- [ ] E2E Test

---

## Screenshots / Recordings

### Screenshots

<!--
Add screenshots here if applicable.
-->

### Recordings / Demo Videos

<!--
Add screen recordings, demo videos, or GIFs here if applicable.
-->

---

## Testing

Please select the type of tests included:

- [ ] Unit Tests
- [ ] E2E Tests
- [ ] No Tests Required (with justification below)

<!--
Describe testing details:
- What was tested
- How it was tested
- Any edge cases covered
- Any missing coverage (if applicable)
-->

---

## Additional Notes

<!--
Add any additional notes, caveats, follow-up tasks, or reviewer guidance here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Bucket class options now display additional type-specific information in the object bucket claim creation form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->