### PR TITLE
Add bracket if IPv6 host for external postgressql db_url

### DIFF
--- a/packages/odf/components/create-storage-system/create-storage-system-steps/optional-settings-step/optional-settings-step.tsx
+++ b/packages/odf/components/create-storage-system/create-storage-system-steps/optional-settings-step/optional-settings-step.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { FDF_FLAG } from '@odf/core/redux';
 import { BackingStorageType, DeploymentType } from '@odf/core/types';
-import { TechPreviewBadge } from '@odf/shared';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { useFlag } from '@openshift-console/dynamic-plugin-sdk';
 import { Form, FormGroup, Checkbox } from '@patternfly/react-core';
@@ -65,14 +64,7 @@ export const OptionalSettings: React.FC<OptionalSettingsProps> = ({
         {!hasOCS && (
           <Checkbox
             id="use-external-postgress"
-            label={
-              <>
-                {t('Use external PostgreSQL')}
-                <span className="pf-v6-u-ml-sm">
-                  <TechPreviewBadge />
-                </span>
-              </>
-            }
+            label={t('Use external PostgreSQL')}
             description={t(
               'Allow Noobaa to connect to an external postgres server'
             )}

--- a/packages/odf/components/create-storage-system/external-systems/CreateCephSystem/CreateCephCluster.tsx
+++ b/packages/odf/components/create-storage-system/external-systems/CreateCephSystem/CreateCephCluster.tsx
@@ -9,7 +9,6 @@ import { hasAnyInternalOCS, labelOCSNamespace } from '@odf/core/utils';
 import {
   inTransitEncryptionSettingsForRHCS,
   PageHeading,
-  TechPreviewBadge,
   useCustomTranslation,
   useK8sList,
 } from '@odf/shared';
@@ -430,14 +429,7 @@ const CreateCephCluster: React.FC = () => {
           />
           <Checkbox
             id="use-external-postgress"
-            label={
-              <>
-                {t('Use external PostgreSQL')}
-                <span className="pf-v6-u-ml-sm">
-                  <TechPreviewBadge />
-                </span>
-              </>
-            }
+            label={t('Use external PostgreSQL')}
             description={t(
               'Allow Noobaa to connect to an external postgres server'
             )}

--- a/packages/odf/components/create-storage-system/payloads.ts
+++ b/packages/odf/components/create-storage-system/payloads.ts
@@ -1,4 +1,8 @@
-import { getOCSRequestData, OCSRequestData } from '@odf/core/components/utils';
+import {
+  formatIPV6HostForURL,
+  getOCSRequestData,
+  OCSRequestData,
+} from '@odf/core/components/utils';
 import { DeploymentType, BackingStorageType } from '@odf/core/types';
 import { isFlexibleScaling } from '@odf/core/utils';
 import { Payload } from '@odf/odf-plugin-sdk/extensions';
@@ -34,7 +38,7 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import { K8sKind } from '@openshift-console/dynamic-plugin-sdk/lib/api/common-types';
 import * as _ from 'lodash-es';
-import { ocsTaint, DefaultRequestSize, NO_PROVISIONER } from '../../constants';
+import { DefaultRequestSize, NO_PROVISIONER, ocsTaint } from '../../constants';
 import { WizardNodeState, WizardState } from './reducer';
 
 export const createSecretPayload = (
@@ -76,7 +80,7 @@ export const createNoobaaExternalPostgresResources = (
 ): Promise<K8sResourceKind>[] => {
   let secretResources: Promise<K8sResourceKind>[] = [];
   const stringData = {
-    db_url: `postgresql://${externalPostgresDetails.username}:${externalPostgresDetails.password}@${externalPostgresDetails.serverName}:${externalPostgresDetails.port}/${externalPostgresDetails.databaseName}`,
+    db_url: `postgresql://${externalPostgresDetails.username}:${externalPostgresDetails.password}@${formatIPV6HostForURL(externalPostgresDetails.serverName)}:${externalPostgresDetails.port}/${externalPostgresDetails.databaseName}`,
   };
   const noobaaExternalPostgresSecretPayload = createSecretPayload(
     NOOBA_EXTERNAL_PG_SECRET_NAME,

--- a/packages/odf/components/utils/common.ts
+++ b/packages/odf/components/utils/common.ts
@@ -290,6 +290,10 @@ export const getIPFamily = (addr: string): IPFamily => {
   return ipPattern.test(addr) ? IPFamily.IPV4 : IPFamily.IPV6;
 };
 
+export const formatIPV6HostForURL = (host: string): string => {
+  const ipv6Pattern = /^(?=.*:)[0-9A-Fa-f:]+$/;
+  return ipv6Pattern.test(host) ? `[${host}]` : host;
+};
 export const checkError = (
   data: string = '{}',
   requiredKeys = [],


### PR DESCRIPTION
## Description

https://redhat.atlassian.net/browse/DFBUGS-10790
https://redhat.atlassian.net/browse/DFBUGS-10063

---

## Change Type

Please select all applicable options:

- [ ] Feature
- [✅ ] Bug Fix
- [ ] Improvement
- [ ] Refactor
- [ ] Tests

---

## Component / Area Impacted

Please select all applicable options:

- [ ✅] ODF
- [ ] FDF
- [ ] Client
- [ ] MCO
- [ ] Fusion Access (SAN Storage)
- [ ] CNSA (Remote Mount)
- [ ] E2E Test

---

## Screenshots / Recordings

### Screenshots

<img width="1728" height="965" alt="Screenshot 2026-09-09 at 13 49 58" src="https://github.com/user-attachments/assets/e2e06a5d-f43f-4b9d-b07d-b5a60ba248e6" />


<img width="1728" height="923" alt="Screenshot 2026-09-09 at 14 01 10" src="https://github.com/user-attachments/assets/3a2ffcfc-72c7-49a1-a38b-d433bcf2142b" />


---

## Testing

Please select the type of tests included:

- [ ] Unit Tests
- [ ] E2E Tests
- [ ] No Tests Required (with justification below)

<!--
Describe testing details:
- What was tested
- How it was tested
- Any edge cases covered
- Any missing coverage (if applicable)
-->

---

## Additional Notes

<!--
Add any additional notes, caveats, follow-up tasks, or reviewer guidance here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed external PostgreSQL connection URLs for IPv6 server addresses by formatting hosts correctly.
  - Prevented invalid double-bracketing for already-bracketed IPv6 addresses.
  - Added support for compressed and IPv4-mapped IPv6 database hosts in connection strings.

- **User Interface**
  - Removed the “Tech Preview” badge from the external PostgreSQL option during storage system setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->