### PR TITLE
Block duplicate DRPolicy names on create

### DIFF
--- a/locales/en/plugin__odf-console.json
+++ b/locales/en/plugin__odf-console.json
@@ -163,6 +163,7 @@
   "A BackingStore represents a storage target to be used as the underlying storage layer in Multicloud Object Gateway buckets.": "A BackingStore represents a storage target to be used as the underlying storage layer in Multicloud Object Gateway buckets.",
   "A dimension is the number of values in a vector. Larger dimensions require more storage.": "A dimension is the number of values in a vector. Larger dimensions require more storage.",
   "A dimension must be an integer between 1 and 4096": "A dimension must be an integer between 1 and 4096",
+  "A DRPolicy with name '{{name}}' already exists. Please choose a different name.": "A DRPolicy with name '{{name}}' already exists. Please choose a different name.",
   "A failover will occur for all namespaces currently under this DRPC.": "A failover will occur for all namespaces currently under this DRPC.",
   "A list of all Multicloud Object Gateway resources that are currently in use. Those resources are used to store data according to the buckets' policies and can be a cloud-based resource or a bare metal resource.": "A list of all Multicloud Object Gateway resources that are currently in use. Those resources are used to store data according to the buckets' policies and can be a cloud-based resource or a bare metal resource.",
   "a local backing store is recommended for better performance": "a local backing store is recommended for better performance",

--- a/packages/mco/components/create-dr-policy/create-dr-policy-wizard.tsx
+++ b/packages/mco/components/create-dr-policy/create-dr-policy-wizard.tsx
@@ -4,6 +4,7 @@ import { getMajorVersion } from '@odf/mco/utils';
 import {
   ACM_DEFAULT_DOC_VERSION,
   DRClusterModel,
+  DRPolicyModel,
   MirrorPeerModel,
   useDocVersion,
 } from '@odf/shared';
@@ -124,6 +125,13 @@ export const CreateDRPolicyWizard: React.FC<CreateDRPolicyWizardProps> = ({
   const [drClusters, drClustersLoaded, drClustersLoadError] =
     useK8sWatchResource<DRClusterKind[]>({
       kind: referenceForModel(DRClusterModel),
+      isList: true,
+      namespaced: false,
+    });
+
+  const [drPolicies, drPoliciesLoaded, drPoliciesLoadError] =
+    useK8sWatchResource<DRPolicyKind[]>({
+      kind: referenceForModel(DRPolicyModel),
       isList: true,
       namespaced: false,
     });
@@ -298,8 +306,13 @@ export const CreateDRPolicyWizard: React.FC<CreateDRPolicyWizardProps> = ({
     setStep(CreateDRPolicyWizardSteps.Clusters);
   };
 
-  const loaded = mirrorPeerLoaded && drClustersLoaded;
-  const loadedError = mirrorPeerLoadError || drClustersLoadError;
+  const loaded = mirrorPeerLoaded && drClustersLoaded && drPoliciesLoaded;
+  const loadedError =
+    mirrorPeerLoadError || drClustersLoadError || drPoliciesLoadError;
+
+  const isPolicyNameTaken = (drPolicies ?? []).some(
+    (policy) => getName(policy) === state.policy.policyName
+  );
 
   const clusterNames = React.useMemo(
     () => state.clusters.selectedClusters.map(getName),
@@ -369,12 +382,14 @@ export const CreateDRPolicyWizard: React.FC<CreateDRPolicyWizardProps> = ({
       allDRClustersExist,
       prePairValidationPassed
     ),
-    [CreateDRPolicyWizardSteps.Policy]: validatePolicyStepInputs(state),
-    [CreateDRPolicyWizardSteps.Review]: validateReviewStepInputs(
-      state,
-      allDRClustersExist,
-      prePairValidationPassed
-    ),
+    [CreateDRPolicyWizardSteps.Policy]:
+      validatePolicyStepInputs(state) && !isPolicyNameTaken,
+    [CreateDRPolicyWizardSteps.Review]:
+      validateReviewStepInputs(
+        state,
+        allDRClustersExist,
+        prePairValidationPassed
+      ) && !isPolicyNameTaken,
   };
 
   return (
@@ -446,6 +461,7 @@ export const CreateDRPolicyWizard: React.FC<CreateDRPolicyWizardProps> = ({
           state={state}
           dispatch={dispatch}
           docHref={gettingStartedDRDocs(odfMCOVersion).CREATE_POLICY}
+          isPolicyNameTaken={isPolicyNameTaken}
         />
       </WizardStep>
       <WizardStep

--- a/packages/mco/components/create-dr-policy/utils/k8s-utils.spec.ts
+++ b/packages/mco/components/create-dr-policy/utils/k8s-utils.spec.ts
@@ -3,7 +3,6 @@ import { ManagedClusterInfoType, MirrorPeerKind } from '@odf/mco/types';
 import {
   k8sCreate,
   k8sDelete,
-  k8sGet,
   k8sUpdate,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { createPolicyPromises } from './k8s-utils';
@@ -11,18 +10,15 @@ import { drPolicyInitialState, DRPolicyState } from './reducer';
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
   ...jest.requireActual('@openshift-console/dynamic-plugin-sdk'),
-  k8sGet: jest.fn(),
   k8sCreate: jest.fn(),
   k8sUpdate: jest.fn(),
   k8sDelete: jest.fn(),
 }));
 
-const mockK8sGet = k8sGet as jest.Mock;
 const mockK8sCreate = k8sCreate as jest.Mock;
 const mockK8sUpdate = k8sUpdate as jest.Mock;
 const mockK8sDelete = k8sDelete as jest.Mock;
 
-const notFound = { response: { status: 404 } };
 const forbidden = { response: { status: 403 } };
 const conflict = { response: { status: 409 } };
 
@@ -78,11 +74,6 @@ const existingMirrorPeer = {
   spec: { items: [peerItem('east-1'), peerItem('west-1')] },
 } as MirrorPeerKind;
 
-const existingPolicy = {
-  metadata: { name: 'policy-1', uid: 'uid-1', resourceVersion: '1' },
-  spec: { drClusters: ['east-1', 'west-1'], schedulingInterval: '10m' },
-};
-
 const resolveCreate = ({ model, data }) =>
   Promise.resolve(
     model.kind === 'MirrorPeer'
@@ -98,8 +89,7 @@ describe('createPolicyPromises DRPolicy create vs update detection', () => {
     mockK8sDelete.mockResolvedValue({});
   });
 
-  it('sets isNewPolicy from createOrUpdate create vs update', async () => {
-    mockK8sGet.mockRejectedValueOnce(notFound);
+  it('creates a DRPolicy and does not update when the name already exists', async () => {
     await expect(
       createPolicyPromises(state, [existingMirrorPeer])
     ).resolves.toMatchObject({
@@ -110,31 +100,15 @@ describe('createPolicyPromises DRPolicy create vs update detection', () => {
     expect(mockK8sUpdate).not.toHaveBeenCalled();
 
     jest.clearAllMocks();
-    mockK8sUpdate.mockImplementation(({ data }) => Promise.resolve(data));
-    mockK8sGet.mockResolvedValue(existingPolicy);
-    await expect(
-      createPolicyPromises(state, [existingMirrorPeer])
-    ).resolves.toMatchObject({ isNewPolicy: false });
-    expect(mockK8sCreate).not.toHaveBeenCalled();
-  });
-
-  it('fails closed on forbidden GET; 404→409 race becomes an update', async () => {
-    mockK8sGet.mockRejectedValue(forbidden);
-    await expect(
-      createPolicyPromises(state, [existingMirrorPeer])
-    ).rejects.toEqual(forbidden);
-
-    mockK8sGet
-      .mockRejectedValueOnce(notFound)
-      .mockResolvedValue(existingPolicy);
     mockK8sCreate.mockRejectedValueOnce(conflict);
+    mockK8sUpdate.mockImplementation(({ data }) => Promise.resolve(data));
     await expect(
       createPolicyPromises(state, [existingMirrorPeer])
-    ).resolves.toMatchObject({ isNewPolicy: false });
+    ).rejects.toEqual(conflict);
+    expect(mockK8sUpdate).not.toHaveBeenCalled();
   });
 
   it('creates MirrorPeer when missing and rolls it back if DRPolicy create fails', async () => {
-    mockK8sGet.mockRejectedValue(notFound);
     mockK8sCreate.mockImplementation(resolveCreate);
     await expect(createPolicyPromises(state, [])).resolves.toMatchObject({
       isNewMirrorPeer: true,
@@ -142,8 +116,12 @@ describe('createPolicyPromises DRPolicy create vs update detection', () => {
       isNewPolicy: true,
     });
 
-    mockK8sGet.mockRejectedValue(forbidden);
-    mockK8sCreate.mockImplementation(resolveCreate);
+    mockK8sCreate.mockImplementation(({ model, data }) => {
+      if (model.kind === 'DRPolicy') {
+        return Promise.reject(forbidden);
+      }
+      return resolveCreate({ model, data });
+    });
     await expect(createPolicyPromises(state, [])).rejects.toEqual(forbidden);
     expect(mockK8sDelete).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -155,7 +133,6 @@ describe('createPolicyPromises DRPolicy create vs update detection', () => {
   });
 
   it('does not match MirrorPeer with same SC name but different namespace', async () => {
-    mockK8sGet.mockRejectedValue(notFound);
     mockK8sCreate.mockImplementation(resolveCreate);
     const staleMirrorPeer = {
       metadata: { name: 'mirrorpeer-stale' },

--- a/packages/mco/components/create-dr-policy/utils/k8s-utils.ts
+++ b/packages/mco/components/create-dr-policy/utils/k8s-utils.ts
@@ -28,10 +28,6 @@ import {
   SecretModel,
 } from '@odf/shared';
 import {
-  createOrUpdate,
-  type CreateOrUpdateMutationDetails,
-} from '@odf/shared/utils/k8s';
-import {
   getAPIVersionForModel,
   k8sCreate,
   k8sDelete,
@@ -106,65 +102,32 @@ const createMirrorPeer = (
   });
 };
 
-type CreateDRPolicyResult = {
-  policy: DRPolicyKind;
-  isUpdated: boolean;
-  previousPolicySpec?: DRPolicyKind['spec'];
-};
-
-const createDRPolicy = async (
+const createDRPolicy = (
   policyName: string,
   replicationType: ReplicationType,
   syncIntervalTime: string,
   enableRBDImageFlatten: boolean,
   peerNames: string[]
-): Promise<CreateDRPolicyResult> => {
+): Promise<DRPolicyKind> => {
   const schedulingInterval =
     replicationType === ReplicationType.ASYNC ? syncIntervalTime : '0m';
   const replicationClassSelector = enableRBDImageFlatten
     ? { matchLabels: RBD_IMAGE_FLATTEN_LABEL }
     : {};
-  const mutationDetails: CreateOrUpdateMutationDetails = {};
-  let previousPolicySpec: DRPolicyKind['spec'];
 
-  const policy = await createOrUpdate<DRPolicyKind>({
+  return k8sCreate({
     model: DRPolicyModel,
-    name: policyName,
-    mutationDetails,
-    mutate: (current) => {
-      if (current) {
-        previousPolicySpec = current.spec
-          ? (JSON.parse(JSON.stringify(current.spec)) as DRPolicyKind['spec'])
-          : current.spec;
-      }
-      const base: DRPolicyKind = current ?? {
-        apiVersion: getAPIVersionForModel(DRPolicyModel),
-        kind: DRPolicyModel.kind,
-        metadata: { name: policyName },
-        spec: {
-          replicationClassSelector,
-          schedulingInterval,
-          drClusters: peerNames,
-        },
-      };
-
-      return {
-        ...base,
-        spec: {
-          ...base.spec,
-          replicationClassSelector,
-          schedulingInterval,
-          drClusters: peerNames,
-        },
-      };
+    data: {
+      apiVersion: getAPIVersionForModel(DRPolicyModel),
+      kind: DRPolicyModel.kind,
+      metadata: { name: policyName },
+      spec: {
+        replicationClassSelector,
+        schedulingInterval,
+        drClusters: peerNames,
+      },
     },
   });
-
-  return {
-    policy,
-    isUpdated: !!mutationDetails.isUpdated,
-    previousPolicySpec,
-  };
 };
 
 export type CreatePolicyResult = {
@@ -185,11 +148,10 @@ export const createPolicyPromises = async (
   if (state.configure.replicationBackend === BackendType.DataFoundation) {
     let createdMirrorPeer: MirrorPeerKind | undefined;
     let peering: OdfPeeringResult;
-    let policyResult: CreateDRPolicyResult;
     try {
       peering = await prepareOdfPeering(state, mirrorPeers, peerNames);
       createdMirrorPeer = peering.isNew ? peering.mirrorPeer : undefined;
-      policyResult = await createDRPolicy(
+      await createDRPolicy(
         state.policy.policyName,
         state.policy.replicationType,
         state.policy.syncIntervalTime,
@@ -211,10 +173,7 @@ export const createPolicyPromises = async (
 
     const mirrorPeerName = getName(peering.mirrorPeer);
     return {
-      isNewPolicy: !policyResult.isUpdated,
-      ...(policyResult.previousPolicySpec
-        ? { previousPolicySpec: policyResult.previousPolicySpec }
-        : {}),
+      isNewPolicy: true,
       ...(!!mirrorPeerName
         ? {
             mirrorPeerName,
@@ -227,17 +186,8 @@ export const createPolicyPromises = async (
   } else {
     const allDRClustersExist =
       selectedDRClusters?.length === MAX_ALLOWED_CLUSTERS;
-    let policyResult: CreateDRPolicyResult;
 
-    if (allDRClustersExist) {
-      policyResult = await createDRPolicy(
-        state.policy.policyName,
-        state.policy.replicationType,
-        state.policy.syncIntervalTime,
-        state.policy.enableRBDImageFlatten,
-        peerNames
-      );
-    } else {
+    if (!allDRClustersExist) {
       const created: CreatedResources = {
         secrets: [],
         profiles: [],
@@ -245,7 +195,7 @@ export const createPolicyPromises = async (
       };
       try {
         await prepareThirdPartyPeering(state, selectedDRClusters, created);
-        policyResult = await createDRPolicy(
+        await createDRPolicy(
           state.policy.policyName,
           state.policy.replicationType,
           state.policy.syncIntervalTime,
@@ -256,13 +206,18 @@ export const createPolicyPromises = async (
         await rollbackThirdPartyResources(created);
         throw error;
       }
+    } else {
+      await createDRPolicy(
+        state.policy.policyName,
+        state.policy.replicationType,
+        state.policy.syncIntervalTime,
+        state.policy.enableRBDImageFlatten,
+        peerNames
+      );
     }
 
     return {
-      isNewPolicy: !policyResult.isUpdated,
-      ...(policyResult.previousPolicySpec
-        ? { previousPolicySpec: policyResult.previousPolicySpec }
-        : {}),
+      isNewPolicy: true,
     };
   }
 };

--- a/packages/mco/components/create-dr-policy/wizard-steps/policy-step/policy-step.tsx
+++ b/packages/mco/components/create-dr-policy/wizard-steps/policy-step/policy-step.tsx
@@ -11,6 +11,9 @@ import {
   ExpandableSection,
   Form,
   FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
   TextInput,
   Title,
 } from '@patternfly/react-core';
@@ -76,14 +79,17 @@ type PolicyStepProps = {
   state: DRPolicyState;
   dispatch: React.Dispatch<DRPolicyAction>;
   docHref: string;
+  isPolicyNameTaken: boolean;
 };
 
 export const PolicyStep: React.FC<PolicyStepProps> = ({
   state,
   dispatch,
   docHref,
+  isPolicyNameTaken,
 }) => {
   const { t } = useCustomTranslation();
+  const nameValidated = isPolicyNameTaken ? 'error' : 'default';
 
   return (
     <Form className="mco-create-data-policy__body">
@@ -108,6 +114,7 @@ export const PolicyStep: React.FC<PolicyStepProps> = ({
           value={state.policy.policyName}
           type="text"
           placeholder={t('Enter a policy name')}
+          validated={nameValidated}
           onChange={(_event, policyName) =>
             dispatch({
               type: DRPolicyActionType.SET_POLICY_NAME,
@@ -116,6 +123,18 @@ export const PolicyStep: React.FC<PolicyStepProps> = ({
           }
           isRequired
         />
+        {isPolicyNameTaken && (
+          <FormHelperText>
+            <HelperText>
+              <HelperTextItem variant="error">
+                {t(
+                  "A DRPolicy with name '{{name}}' already exists. Please choose a different name.",
+                  { name: state.policy.policyName }
+                )}
+              </HelperTextItem>
+            </HelperText>
+          </FormHelperText>
+        )}
       </FormGroup>
       <SelectReplicationType
         selectedClusters={state.clusters.selectedClusters}


### PR DESCRIPTION
Create wizard was upserting an existing CR instead of failing, which hid duplicates or hit immutable schedulingInterval. Validate uniqueness in the Policy step and create-only. Watch existing DRPolicies and block Next/Create if the name is taken Create the DRPolicy with k8sCreate only (no patch). Leave createOrUpdate on Secret, Ramen ConfigMap, and DRCluster for TPS retry.

Refs [DFBUGS-10678](https://redhat.atlassian.net/browse/DFBUGS-10678)

## Description

<!--
Provide a clear and concise description of the change.
Include context, motivation, linked issues, and any important implementation details.
-->

---

## Change Type

Please select all applicable options:

- [ ] Feature
- [x] Bug Fix
- [ ] Improvement
- [ ] Refactor
- [ ] Tests

---

## Component / Area Impacted

Please select all applicable options:

- [x] ODF
- [ ] FDF
- [ ] Client
- [ ] MCO
- [ ] Fusion Access (SAN Storage)
- [ ] CNSA (Remote Mount)
- [ ] E2E Test

---

## Screenshots / Recordings

### Screenshots
<img width="3350" height="1038" alt="image" src="https://github.com/user-attachments/assets/7ee48985-53ad-44e9-b600-6fac5cd4da73" />

<img width="2986" height="1650" alt="image" src="https://github.com/user-attachments/assets/266b460e-0bcf-4600-9d45-316cd8e54cc0" />

<!--
Add screenshots here if applicable.
-->

### Recordings / Demo Videos

<!--
Add screen recordings, demo videos, or GIFs here if applicable.
-->

---

## Testing

Please select the type of tests included:

- [ ] Unit Tests
- [ ] E2E Tests
- [ ] No Tests Required (with justification below)

<!--
Describe testing details:
- What was tested
- How it was tested
- Any edge cases covered
- Any missing coverage (if applicable)
-->

---

## Additional Notes

<!--
Add any additional notes, caveats, follow-up tasks, or reviewer guidance here.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation to prevent creating a DR policy with a name that already exists.
  * The policy wizard now highlights duplicate names and displays an inline error message.
  * Policy creation consistently reports conflicts instead of attempting to update existing policies.

* **Bug Fixes**
  * Improved handling of policy creation when related DR clusters already exist.
  * Added English localization for the duplicate-name validation message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->