### PR TITLE
link Topology apps to the DRPC details page

### DIFF
--- a/packages/mco/components/topology/sidebar/AppSidebar.tsx
+++ b/packages/mco/components/topology/sidebar/AppSidebar.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { getNamespace } from '@odf/shared/selectors';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { useNavigate } from 'react-router';
 import {
@@ -94,7 +95,7 @@ export const DRPCTable: React.FC<DRPCTableProps> = ({ apps }) => {
                       variant="link"
                       isInline
                       onClick={() =>
-                        navigate(getAppLink(app.name, app.namespace))
+                        navigate(getAppLink(app.drpcName, app.drpcNamespace))
                       }
                     >
                       {app.name}
@@ -142,6 +143,8 @@ export const AppSidebar: React.FC<AppSidebarProps> = ({ edgeData }) => {
     return {
       name: op.applicationName,
       namespace: op.applicationNamespace,
+      drpcName: op.drpcName,
+      drpcNamespace: getNamespace(op.drpc) || op.applicationNamespace,
       status: getDRStatus({
         phase: op.phase,
         progression: op.progression,

--- a/packages/mco/components/topology/sidebar/ClusterSidebar.tsx
+++ b/packages/mco/components/topology/sidebar/ClusterSidebar.tsx
@@ -62,6 +62,8 @@ export const ClusterSidebar: React.FC<ClusterSidebarProps> = ({ resource }) => {
       protectedApps.map((app) => ({
         name: app.name,
         namespace: app.namespace,
+        drpcName: app.drpcName,
+        drpcNamespace: app.drpcNamespace,
         status: app.status,
         drPolicy: app.drPolicy,
       })),

--- a/packages/mco/components/topology/sidebar/OperationSidebar.tsx
+++ b/packages/mco/components/topology/sidebar/OperationSidebar.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { getDRStatus } from '@odf/mco/utils/dr-status';
 import { DASH } from '@odf/shared/constants';
+import { getNamespace } from '@odf/shared/selectors';
 import { useCustomTranslation } from '@odf/shared/useCustomTranslationHook';
 import { useNavigate } from 'react-router';
 import {
@@ -157,7 +158,8 @@ const OperationsTableView: React.FC<{
                               navigate(
                                 getAppLink(
                                   operation.drpcName,
-                                  operation.applicationNamespace
+                                  getNamespace(operation.drpc) ||
+                                    operation.applicationNamespace
                                 )
                               )
                             }

--- a/packages/mco/components/topology/types.ts
+++ b/packages/mco/components/topology/types.ts
@@ -50,6 +50,8 @@ export type { ClusterAppsMap, ClusterPairOperationsMap };
 export type AppSidebarItem = {
   name: string;
   namespace: string;
+  drpcName: string;
+  drpcNamespace: string;
   status: DRStatus;
   drPolicy: string;
 };

--- a/packages/mco/components/topology/utils/sidebar-utils.tsx
+++ b/packages/mco/components/topology/utils/sidebar-utils.tsx
@@ -14,8 +14,8 @@ import {
   isUserActionRequired as isUserActionRequiredUtil,
 } from '../../../utils/dr-status';
 
-export const getAppLink = (name: string, namespace: string) => {
-  return `/k8s/ns/${namespace}/${referenceForModel(DRPlacementControlModel)}/${name}`;
+export const getAppLink = (drpcName: string, drpcNamespace: string) => {
+  return `/k8s/ns/${drpcNamespace}/${referenceForModel(DRPlacementControlModel)}/${drpcName}`;
 };
 
 /**

--- a/packages/mco/hooks/useProtectedAppsByCluster.ts
+++ b/packages/mco/hooks/useProtectedAppsByCluster.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { getNamespace } from '@odf/shared/selectors';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 import {
   DRPlacementControlKind,
@@ -22,6 +23,8 @@ import {
 export type ProtectedAppInfo = {
   name: string;
   namespace: string;
+  drpcName: string;
+  drpcNamespace: string;
   drPolicy: string;
   status: DRStatus;
   pav: ProtectedApplicationViewKind;
@@ -81,7 +84,8 @@ export const useProtectedAppsByCluster = (): [
         const appNamespace = pav.metadata?.namespace;
         const phase = pav.status?.drInfo?.status?.phase as Phase;
 
-        const drpcName = pav.spec?.drpcRef?.name;
+        const drpcRef = pav.spec?.drpcRef;
+        const drpcName = drpcRef?.name;
         const drpc = drpcName ? drpcByName.get(drpcName) : undefined;
         const drPolicy = drPolicyByName.get(drPolicyName);
         const progression = drpc?.status?.progression;
@@ -140,6 +144,8 @@ export const useProtectedAppsByCluster = (): [
         const appInfo: ProtectedAppInfo = {
           name: appName,
           namespace: appNamespace,
+          drpcName: drpcName || '',
+          drpcNamespace: getNamespace(drpc) || drpcRef?.namespace || '',
           drPolicy: drPolicyName,
           status,
           pav,


### PR DESCRIPTION
Bug [DFBUGS-10152](https://redhat.atlassian.net/browse/DFBUGS-10152)
Topology used the application name and namespace in the hub DRPC URL, which 404s when those differ from the DRPC (ApplicationSet). Pass DRPC identity from the PAV and DRPC objects instead.

## Description

<!--
Provide a clear and concise description of the change.
Include context, motivation, linked issues, and any important implementation details.
-->

---

## Change Type

Please select all applicable options:

- [ ] Feature
- [x] Bug Fix
- [ ] Improvement
- [ ] Refactor
- [ ] Tests

---

## Component / Area Impacted

Please select all applicable options:

- [x] ODF
- [ ] FDF
- [ ] Client
- [ ] MCO
- [ ] Fusion Access (SAN Storage)
- [ ] CNSA (Remote Mount)
- [ ] E2E Test

---

## Screenshots / Recordings

### Screenshots

<!--
Add screenshots here if applicable.
-->

### Recordings / Demo Videos

Before:
https://github.com/user-attachments/assets/3e6e433a-ce87-4349-a8ba-f6ad26e62c70



After this fix pr it shows the drop details of the selected drop:
https://github.com/user-attachments/assets/e5ea8dd8-d824-4a37-9c1f-e67b6ac97828

<!--



Add screen recordings, demo videos, or GIFs here if applicable.
-->

---

## Testing

Please select the type of tests included:

- [ ] Unit Tests
- [ ] E2E Tests
- [ ] No Tests Required (with justification below)

<!--
Describe testing details:
- What was tested
- How it was tested
- Any edge cases covered
- Any missing coverage (if applicable)
-->

---

## Additional Notes

<!--
Add any additional notes, caveats, follow-up tasks, or reviewer guidance here.
-->
